### PR TITLE
Add processes/samples for the m(ttbar) analysis

### DIFF
--- a/cmsdb/campaigns/run2_2017_nano_v9/__init__.py
+++ b/cmsdb/campaigns/run2_2017_nano_v9/__init__.py
@@ -32,3 +32,4 @@ import cmsdb.campaigns.run2_2017_nano_v9.qcd  # noqa
 import cmsdb.campaigns.run2_2017_nano_v9.higgs  # noqa
 import cmsdb.campaigns.run2_2017_nano_v9.hh2bbtautau  # noqa
 import cmsdb.campaigns.run2_2017_nano_v9.hh2bbww  # noqa
+import cmsdb.campaigns.run2_2017_nano_v9.mttbar  # noqa

--- a/cmsdb/campaigns/run2_2017_nano_v9/data.py
+++ b/cmsdb/campaigns/run2_2017_nano_v9/data.py
@@ -326,3 +326,83 @@ cpn.add_dataset(
         "jec_era": "RunF",
     },
 )
+
+
+#
+# SinglePhoton
+#
+
+cpn.add_dataset(
+    name="data_pho_b",
+    id=14226103,
+    is_data=True,
+    processes=[procs.data_pho],
+    keys=[
+        "/SinglePhoton/Run2017B-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD",
+    ],
+    n_files=10,
+    n_events=15950935,
+    aux={
+        "jec_era": "RunB",
+    },
+)
+
+cpn.add_dataset(
+    name="data_pho_c",
+    id=14226292,
+    is_data=True,
+    processes=[procs.data_pho],
+    keys=[
+        "/SinglePhoton/Run2017C-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD",
+    ],
+    n_files=34,
+    n_events=42182948,
+    aux={
+        "jec_era": "RunC",
+    },
+)
+
+cpn.add_dataset(
+    name="data_pho_d",
+    id=14226047,
+    is_data=True,
+    processes=[procs.data_pho],
+    keys=[
+        "/SinglePhoton/Run2017D-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD",
+    ],
+    n_files=7,
+    n_events=9753462,
+    aux={
+        "jec_era": "RunD",
+    },
+)
+
+cpn.add_dataset(
+    name="data_pho_e",
+    id=14226326,
+    is_data=True,
+    processes=[procs.data_pho],
+    keys=[
+        "/SinglePhoton/Run2017E-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD",
+    ],
+    n_files=22,
+    n_events=19011446,
+    aux={
+        "jec_era": "RunE",
+    },
+)
+
+cpn.add_dataset(
+    name="data_pho_f",
+    id=14226332,
+    is_data=True,
+    processes=[procs.data_pho],
+    keys=[
+        "/SinglePhoton/Run2017F-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD",
+    ],
+    n_files=31,
+    n_events=29783015,
+    aux={
+        "jec_era": "RunF",
+    },
+)

--- a/cmsdb/campaigns/run2_2017_nano_v9/mttbar.py
+++ b/cmsdb/campaigns/run2_2017_nano_v9/mttbar.py
@@ -1,0 +1,1808 @@
+# coding: utf-8
+
+"""
+Signal samples for m(ttbar) line search
+"""
+
+import cmsdb.processes as procs
+from cmsdb.campaigns.run2_2017_nano_v9 import campaign_run2_2017_nano_v9 as cpn
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_400_w_40_madgraph",
+    id=14243245,
+    processes=[procs.zprime_tt_m_400_w_40],
+    keys=[
+        "/ZPrimeToTT_M400_W40_TuneCP2_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=10,
+    n_events=497000,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_400_w_120_madgraph",
+    id=14278504,
+    processes=[procs.zprime_tt_m_400_w_120],
+    keys=[
+        "/ZPrimeToTT_M400_W120_TuneCP2_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_400_w_4_madgraph",
+    id=14336497,
+    processes=[procs.zprime_tt_m_400_w_4],
+    keys=[
+        "/ZprimeToTTJets_M400_W4_TuneCP2_13TeV-madgraphMLM-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=11,
+    n_events=201853,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_500_w_50_madgraph",
+    id=14281237,
+    processes=[procs.zprime_tt_m_500_w_50],
+    keys=[
+        "/ZPrimeToTT_M500_W50_TuneCP2_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=9,
+    n_events=491000,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_500_w_150_madgraph",
+    id=14281224,
+    processes=[procs.zprime_tt_m_500_w_150],
+    keys=[
+        "/ZPrimeToTT_M500_W150_TuneCP2_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=17,
+    n_events=494000,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_500_w_5_madgraph",
+    id=14360854,
+    processes=[procs.zprime_tt_m_500_w_5],
+    keys=[
+        "/ZprimeToTTJets_M500_W5_TuneCP2_13TeV-madgraphMLM-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=7,
+    n_events=188083,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_600_w_60_madgraph",
+    id=14281128,
+    processes=[procs.zprime_tt_m_600_w_60],
+    keys=[
+        "/ZPrimeToTT_M600_W60_TuneCP2_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=8,
+    n_events=494000,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_600_w_180_madgraph",
+    id=14283411,
+    processes=[procs.zprime_tt_m_600_w_180],
+    keys=[
+        "/ZPrimeToTT_M600_W180_TuneCP2_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=16,
+    n_events=491000,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_600_w_6_madgraph",
+    id=14332670,
+    processes=[procs.zprime_tt_m_600_w_6],
+    keys=[
+        "/ZprimeToTTJets_M600_W6_TuneCP2_13TeV-madgraphMLM-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=198225,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_700_w_70_madgraph",
+    id=14278238,
+    processes=[procs.zprime_tt_m_700_w_70],
+    keys=[
+        "/ZPrimeToTT_M700_W70_TuneCP2_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_700_w_210_madgraph",
+    id=14281059,
+    processes=[procs.zprime_tt_m_700_w_210],
+    keys=[
+        "/ZPrimeToTT_M700_W210_TuneCP2_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=10,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_700_w_7_madgraph",
+    id=14333023,
+    processes=[procs.zprime_tt_m_700_w_7],
+    keys=[
+        "/ZprimeToTTJets_M700_W7_TuneCP2_13TeV-madgraphMLM-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=6,
+    n_events=200215,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_800_w_80_madgraph",
+    id=14279821,
+    processes=[procs.zprime_tt_m_800_w_80],
+    keys=[
+        "/ZPrimeToTT_M800_W80_TuneCP2_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=494000,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_800_w_240_madgraph",
+    id=14254580,
+    processes=[procs.zprime_tt_m_800_w_240],
+    keys=[
+        "/ZPrimeToTT_M800_W240_TuneCP2_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_800_w_8_madgraph",
+    id=14333373,
+    processes=[procs.zprime_tt_m_800_w_8],
+    keys=[
+        "/ZprimeToTTJets_M800_W8_TuneCP2_13TeV-madgraphMLM-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=7,
+    n_events=193169,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_900_w_90_madgraph",
+    id=14284536,
+    processes=[procs.zprime_tt_m_900_w_90],
+    keys=[
+        "/ZPrimeToTT_M900_W90_TuneCP2_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=16,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_900_w_270_madgraph",
+    id=14285297,
+    processes=[procs.zprime_tt_m_900_w_270],
+    keys=[
+        "/ZPrimeToTT_M900_W270_TuneCP2_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=17,
+    n_events=461000,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_900_w_9_madgraph",
+    id=14336552,
+    processes=[procs.zprime_tt_m_900_w_9],
+    keys=[
+        "/ZprimeToTTJets_M900_W9_TuneCP2_13TeV-madgraphMLM-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=13,
+    n_events=199844,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_1000_w_100_madgraph",
+    id=14280940,
+    processes=[procs.zprime_tt_m_1000_w_100],
+    keys=[
+        "/ZPrimeToTT_M1000_W100_TuneCP2_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_1000_w_300_madgraph",
+    id=14300363,
+    processes=[procs.zprime_tt_m_1000_w_300],
+    keys=[
+        "/ZPrimeToTT_M1000_W300_TuneCP2_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_1000_w_10_madgraph",
+    id=14336319,
+    processes=[procs.zprime_tt_m_1000_w_10],
+    keys=[
+        "/ZprimeToTTJets_M1000_W10_TuneCP2_13TeV-madgraphMLM-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=10,
+    n_events=194229,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_1200_w_120_madgraph",
+    id=14302542,
+    processes=[procs.zprime_tt_m_1200_w_120],
+    keys=[
+        "/ZPrimeToTT_M1200_W120_TuneCP2_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=11,
+    n_events=497000,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_1200_w_360_madgraph",
+    id=14281223,
+    processes=[procs.zprime_tt_m_1200_w_360],
+    keys=[
+        "/ZPrimeToTT_M1200_W360_TuneCP2_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=15,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_1200_w_12_madgraph",
+    id=14229932,
+    processes=[procs.zprime_tt_m_1200_w_12],
+    keys=[
+        "/ZprimeToTT_M1200_W12_TuneCP2_PSweights_13TeV-madgraph-pythiaMLM-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=195613,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_1400_w_140_madgraph",
+    id=14282426,
+    processes=[procs.zprime_tt_m_1400_w_140],
+    keys=[
+        "/ZPrimeToTT_M1400_W140_TuneCP2_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=25,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_1400_w_420_madgraph",
+    id=14281274,
+    processes=[procs.zprime_tt_m_1400_w_420],
+    keys=[
+        "/ZPrimeToTT_M1400_W420_TuneCP2_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=20,
+    n_events=488000,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_1400_w_14_madgraph",
+    id=14230187,
+    processes=[procs.zprime_tt_m_1400_w_14],
+    keys=[
+        "/ZprimeToTT_M1400_W14_TuneCP2_PSweights_13TeV-madgraph-pythiaMLM-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=4,
+    n_events=208708,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_1600_w_160_madgraph",
+    id=14281016,
+    processes=[procs.zprime_tt_m_1600_w_160],
+    keys=[
+        "/ZPrimeToTT_M1600_W160_TuneCP2_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=10,
+    n_events=494000,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_1600_w_480_madgraph",
+    id=14281289,
+    processes=[procs.zprime_tt_m_1600_w_480],
+    keys=[
+        "/ZPrimeToTT_M1600_W480_TuneCP2_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=15,
+    n_events=497000,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_1600_w_16_madgraph",
+    id=14231201,
+    processes=[procs.zprime_tt_m_1600_w_16],
+    keys=[
+        "/ZprimeToTT_M1600_W16_TuneCP2_PSweights_13TeV-madgraph-pythiaMLM-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=8,
+    n_events=219802,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_1800_w_180_madgraph",
+    id=14282425,
+    processes=[procs.zprime_tt_m_1800_w_180],
+    keys=[
+        "/ZPrimeToTT_M1800_W180_TuneCP2_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=19,
+    n_events=491000,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_1800_w_540_madgraph",
+    id=14281392,
+    processes=[procs.zprime_tt_m_1800_w_540],
+    keys=[
+        "/ZPrimeToTT_M1800_W540_TuneCP2_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=6,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_1800_w_18_madgraph",
+    id=14227878,
+    processes=[procs.zprime_tt_m_1800_w_18],
+    keys=[
+        "/ZprimeToTT_M1800_W18_TuneCP2_PSweights_13TeV-madgraph-pythiaMLM-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=208252,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_2000_w_200_madgraph",
+    id=14281145,
+    processes=[procs.zprime_tt_m_2000_w_200],
+    keys=[
+        "/ZPrimeToTT_M2000_W200_TuneCP2_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=22,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_2000_w_600_madgraph",
+    id=14251230,
+    processes=[procs.zprime_tt_m_2000_w_600],
+    keys=[
+        "/ZPrimeToTT_M2000_W600_TuneCP2_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_2000_w_20_madgraph",
+    id=14229693,
+    processes=[procs.zprime_tt_m_2000_w_20],
+    keys=[
+        "/ZprimeToTT_M2000_W20_TuneCP2_PSweights_13TeV-madgraph-pythiaMLM-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=211425,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_2500_w_250_madgraph",
+    id=14281310,
+    processes=[procs.zprime_tt_m_2500_w_250],
+    keys=[
+        "/ZPrimeToTT_M2500_W250_TuneCP2_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=14,
+    n_events=489000,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_2500_w_750_madgraph",
+    id=14281195,
+    processes=[procs.zprime_tt_m_2500_w_750],
+    keys=[
+        "/ZPrimeToTT_M2500_W750_TuneCP2_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=17,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_2500_w_25_madgraph",
+    id=14229120,
+    processes=[procs.zprime_tt_m_2500_w_25],
+    keys=[
+        "/ZprimeToTT_M2500_W25_TuneCP2_PSweights_13TeV-madgraph-pythiaMLM-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=10,
+    n_events=203518,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_3000_w_300_madgraph",
+    id=14281572,
+    processes=[procs.zprime_tt_m_3000_w_300],
+    keys=[
+        "/ZPrimeToTT_M3000_W300_TuneCP2_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=11,
+    n_events=491000,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_3000_w_900_madgraph",
+    id=14281154,
+    processes=[procs.zprime_tt_m_3000_w_900],
+    keys=[
+        "/ZPrimeToTT_M3000_W900_TuneCP2_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=16,
+    n_events=488000,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_3000_w_30_madgraph",
+    id=14229343,
+    processes=[procs.zprime_tt_m_3000_w_30],
+    keys=[
+        "/ZprimeToTT_M3000_W30_TuneCP2_PSweights_13TeV-madgraph-pythiaMLM-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=4,
+    n_events=192535,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_3500_w_350_madgraph",
+    id=14281316,
+    processes=[procs.zprime_tt_m_3500_w_350],
+    keys=[
+        "/ZPrimeToTT_M3500_W350_TuneCP2_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=3,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_3500_w_1050_madgraph",
+    id=14281186,
+    processes=[procs.zprime_tt_m_3500_w_1050],
+    keys=[
+        "/ZPrimeToTT_M3500_W1050_TuneCP2_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=3,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_3500_w_35_madgraph",
+    id=14231079,
+    processes=[procs.zprime_tt_m_3500_w_35],
+    keys=[
+        "/ZprimeToTT_M3500_W35_TuneCP2_PSweights_13TeV-madgraph-pythiaMLM-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=189565,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_4000_w_400_madgraph",
+    id=14284374,
+    processes=[procs.zprime_tt_m_4000_w_400],
+    keys=[
+        "/ZPrimeToTT_M4000_W400_TuneCP2_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=4,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_4000_w_1200_madgraph",
+    id=14277978,
+    processes=[procs.zprime_tt_m_4000_w_1200],
+    keys=[
+        "/ZPrimeToTT_M4000_W1200_TuneCP2_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=4,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_4000_w_40_madgraph",
+    id=14229745,
+    processes=[procs.zprime_tt_m_4000_w_40],
+    keys=[
+        "/ZprimeToTT_M4000_W40_TuneCP2_PSweights_13TeV-madgraph-pythiaMLM-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=184083,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_4500_w_450_madgraph",
+    id=14283349,
+    processes=[procs.zprime_tt_m_4500_w_450],
+    keys=[
+        "/ZPrimeToTT_M4500_W450_TuneCP2_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=19,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_4500_w_1350_madgraph",
+    id=14284730,
+    processes=[procs.zprime_tt_m_4500_w_1350],
+    keys=[
+        "/ZPrimeToTT_M4500_W1350_TuneCP2_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=15,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_4500_w_45_madgraph",
+    id=14229612,
+    processes=[procs.zprime_tt_m_4500_w_45],
+    keys=[
+        "/ZprimeToTT_M4500_W45_TuneCP2_PSweights_13TeV-madgraph-pythiaMLM-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=4,
+    n_events=174039,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_5000_w_500_madgraph",
+    id=14332776,
+    processes=[procs.zprime_tt_m_5000_w_500],
+    keys=[
+        "/ZPrimeToTT_M5000_W500_TuneCP2_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=200000,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_5000_w_1500_madgraph",
+    id=14349020,
+    processes=[procs.zprime_tt_m_5000_w_1500],
+    keys=[
+        "/ZPrimeToTT_M5000_W1500_TuneCP2_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=11,
+    n_events=200000,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_5000_w_50_madgraph",
+    id=14336465,
+    processes=[procs.zprime_tt_m_5000_w_50],
+    keys=[
+        "/ZprimeToTTJets_M5000_W50_TuneCP2_13TeV-madgraphMLM-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=17,
+    n_events=194238,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_6000_w_600_madgraph",
+    id=14333187,
+    processes=[procs.zprime_tt_m_6000_w_600],
+    keys=[
+        "/ZPrimeToTT_M6000_W600_TuneCP2_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=14,
+    n_events=197000,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_6000_w_1800_madgraph",
+    id=14333643,
+    processes=[procs.zprime_tt_m_6000_w_1800],
+    keys=[
+        "/ZPrimeToTT_M6000_W1800_TuneCP2_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=9,
+    n_events=200000,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_6000_w_60_madgraph",
+    id=14344862,
+    processes=[procs.zprime_tt_m_6000_w_60],
+    keys=[
+        "/ZprimeToTTJets_M6000_W60_TuneCP2_13TeV-madgraphMLM-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=14,
+    n_events=202610,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_7000_w_700_madgraph",
+    id=14332787,
+    processes=[procs.zprime_tt_m_7000_w_700],
+    keys=[
+        "/ZPrimeToTT_M7000_W700_TuneCP2_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=200000,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_7000_w_2100_madgraph",
+    id=14332786,
+    processes=[procs.zprime_tt_m_7000_w_2100],
+    keys=[
+        "/ZPrimeToTT_M7000_W2100_TuneCP2_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=4,
+    n_events=200000,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_7000_w_70_madgraph",
+    id=14336584,
+    processes=[procs.zprime_tt_m_7000_w_70],
+    keys=[
+        "/ZprimeToTTJets_M7000_W70_TuneCP2_13TeV-madgraphMLM-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=15,
+    n_events=192854,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_8000_w_800_madgraph",
+    id=14341073,
+    processes=[procs.zprime_tt_m_8000_w_800],
+    keys=[
+        "/ZPrimeToTT_M8000_W800_TuneCP2_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=190000,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_8000_w_2400_madgraph",
+    id=14341059,
+    processes=[procs.zprime_tt_m_8000_w_2400],
+    keys=[
+        "/ZPrimeToTT_M8000_W2400_TuneCP2_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=3,
+    n_events=200000,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_8000_w_80_madgraph",
+    id=14345474,
+    processes=[procs.zprime_tt_m_8000_w_80],
+    keys=[
+        "/ZprimeToTTJets_M8000_W80_TuneCP2_13TeV-madgraphMLM-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=15,
+    n_events=191551,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_9000_w_900_madgraph",
+    id=14333371,
+    processes=[procs.zprime_tt_m_9000_w_900],
+    keys=[
+        "/ZPrimeToTT_M9000_W900_TuneCP2_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=12,
+    n_events=200000,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_9000_w_2700_madgraph",
+    id=14332759,
+    processes=[procs.zprime_tt_m_9000_w_2700],
+    keys=[
+        "/ZPrimeToTT_M9000_W2700_TuneCP2_13TeV-madgraph-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=8,
+    n_events=200000,
+)
+
+
+cpn.add_dataset(
+    name="zprime_tt_m_9000_w_90_madgraph",
+    id=14342305,
+    processes=[procs.zprime_tt_m_9000_w_90],
+    keys=[
+        "/ZprimeToTTJets_M9000_W90_TuneCP2_13TeV-madgraphMLM-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=16,
+    n_events=182122,
+)
+
+
+cpn.add_dataset(
+    name="hpseudo_tt_sl_m_365_w_91p25_res_madgraph",
+    id=14274405,
+    processes=[procs.hpseudo_tt_sl_m_365_w_91p25_res],
+    keys=[
+        "/HpseudoToTTTo1L1Nu2J_m365_w91p25_res_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=5,
+    n_events=497000,
+)
+
+
+cpn.add_dataset(
+    name="hpseudo_tt_sl_m_365_w_91p25_int_madgraph",
+    id=14275759,
+    processes=[procs.hpseudo_tt_sl_m_365_w_91p25_int],
+    keys=[
+        "/HpseudoToTTTo1L1Nu2J_m365_w91p25_int_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="hpseudo_tt_sl_m_365_w_36p5_res_madgraph",
+    id=14275955,
+    processes=[procs.hpseudo_tt_sl_m_365_w_36p5_res],
+    keys=[
+        "/HpseudoToTTTo1L1Nu2J_m365_w36p5_res_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=494000,
+)
+
+
+cpn.add_dataset(
+    name="hpseudo_tt_sl_m_365_w_36p5_int_madgraph",
+    id=14281052,
+    processes=[procs.hpseudo_tt_sl_m_365_w_36p5_int],
+    keys=[
+        "/HpseudoToTTTo1L1Nu2J_m365_w36p5_int_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=17,
+    n_events=497000,
+)
+
+
+cpn.add_dataset(
+    name="hpseudo_tt_sl_m_365_w_9p125_res_madgraph",
+    id=14275721,
+    processes=[procs.hpseudo_tt_sl_m_365_w_9p125_res],
+    keys=[
+        "/HpseudoToTTTo1L1Nu2J_m365_w9p125_res_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=3,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="hpseudo_tt_sl_m_365_w_9p125_int_madgraph",
+    id=14277890,
+    processes=[procs.hpseudo_tt_sl_m_365_w_9p125_int],
+    keys=[
+        "/HpseudoToTTTo1L1Nu2J_m365_w9p125_int_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=7,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="hpseudo_tt_sl_m_400_w_100p0_res_madgraph",
+    id=14274326,
+    processes=[procs.hpseudo_tt_sl_m_400_w_100p0_res],
+    keys=[
+        "/HpseudoToTTTo1L1Nu2J_m400_w100p0_res_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=4,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="hpseudo_tt_sl_m_400_w_100p0_int_madgraph",
+    id=14272588,
+    processes=[procs.hpseudo_tt_sl_m_400_w_100p0_int],
+    keys=[
+        "/HpseudoToTTTo1L1Nu2J_m400_w100p0_int_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=6,
+    n_events=488000,
+)
+
+
+cpn.add_dataset(
+    name="hpseudo_tt_sl_m_400_w_40p0_res_madgraph",
+    id=14275830,
+    processes=[procs.hpseudo_tt_sl_m_400_w_40p0_res],
+    keys=[
+        "/HpseudoToTTTo1L1Nu2J_m400_w40p0_res_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=3,
+    n_events=497000,
+)
+
+
+cpn.add_dataset(
+    name="hpseudo_tt_sl_m_400_w_40p0_int_madgraph",
+    id=14276084,
+    processes=[procs.hpseudo_tt_sl_m_400_w_40p0_int],
+    keys=[
+        "/HpseudoToTTTo1L1Nu2J_m400_w40p0_int_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="hpseudo_tt_sl_m_400_w_10p0_res_madgraph",
+    id=14240629,
+    processes=[procs.hpseudo_tt_sl_m_400_w_10p0_res],
+    keys=[
+        "/HpseudoToTTTo1L1Nu2J_m400_w10p0_res_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=16,
+    n_events=488000,
+)
+
+
+cpn.add_dataset(
+    name="hpseudo_tt_sl_m_400_w_10p0_int_madgraph",
+    id=14240655,
+    processes=[procs.hpseudo_tt_sl_m_400_w_10p0_int],
+    keys=[
+        "/HpseudoToTTTo1L1Nu2J_m400_w10p0_int_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=4,
+    n_events=458000,
+)
+
+
+cpn.add_dataset(
+    name="hpseudo_tt_sl_m_500_w_125p0_res_madgraph",
+    id=14276068,
+    processes=[procs.hpseudo_tt_sl_m_500_w_125p0_res],
+    keys=[
+        "/HpseudoToTTTo1L1Nu2J_m500_w125p0_res_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=7,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="hpseudo_tt_sl_m_500_w_125p0_int_madgraph",
+    id=14274305,
+    processes=[procs.hpseudo_tt_sl_m_500_w_125p0_int],
+    keys=[
+        "/HpseudoToTTTo1L1Nu2J_m500_w125p0_int_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=3,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="hpseudo_tt_sl_m_500_w_50p0_res_madgraph",
+    id=14276098,
+    processes=[procs.hpseudo_tt_sl_m_500_w_50p0_res],
+    keys=[
+        "/HpseudoToTTTo1L1Nu2J_m500_w50p0_res_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=13,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="hpseudo_tt_sl_m_500_w_50p0_int_madgraph",
+    id=14275833,
+    processes=[procs.hpseudo_tt_sl_m_500_w_50p0_int],
+    keys=[
+        "/HpseudoToTTTo1L1Nu2J_m500_w50p0_int_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=3,
+    n_events=482000,
+)
+
+
+cpn.add_dataset(
+    name="hpseudo_tt_sl_m_500_w_12p5_res_madgraph",
+    id=14274303,
+    processes=[procs.hpseudo_tt_sl_m_500_w_12p5_res],
+    keys=[
+        "/HpseudoToTTTo1L1Nu2J_m500_w12p5_res_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=9,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="hpseudo_tt_sl_m_500_w_12p5_int_madgraph",
+    id=14275598,
+    processes=[procs.hpseudo_tt_sl_m_500_w_12p5_int],
+    keys=[
+        "/HpseudoToTTTo1L1Nu2J_m500_w12p5_int_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=3,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="hpseudo_tt_sl_m_600_w_150p0_res_madgraph",
+    id=14275768,
+    processes=[procs.hpseudo_tt_sl_m_600_w_150p0_res],
+    keys=[
+        "/HpseudoToTTTo1L1Nu2J_m600_w150p0_res_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=3,
+    n_events=497000,
+)
+
+
+cpn.add_dataset(
+    name="hpseudo_tt_sl_m_600_w_150p0_int_madgraph",
+    id=14279461,
+    processes=[procs.hpseudo_tt_sl_m_600_w_150p0_int],
+    keys=[
+        "/HpseudoToTTTo1L1Nu2J_m600_w150p0_int_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=3,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="hpseudo_tt_sl_m_600_w_60p0_res_madgraph",
+    id=14278291,
+    processes=[procs.hpseudo_tt_sl_m_600_w_60p0_res],
+    keys=[
+        "/HpseudoToTTTo1L1Nu2J_m600_w60p0_res_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=3,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="hpseudo_tt_sl_m_600_w_60p0_int_madgraph",
+    id=14281149,
+    processes=[procs.hpseudo_tt_sl_m_600_w_60p0_int],
+    keys=[
+        "/HpseudoToTTTo1L1Nu2J_m600_w60p0_int_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=11,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="hpseudo_tt_sl_m_600_w_15p0_res_madgraph",
+    id=14276407,
+    processes=[procs.hpseudo_tt_sl_m_600_w_15p0_res],
+    keys=[
+        "/HpseudoToTTTo1L1Nu2J_m600_w15p0_res_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=15,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="hpseudo_tt_sl_m_600_w_15p0_int_madgraph",
+    id=14274442,
+    processes=[procs.hpseudo_tt_sl_m_600_w_15p0_int],
+    keys=[
+        "/HpseudoToTTTo1L1Nu2J_m600_w15p0_int_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=15,
+    n_events=496000,
+)
+
+
+cpn.add_dataset(
+    name="hpseudo_tt_sl_m_800_w_200p0_res_madgraph",
+    id=14275481,
+    processes=[procs.hpseudo_tt_sl_m_800_w_200p0_res],
+    keys=[
+        "/HpseudoToTTTo1L1Nu2J_m800_w200p0_res_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=4,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="hpseudo_tt_sl_m_800_w_200p0_int_madgraph",
+    id=14276069,
+    processes=[procs.hpseudo_tt_sl_m_800_w_200p0_int],
+    keys=[
+        "/HpseudoToTTTo1L1Nu2J_m800_w200p0_int_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=17,
+    n_events=491000,
+)
+
+
+cpn.add_dataset(
+    name="hpseudo_tt_sl_m_800_w_80p0_res_madgraph",
+    id=14276012,
+    processes=[procs.hpseudo_tt_sl_m_800_w_80p0_res],
+    keys=[
+        "/HpseudoToTTTo1L1Nu2J_m800_w80p0_res_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="hpseudo_tt_sl_m_800_w_80p0_int_madgraph",
+    id=14276360,
+    processes=[procs.hpseudo_tt_sl_m_800_w_80p0_int],
+    keys=[
+        "/HpseudoToTTTo1L1Nu2J_m800_w80p0_int_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=12,
+    n_events=498000,
+)
+
+
+cpn.add_dataset(
+    name="hpseudo_tt_sl_m_800_w_20p0_res_madgraph",
+    id=14279434,
+    processes=[procs.hpseudo_tt_sl_m_800_w_20p0_res],
+    keys=[
+        "/HpseudoToTTTo1L1Nu2J_m800_w20p0_res_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=15,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="hpseudo_tt_sl_m_800_w_20p0_int_madgraph",
+    id=14296517,
+    processes=[procs.hpseudo_tt_sl_m_800_w_20p0_int],
+    keys=[
+        "/HpseudoToTTTo1L1Nu2J_m800_w20p0_int_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=14,
+    n_events=467000,
+)
+
+
+cpn.add_dataset(
+    name="hpseudo_tt_sl_m_1000_w_250p0_res_madgraph",
+    id=14277928,
+    processes=[procs.hpseudo_tt_sl_m_1000_w_250p0_res],
+    keys=[
+        "/HpseudoToTTTo1L1Nu2J_m1000_w250p0_res_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=4,
+    n_events=498000,
+)
+
+
+cpn.add_dataset(
+    name="hpseudo_tt_sl_m_1000_w_250p0_int_madgraph",
+    id=14274475,
+    processes=[procs.hpseudo_tt_sl_m_1000_w_250p0_int],
+    keys=[
+        "/HpseudoToTTTo1L1Nu2J_m1000_w250p0_int_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=6,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="hpseudo_tt_sl_m_1000_w_100p0_res_madgraph",
+    id=14274418,
+    processes=[procs.hpseudo_tt_sl_m_1000_w_100p0_res],
+    keys=[
+        "/HpseudoToTTTo1L1Nu2J_m1000_w100p0_res_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=5,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="hpseudo_tt_sl_m_1000_w_100p0_int_madgraph",
+    id=14274332,
+    processes=[procs.hpseudo_tt_sl_m_1000_w_100p0_int],
+    keys=[
+        "/HpseudoToTTTo1L1Nu2J_m1000_w100p0_int_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=19,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="hpseudo_tt_sl_m_1000_w_25p0_res_madgraph",
+    id=14241343,
+    processes=[procs.hpseudo_tt_sl_m_1000_w_25p0_res],
+    keys=[
+        "/HpseudoToTTTo1L1Nu2J_m1000_w25p0_res_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=20,
+    n_events=497000,
+)
+
+
+cpn.add_dataset(
+    name="hpseudo_tt_sl_m_1000_w_25p0_int_madgraph",
+    id=14249272,
+    processes=[procs.hpseudo_tt_sl_m_1000_w_25p0_int],
+    keys=[
+        "/HpseudoToTTTo1L1Nu2J_m1000_w25p0_int_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=5,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="hscalar_tt_sl_m_365_w_91p25_res_madgraph",
+    id=14274676,
+    processes=[procs.hscalar_tt_sl_m_365_w_91p25_res],
+    keys=[
+        "/HscalarToTTTo1L1Nu2J_m365_w91p25_res_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=9,
+    n_events=496000,
+)
+
+
+cpn.add_dataset(
+    name="hscalar_tt_sl_m_365_w_91p25_int_madgraph",
+    id=14274334,
+    processes=[procs.hscalar_tt_sl_m_365_w_91p25_int],
+    keys=[
+        "/HscalarToTTTo1L1Nu2J_m365_w91p25_int_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=4,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="hscalar_tt_sl_m_365_w_36p5_res_madgraph",
+    id=14279145,
+    processes=[procs.hscalar_tt_sl_m_365_w_36p5_res],
+    keys=[
+        "/HscalarToTTTo1L1Nu2J_m365_w36p5_res_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=4,
+    n_events=494000,
+)
+
+
+cpn.add_dataset(
+    name="hscalar_tt_sl_m_365_w_36p5_int_madgraph",
+    id=14289222,
+    processes=[procs.hscalar_tt_sl_m_365_w_36p5_int],
+    keys=[
+        "/HscalarToTTTo1L1Nu2J_m365_w36p5_int_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="hscalar_tt_sl_m_365_w_9p125_res_madgraph",
+    id=14274416,
+    processes=[procs.hscalar_tt_sl_m_365_w_9p125_res],
+    keys=[
+        "/HscalarToTTTo1L1Nu2J_m365_w9p125_res_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=8,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="hscalar_tt_sl_m_365_w_9p125_int_madgraph",
+    id=14281021,
+    processes=[procs.hscalar_tt_sl_m_365_w_9p125_int],
+    keys=[
+        "/HscalarToTTTo1L1Nu2J_m365_w9p125_int_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=17,
+    n_events=497000,
+)
+
+
+cpn.add_dataset(
+    name="hscalar_tt_sl_m_400_w_100p0_res_madgraph",
+    id=14275618,
+    processes=[procs.hscalar_tt_sl_m_400_w_100p0_res],
+    keys=[
+        "/HscalarToTTTo1L1Nu2J_m400_w100p0_res_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="hscalar_tt_sl_m_400_w_100p0_int_madgraph",
+    id=14274362,
+    processes=[procs.hscalar_tt_sl_m_400_w_100p0_int],
+    keys=[
+        "/HscalarToTTTo1L1Nu2J_m400_w100p0_int_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=8,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="hscalar_tt_sl_m_400_w_40p0_res_madgraph",
+    id=14288310,
+    processes=[procs.hscalar_tt_sl_m_400_w_40p0_res],
+    keys=[
+        "/HscalarToTTTo1L1Nu2J_m400_w40p0_res_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=3,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="hscalar_tt_sl_m_400_w_40p0_int_madgraph",
+    id=14274962,
+    processes=[procs.hscalar_tt_sl_m_400_w_40p0_int],
+    keys=[
+        "/HscalarToTTTo1L1Nu2J_m400_w40p0_int_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=3,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="hscalar_tt_sl_m_400_w_10p0_res_madgraph",
+    id=14251426,
+    processes=[procs.hscalar_tt_sl_m_400_w_10p0_res],
+    keys=[
+        "/HscalarToTTTo1L1Nu2J_m400_w10p0_res_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=4,
+    n_events=491000,
+)
+
+
+cpn.add_dataset(
+    name="hscalar_tt_sl_m_400_w_10p0_int_madgraph",
+    id=14248632,
+    processes=[procs.hscalar_tt_sl_m_400_w_10p0_int],
+    keys=[
+        "/HscalarToTTTo1L1Nu2J_m400_w10p0_int_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=6,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="hscalar_tt_sl_m_500_w_125p0_res_madgraph",
+    id=14274427,
+    processes=[procs.hscalar_tt_sl_m_500_w_125p0_res],
+    keys=[
+        "/HscalarToTTTo1L1Nu2J_m500_w125p0_res_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=11,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="hscalar_tt_sl_m_500_w_125p0_int_madgraph",
+    id=14275741,
+    processes=[procs.hscalar_tt_sl_m_500_w_125p0_int],
+    keys=[
+        "/HscalarToTTTo1L1Nu2J_m500_w125p0_int_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=485000,
+)
+
+
+cpn.add_dataset(
+    name="hscalar_tt_sl_m_500_w_50p0_res_madgraph",
+    id=14275773,
+    processes=[procs.hscalar_tt_sl_m_500_w_50p0_res],
+    keys=[
+        "/HscalarToTTTo1L1Nu2J_m500_w50p0_res_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=3,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="hscalar_tt_sl_m_500_w_50p0_int_madgraph",
+    id=14275783,
+    processes=[procs.hscalar_tt_sl_m_500_w_50p0_int],
+    keys=[
+        "/HscalarToTTTo1L1Nu2J_m500_w50p0_int_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=497000,
+)
+
+
+cpn.add_dataset(
+    name="hscalar_tt_sl_m_500_w_12p5_res_madgraph",
+    id=14275965,
+    processes=[procs.hscalar_tt_sl_m_500_w_12p5_res],
+    keys=[
+        "/HscalarToTTTo1L1Nu2J_m500_w12p5_res_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="hscalar_tt_sl_m_500_w_12p5_int_madgraph",
+    id=14275799,
+    processes=[procs.hscalar_tt_sl_m_500_w_12p5_int],
+    keys=[
+        "/HscalarToTTTo1L1Nu2J_m500_w12p5_int_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="hscalar_tt_sl_m_600_w_150p0_res_madgraph",
+    id=14278372,
+    processes=[procs.hscalar_tt_sl_m_600_w_150p0_res],
+    keys=[
+        "/HscalarToTTTo1L1Nu2J_m600_w150p0_res_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=3,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="hscalar_tt_sl_m_600_w_150p0_int_madgraph",
+    id=14275881,
+    processes=[procs.hscalar_tt_sl_m_600_w_150p0_int],
+    keys=[
+        "/HscalarToTTTo1L1Nu2J_m600_w150p0_int_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=4,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="hscalar_tt_sl_m_600_w_60p0_res_madgraph",
+    id=14277937,
+    processes=[procs.hscalar_tt_sl_m_600_w_60p0_res],
+    keys=[
+        "/HscalarToTTTo1L1Nu2J_m600_w60p0_res_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=4,
+    n_events=497000,
+)
+
+
+cpn.add_dataset(
+    name="hscalar_tt_sl_m_600_w_60p0_int_madgraph",
+    id=14281292,
+    processes=[procs.hscalar_tt_sl_m_600_w_60p0_int],
+    keys=[
+        "/HscalarToTTTo1L1Nu2J_m600_w60p0_int_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=11,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="hscalar_tt_sl_m_600_w_15p0_res_madgraph",
+    id=14277655,
+    processes=[procs.hscalar_tt_sl_m_600_w_15p0_res],
+    keys=[
+        "/HscalarToTTTo1L1Nu2J_m600_w15p0_res_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=3,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="hscalar_tt_sl_m_600_w_15p0_int_madgraph",
+    id=14281221,
+    processes=[procs.hscalar_tt_sl_m_600_w_15p0_int],
+    keys=[
+        "/HscalarToTTTo1L1Nu2J_m600_w15p0_int_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=20,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="hscalar_tt_sl_m_800_w_200p0_res_madgraph",
+    id=14279147,
+    processes=[procs.hscalar_tt_sl_m_800_w_200p0_res],
+    keys=[
+        "/HscalarToTTTo1L1Nu2J_m800_w200p0_res_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=7,
+    n_events=498000,
+)
+
+
+cpn.add_dataset(
+    name="hscalar_tt_sl_m_800_w_200p0_int_madgraph",
+    id=14276378,
+    processes=[procs.hscalar_tt_sl_m_800_w_200p0_int],
+    keys=[
+        "/HscalarToTTTo1L1Nu2J_m800_w200p0_int_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=17,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="hscalar_tt_sl_m_800_w_80p0_res_madgraph",
+    id=14275775,
+    processes=[procs.hscalar_tt_sl_m_800_w_80p0_res],
+    keys=[
+        "/HscalarToTTTo1L1Nu2J_m800_w80p0_res_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=3,
+    n_events=497000,
+)
+
+
+cpn.add_dataset(
+    name="hscalar_tt_sl_m_800_w_80p0_int_madgraph",
+    id=14276054,
+    processes=[procs.hscalar_tt_sl_m_800_w_80p0_int],
+    keys=[
+        "/HscalarToTTTo1L1Nu2J_m800_w80p0_int_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=11,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="hscalar_tt_sl_m_800_w_20p0_res_madgraph",
+    id=14277314,
+    processes=[procs.hscalar_tt_sl_m_800_w_20p0_res],
+    keys=[
+        "/HscalarToTTTo1L1Nu2J_m800_w20p0_res_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=8,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="hscalar_tt_sl_m_800_w_20p0_int_madgraph",
+    id=14279331,
+    processes=[procs.hscalar_tt_sl_m_800_w_20p0_int],
+    keys=[
+        "/HscalarToTTTo1L1Nu2J_m800_w20p0_int_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=3,
+    n_events=494000,
+)
+
+
+cpn.add_dataset(
+    name="hscalar_tt_sl_m_1000_w_250p0_res_madgraph",
+    id=14278458,
+    processes=[procs.hscalar_tt_sl_m_1000_w_250p0_res],
+    keys=[
+        "/HscalarToTTTo1L1Nu2J_m1000_w250p0_res_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=4,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="hscalar_tt_sl_m_1000_w_250p0_int_madgraph",
+    id=14274336,
+    processes=[procs.hscalar_tt_sl_m_1000_w_250p0_int],
+    keys=[
+        "/HscalarToTTTo1L1Nu2J_m1000_w250p0_int_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=12,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="hscalar_tt_sl_m_1000_w_100p0_res_madgraph",
+    id=14275860,
+    processes=[procs.hscalar_tt_sl_m_1000_w_100p0_res],
+    keys=[
+        "/HscalarToTTTo1L1Nu2J_m1000_w100p0_res_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=3,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="hscalar_tt_sl_m_1000_w_100p0_int_madgraph",
+    id=14275758,
+    processes=[procs.hscalar_tt_sl_m_1000_w_100p0_int],
+    keys=[
+        "/HscalarToTTTo1L1Nu2J_m1000_w100p0_int_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=496000,
+)
+
+
+cpn.add_dataset(
+    name="hscalar_tt_sl_m_1000_w_25p0_res_madgraph",
+    id=14241206,
+    processes=[procs.hscalar_tt_sl_m_1000_w_25p0_res],
+    keys=[
+        "/HscalarToTTTo1L1Nu2J_m1000_w25p0_res_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=16,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="hscalar_tt_sl_m_1000_w_25p0_int_madgraph",
+    id=14241488,
+    processes=[procs.hscalar_tt_sl_m_1000_w_25p0_int],
+    keys=[
+        "/HscalarToTTTo1L1Nu2J_m1000_w25p0_int_TuneCP5_13TeV-madgraph_pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=9,
+    n_events=482000,
+)
+
+
+cpn.add_dataset(
+    name="rsgluon_tt_m_500_pythia",
+    id=14231292,
+    processes=[procs.rsgluon_tt_m_500],
+    keys=[
+        "/RSGluonToTT_M-500_TuneCP5_13TeV-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=9,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="rsgluon_tt_m_1000_pythia",
+    id=14231929,
+    processes=[procs.rsgluon_tt_m_1000],
+    keys=[
+        "/RSGluonToTT_M-1000_TuneCP5_13TeV-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=8,
+    n_events=485000,
+)
+
+
+cpn.add_dataset(
+    name="rsgluon_tt_m_1500_pythia",
+    id=14227364,
+    processes=[procs.rsgluon_tt_m_1500],
+    keys=[
+        "/RSGluonToTT_M-1500_TuneCP5_13TeV-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="rsgluon_tt_m_2000_pythia",
+    id=14230161,
+    processes=[procs.rsgluon_tt_m_2000],
+    keys=[
+        "/RSGluonToTT_M-2000_TuneCP5_13TeV-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=6,
+    n_events=494000,
+)
+
+
+cpn.add_dataset(
+    name="rsgluon_tt_m_2500_pythia",
+    id=14231336,
+    processes=[procs.rsgluon_tt_m_2500],
+    keys=[
+        "/RSGluonToTT_M-2500_TuneCP5_13TeV-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=10,
+    n_events=497000,
+)
+
+
+cpn.add_dataset(
+    name="rsgluon_tt_m_3000_pythia",
+    id=14232264,
+    processes=[procs.rsgluon_tt_m_3000],
+    keys=[
+        "/RSGluonToTT_M-3000_TuneCP5_13TeV-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="rsgluon_tt_m_3500_pythia",
+    id=14231628,
+    processes=[procs.rsgluon_tt_m_3500],
+    keys=[
+        "/RSGluonToTT_M-3500_TuneCP5_13TeV-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=8,
+    n_events=497000,
+)
+
+
+cpn.add_dataset(
+    name="rsgluon_tt_m_4000_pythia",
+    id=14231303,
+    processes=[procs.rsgluon_tt_m_4000],
+    keys=[
+        "/RSGluonToTT_M-4000_TuneCP5_13TeV-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=11,
+    n_events=497000,
+)
+
+
+cpn.add_dataset(
+    name="rsgluon_tt_m_4500_pythia",
+    id=14231632,
+    processes=[procs.rsgluon_tt_m_4500],
+    keys=[
+        "/RSGluonToTT_M-4500_TuneCP5_13TeV-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=13,
+    n_events=488000,
+)
+
+
+cpn.add_dataset(
+    name="rsgluon_tt_m_5000_pythia",
+    id=14231549,
+    processes=[procs.rsgluon_tt_m_5000],
+    keys=[
+        "/RSGluonToTT_M-5000_TuneCP5_13TeV-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=8,
+    n_events=500000,
+)
+
+
+cpn.add_dataset(
+    name="rsgluon_tt_m_5500_pythia",
+    id=14231358,
+    processes=[procs.rsgluon_tt_m_5500],
+    keys=[
+        "/RSGluonToTT_M-5500_TuneCP5_13TeV-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=6,
+    n_events=494000,
+)
+
+
+cpn.add_dataset(
+    name="rsgluon_tt_m_6000_pythia",
+    id=14231365,
+    processes=[procs.rsgluon_tt_m_6000],
+    keys=[
+        "/RSGluonToTT_M-6000_TuneCP5_13TeV-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=12,
+    n_events=500000,
+)

--- a/cmsdb/processes/__init__.py
+++ b/cmsdb/processes/__init__.py
@@ -12,3 +12,4 @@ from cmsdb.processes.qcd import *  # noqa
 from cmsdb.processes.higgs import *  # noqa
 from cmsdb.processes.hh2bbtautau import *  # noqa
 from cmsdb.processes.hh2bbww import *  # noqa
+from cmsdb.processes.mttbar import *  # noqa

--- a/cmsdb/processes/data.py
+++ b/cmsdb/processes/data.py
@@ -5,7 +5,7 @@ Data process definitions.
 """
 
 __all__ = [
-    "data", "data_e", "data_mu", "data_tau", "data_met",
+    "data", "data_e", "data_mu", "data_tau", "data_met", "data_pho",
 ]
 
 from order import Process
@@ -49,4 +49,11 @@ data_met = data.add_process(
     id=40,
     is_data=True,
     label=r"Data MET",
+)
+
+data_pho = data.add_process(
+    name="data_pho",
+    id=50,
+    is_data=True,
+    label=r"Data $\gamma$",
 )

--- a/cmsdb/processes/ewk.py
+++ b/cmsdb/processes/ewk.py
@@ -312,7 +312,7 @@ zz = vv.add_process(
     name="zz",
     id=8100,
     label="ZZ",
-    xsecs={13: Number(0.1)},  # TODO
+    xsecs={13: Number(12.13)},  # AN-19-197_v3
 )
 
 zz_qqll_m4 = zz.add_process(
@@ -337,7 +337,7 @@ wz = vv.add_process(
     name="wz",
     id=8200,
     label="WZ",
-    xsecs={13: Number(0.1)},  # TODO
+    xsecs={13: Number(25.56)},  # AN-19-197_v3
 )
 
 wz_lllnu = wz.add_process(
@@ -356,7 +356,7 @@ ww = vv.add_process(
     name="ww",
     id=8300,
     label="WW",
-    xsecs={13: Number(0.1)},  # TODO
+    xsecs={13: Number(75.91)},  # AN-19-197_v3
 )
 
 ww_lnulnu = ww.add_process(

--- a/cmsdb/processes/mttbar.py
+++ b/cmsdb/processes/mttbar.py
@@ -1,0 +1,1700 @@
+# coding: utf-8
+
+"""
+m(ttbar) line search signal process definitions
+"""
+
+__all__ = [
+    "zprime_tt",
+    "zprime_tt_m_400_w_40",
+    "zprime_tt_m_400_w_120",
+    "zprime_tt_m_400_w_4",
+    "zprime_tt_m_500_w_50",
+    "zprime_tt_m_500_w_150",
+    "zprime_tt_m_500_w_5",
+    "zprime_tt_m_600_w_60",
+    "zprime_tt_m_600_w_180",
+    "zprime_tt_m_600_w_6",
+    "zprime_tt_m_700_w_70",
+    "zprime_tt_m_700_w_210",
+    "zprime_tt_m_700_w_7",
+    "zprime_tt_m_800_w_80",
+    "zprime_tt_m_800_w_240",
+    "zprime_tt_m_800_w_8",
+    "zprime_tt_m_900_w_90",
+    "zprime_tt_m_900_w_270",
+    "zprime_tt_m_900_w_9",
+    "zprime_tt_m_1000_w_100",
+    "zprime_tt_m_1000_w_300",
+    "zprime_tt_m_1000_w_10",
+    "zprime_tt_m_1200_w_120",
+    "zprime_tt_m_1200_w_360",
+    "zprime_tt_m_1200_w_12",
+    "zprime_tt_m_1400_w_140",
+    "zprime_tt_m_1400_w_420",
+    "zprime_tt_m_1400_w_14",
+    "zprime_tt_m_1600_w_160",
+    "zprime_tt_m_1600_w_480",
+    "zprime_tt_m_1600_w_16",
+    "zprime_tt_m_1800_w_180",
+    "zprime_tt_m_1800_w_540",
+    "zprime_tt_m_1800_w_18",
+    "zprime_tt_m_2000_w_200",
+    "zprime_tt_m_2000_w_600",
+    "zprime_tt_m_2000_w_20",
+    "zprime_tt_m_2500_w_250",
+    "zprime_tt_m_2500_w_750",
+    "zprime_tt_m_2500_w_25",
+    "zprime_tt_m_3000_w_300",
+    "zprime_tt_m_3000_w_900",
+    "zprime_tt_m_3000_w_30",
+    "zprime_tt_m_3500_w_350",
+    "zprime_tt_m_3500_w_1050",
+    "zprime_tt_m_3500_w_35",
+    "zprime_tt_m_4000_w_400",
+    "zprime_tt_m_4000_w_1200",
+    "zprime_tt_m_4000_w_40",
+    "zprime_tt_m_4500_w_450",
+    "zprime_tt_m_4500_w_1350",
+    "zprime_tt_m_4500_w_45",
+    "zprime_tt_m_5000_w_500",
+    "zprime_tt_m_5000_w_1500",
+    "zprime_tt_m_5000_w_50",
+    "zprime_tt_m_6000_w_600",
+    "zprime_tt_m_6000_w_1800",
+    "zprime_tt_m_6000_w_60",
+    "zprime_tt_m_7000_w_700",
+    "zprime_tt_m_7000_w_2100",
+    "zprime_tt_m_7000_w_70",
+    "zprime_tt_m_8000_w_800",
+    "zprime_tt_m_8000_w_2400",
+    "zprime_tt_m_8000_w_80",
+    "zprime_tt_m_9000_w_900",
+    "zprime_tt_m_9000_w_2700",
+    "zprime_tt_m_9000_w_90",
+    "hscalar_tt",
+    "hscalar_tt_sl",
+    "hscalar_tt_sl_m_365_w_91p25",
+    "hscalar_tt_sl_m_365_w_91p25_res",
+    "hscalar_tt_sl_m_365_w_91p25_int",
+    "hscalar_tt_sl_m_400_w_100p0",
+    "hscalar_tt_sl_m_400_w_100p0_res",
+    "hscalar_tt_sl_m_400_w_100p0_int",
+    "hscalar_tt_sl_m_500_w_125p0",
+    "hscalar_tt_sl_m_500_w_125p0_res",
+    "hscalar_tt_sl_m_500_w_125p0_int",
+    "hscalar_tt_sl_m_600_w_150p0",
+    "hscalar_tt_sl_m_600_w_150p0_res",
+    "hscalar_tt_sl_m_600_w_150p0_int",
+    "hscalar_tt_sl_m_800_w_200p0",
+    "hscalar_tt_sl_m_800_w_200p0_res",
+    "hscalar_tt_sl_m_800_w_200p0_int",
+    "hscalar_tt_sl_m_1000_w_250p0",
+    "hscalar_tt_sl_m_1000_w_250p0_res",
+    "hscalar_tt_sl_m_1000_w_250p0_int",
+    "hscalar_tt_sl_m_365_w_36p5",
+    "hscalar_tt_sl_m_365_w_36p5_res",
+    "hscalar_tt_sl_m_365_w_36p5_int",
+    "hscalar_tt_sl_m_400_w_40p0",
+    "hscalar_tt_sl_m_400_w_40p0_res",
+    "hscalar_tt_sl_m_400_w_40p0_int",
+    "hscalar_tt_sl_m_500_w_50p0",
+    "hscalar_tt_sl_m_500_w_50p0_res",
+    "hscalar_tt_sl_m_500_w_50p0_int",
+    "hscalar_tt_sl_m_600_w_60p0",
+    "hscalar_tt_sl_m_600_w_60p0_res",
+    "hscalar_tt_sl_m_600_w_60p0_int",
+    "hscalar_tt_sl_m_800_w_80p0",
+    "hscalar_tt_sl_m_800_w_80p0_res",
+    "hscalar_tt_sl_m_800_w_80p0_int",
+    "hscalar_tt_sl_m_1000_w_100p0",
+    "hscalar_tt_sl_m_1000_w_100p0_res",
+    "hscalar_tt_sl_m_1000_w_100p0_int",
+    "hscalar_tt_sl_m_365_w_9p125",
+    "hscalar_tt_sl_m_365_w_9p125_res",
+    "hscalar_tt_sl_m_365_w_9p125_int",
+    "hscalar_tt_sl_m_400_w_10p0",
+    "hscalar_tt_sl_m_400_w_10p0_res",
+    "hscalar_tt_sl_m_400_w_10p0_int",
+    "hscalar_tt_sl_m_500_w_12p5",
+    "hscalar_tt_sl_m_500_w_12p5_res",
+    "hscalar_tt_sl_m_500_w_12p5_int",
+    "hscalar_tt_sl_m_600_w_15p0",
+    "hscalar_tt_sl_m_600_w_15p0_res",
+    "hscalar_tt_sl_m_600_w_15p0_int",
+    "hscalar_tt_sl_m_800_w_20p0",
+    "hscalar_tt_sl_m_800_w_20p0_res",
+    "hscalar_tt_sl_m_800_w_20p0_int",
+    "hscalar_tt_sl_m_1000_w_25p0",
+    "hscalar_tt_sl_m_1000_w_25p0_res",
+    "hscalar_tt_sl_m_1000_w_25p0_int",
+    "hpseudo_tt",
+    "hpseudo_tt_sl",
+    "hpseudo_tt_sl_m_365_w_91p25",
+    "hpseudo_tt_sl_m_365_w_91p25_res",
+    "hpseudo_tt_sl_m_365_w_91p25_int",
+    "hpseudo_tt_sl_m_400_w_100p0",
+    "hpseudo_tt_sl_m_400_w_100p0_res",
+    "hpseudo_tt_sl_m_400_w_100p0_int",
+    "hpseudo_tt_sl_m_500_w_125p0",
+    "hpseudo_tt_sl_m_500_w_125p0_res",
+    "hpseudo_tt_sl_m_500_w_125p0_int",
+    "hpseudo_tt_sl_m_600_w_150p0",
+    "hpseudo_tt_sl_m_600_w_150p0_res",
+    "hpseudo_tt_sl_m_600_w_150p0_int",
+    "hpseudo_tt_sl_m_800_w_200p0",
+    "hpseudo_tt_sl_m_800_w_200p0_res",
+    "hpseudo_tt_sl_m_800_w_200p0_int",
+    "hpseudo_tt_sl_m_1000_w_250p0",
+    "hpseudo_tt_sl_m_1000_w_250p0_res",
+    "hpseudo_tt_sl_m_1000_w_250p0_int",
+    "hpseudo_tt_sl_m_365_w_36p5",
+    "hpseudo_tt_sl_m_365_w_36p5_res",
+    "hpseudo_tt_sl_m_365_w_36p5_int",
+    "hpseudo_tt_sl_m_400_w_40p0",
+    "hpseudo_tt_sl_m_400_w_40p0_res",
+    "hpseudo_tt_sl_m_400_w_40p0_int",
+    "hpseudo_tt_sl_m_500_w_50p0",
+    "hpseudo_tt_sl_m_500_w_50p0_res",
+    "hpseudo_tt_sl_m_500_w_50p0_int",
+    "hpseudo_tt_sl_m_600_w_60p0",
+    "hpseudo_tt_sl_m_600_w_60p0_res",
+    "hpseudo_tt_sl_m_600_w_60p0_int",
+    "hpseudo_tt_sl_m_800_w_80p0",
+    "hpseudo_tt_sl_m_800_w_80p0_res",
+    "hpseudo_tt_sl_m_800_w_80p0_int",
+    "hpseudo_tt_sl_m_1000_w_100p0",
+    "hpseudo_tt_sl_m_1000_w_100p0_res",
+    "hpseudo_tt_sl_m_1000_w_100p0_int",
+    "hpseudo_tt_sl_m_365_w_9p125",
+    "hpseudo_tt_sl_m_365_w_9p125_res",
+    "hpseudo_tt_sl_m_365_w_9p125_int",
+    "hpseudo_tt_sl_m_400_w_10p0",
+    "hpseudo_tt_sl_m_400_w_10p0_res",
+    "hpseudo_tt_sl_m_400_w_10p0_int",
+    "hpseudo_tt_sl_m_500_w_12p5",
+    "hpseudo_tt_sl_m_500_w_12p5_res",
+    "hpseudo_tt_sl_m_500_w_12p5_int",
+    "hpseudo_tt_sl_m_600_w_15p0",
+    "hpseudo_tt_sl_m_600_w_15p0_res",
+    "hpseudo_tt_sl_m_600_w_15p0_int",
+    "hpseudo_tt_sl_m_800_w_20p0",
+    "hpseudo_tt_sl_m_800_w_20p0_res",
+    "hpseudo_tt_sl_m_800_w_20p0_int",
+    "hpseudo_tt_sl_m_1000_w_25p0",
+    "hpseudo_tt_sl_m_1000_w_25p0_res",
+    "hpseudo_tt_sl_m_1000_w_25p0_int",
+    "rsgluon_tt",
+    "rsgluon_tt_m_500",
+    "rsgluon_tt_m_1000",
+    "rsgluon_tt_m_1500",
+    "rsgluon_tt_m_2000",
+    "rsgluon_tt_m_2500",
+    "rsgluon_tt_m_3000",
+    "rsgluon_tt_m_3500",
+    "rsgluon_tt_m_4000",
+    "rsgluon_tt_m_4500",
+    "rsgluon_tt_m_5000",
+    "rsgluon_tt_m_5500",
+    "rsgluon_tt_m_6000",
+]
+
+
+from order import Process
+from scinum import Number
+
+#
+# Z prime
+#
+
+zprime = Process(
+    name="zprime",
+    label=r"Z'",
+    id=60000,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+zprime_tt = zprime.add_process(
+    name="zprime_tt",
+    label=rf"{zprime.label} $\rightarrow t\bar{{t}}$",
+    id=61000,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+# width / mass = 10%
+
+zprime_tt_m_400_w_40 = zprime_tt.add_process(
+    name="zprime_tt_m_400_w_40",
+    label=rf"{zprime_tt.label} ($m = 400$ GeV, $\Gamma/m = 10\%$)",
+    id=61001,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+zprime_tt_m_400_w_120 = zprime_tt.add_process(
+    name="zprime_tt_m_400_w_120",
+    label=rf"{zprime_tt.label} ($m = 400$ GeV, $\Gamma/m = 30\%$)",
+    id=61002,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+zprime_tt_m_400_w_4 = zprime_tt.add_process(
+    name="zprime_tt_m_400_w_4",
+    label=rf"{zprime_tt.label} ($m = 400$ GeV, $\Gamma/m = 1\%$)",
+    id=61003,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+# width / mass = 10%
+
+zprime_tt_m_500_w_50 = zprime_tt.add_process(
+    name="zprime_tt_m_500_w_50",
+    label=rf"{zprime_tt.label} ($m = 500$ GeV, $\Gamma/m = 10\%$)",
+    id=61004,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+zprime_tt_m_500_w_150 = zprime_tt.add_process(
+    name="zprime_tt_m_500_w_150",
+    label=rf"{zprime_tt.label} ($m = 500$ GeV, $\Gamma/m = 30\%$)",
+    id=61005,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+zprime_tt_m_500_w_5 = zprime_tt.add_process(
+    name="zprime_tt_m_500_w_5",
+    label=rf"{zprime_tt.label} ($m = 500$ GeV, $\Gamma/m = 1\%$)",
+    id=61006,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+# width / mass = 10%
+
+zprime_tt_m_600_w_60 = zprime_tt.add_process(
+    name="zprime_tt_m_600_w_60",
+    label=rf"{zprime_tt.label} ($m = 600$ GeV, $\Gamma/m = 10\%$)",
+    id=61007,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+zprime_tt_m_600_w_180 = zprime_tt.add_process(
+    name="zprime_tt_m_600_w_180",
+    label=rf"{zprime_tt.label} ($m = 600$ GeV, $\Gamma/m = 30\%$)",
+    id=61008,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+zprime_tt_m_600_w_6 = zprime_tt.add_process(
+    name="zprime_tt_m_600_w_6",
+    label=rf"{zprime_tt.label} ($m = 600$ GeV, $\Gamma/m = 1\%$)",
+    id=61009,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+# width / mass = 10%
+
+zprime_tt_m_700_w_70 = zprime_tt.add_process(
+    name="zprime_tt_m_700_w_70",
+    label=rf"{zprime_tt.label} ($m = 700$ GeV, $\Gamma/m = 10\%$)",
+    id=61010,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+zprime_tt_m_700_w_210 = zprime_tt.add_process(
+    name="zprime_tt_m_700_w_210",
+    label=rf"{zprime_tt.label} ($m = 700$ GeV, $\Gamma/m = 30\%$)",
+    id=61011,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+zprime_tt_m_700_w_7 = zprime_tt.add_process(
+    name="zprime_tt_m_700_w_7",
+    label=rf"{zprime_tt.label} ($m = 700$ GeV, $\Gamma/m = 1\%$)",
+    id=61012,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+# width / mass = 10%
+
+zprime_tt_m_800_w_80 = zprime_tt.add_process(
+    name="zprime_tt_m_800_w_80",
+    label=rf"{zprime_tt.label} ($m = 800$ GeV, $\Gamma/m = 10\%$)",
+    id=61013,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+zprime_tt_m_800_w_240 = zprime_tt.add_process(
+    name="zprime_tt_m_800_w_240",
+    label=rf"{zprime_tt.label} ($m = 800$ GeV, $\Gamma/m = 30\%$)",
+    id=61014,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+zprime_tt_m_800_w_8 = zprime_tt.add_process(
+    name="zprime_tt_m_800_w_8",
+    label=rf"{zprime_tt.label} ($m = 800$ GeV, $\Gamma/m = 1\%$)",
+    id=61015,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+# width / mass = 10%
+
+zprime_tt_m_900_w_90 = zprime_tt.add_process(
+    name="zprime_tt_m_900_w_90",
+    label=rf"{zprime_tt.label} ($m = 900$ GeV, $\Gamma/m = 10\%$)",
+    id=61016,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+zprime_tt_m_900_w_270 = zprime_tt.add_process(
+    name="zprime_tt_m_900_w_270",
+    label=rf"{zprime_tt.label} ($m = 900$ GeV, $\Gamma/m = 30\%$)",
+    id=61017,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+zprime_tt_m_900_w_9 = zprime_tt.add_process(
+    name="zprime_tt_m_900_w_9",
+    label=rf"{zprime_tt.label} ($m = 900$ GeV, $\Gamma/m = 1\%$)",
+    id=61018,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+# width / mass = 10%
+
+zprime_tt_m_1000_w_100 = zprime_tt.add_process(
+    name="zprime_tt_m_1000_w_100",
+    label=rf"{zprime_tt.label} ($m = 1000$ GeV, $\Gamma/m = 10\%$)",
+    id=61019,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+zprime_tt_m_1000_w_300 = zprime_tt.add_process(
+    name="zprime_tt_m_1000_w_300",
+    label=rf"{zprime_tt.label} ($m = 1000$ GeV, $\Gamma/m = 30\%$)",
+    id=61020,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+zprime_tt_m_1000_w_10 = zprime_tt.add_process(
+    name="zprime_tt_m_1000_w_10",
+    label=rf"{zprime_tt.label} ($m = 1000$ GeV, $\Gamma/m = 1\%$)",
+    id=61021,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+# width / mass = 10%
+
+zprime_tt_m_1200_w_120 = zprime_tt.add_process(
+    name="zprime_tt_m_1200_w_120",
+    label=rf"{zprime_tt.label} ($m = 1200$ GeV, $\Gamma/m = 10\%$)",
+    id=61022,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+zprime_tt_m_1200_w_360 = zprime_tt.add_process(
+    name="zprime_tt_m_1200_w_360",
+    label=rf"{zprime_tt.label} ($m = 1200$ GeV, $\Gamma/m = 30\%$)",
+    id=61023,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+zprime_tt_m_1200_w_12 = zprime_tt.add_process(
+    name="zprime_tt_m_1200_w_12",
+    label=rf"{zprime_tt.label} ($m = 1200$ GeV, $\Gamma/m = 1\%$)",
+    id=61024,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+# width / mass = 10%
+
+zprime_tt_m_1400_w_140 = zprime_tt.add_process(
+    name="zprime_tt_m_1400_w_140",
+    label=rf"{zprime_tt.label} ($m = 1400$ GeV, $\Gamma/m = 10\%$)",
+    id=61025,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+zprime_tt_m_1400_w_420 = zprime_tt.add_process(
+    name="zprime_tt_m_1400_w_420",
+    label=rf"{zprime_tt.label} ($m = 1400$ GeV, $\Gamma/m = 30\%$)",
+    id=61026,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+zprime_tt_m_1400_w_14 = zprime_tt.add_process(
+    name="zprime_tt_m_1400_w_14",
+    label=rf"{zprime_tt.label} ($m = 1400$ GeV, $\Gamma/m = 1\%$)",
+    id=61027,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+# width / mass = 10%
+
+zprime_tt_m_1600_w_160 = zprime_tt.add_process(
+    name="zprime_tt_m_1600_w_160",
+    label=rf"{zprime_tt.label} ($m = 1600$ GeV, $\Gamma/m = 10\%$)",
+    id=61028,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+zprime_tt_m_1600_w_480 = zprime_tt.add_process(
+    name="zprime_tt_m_1600_w_480",
+    label=rf"{zprime_tt.label} ($m = 1600$ GeV, $\Gamma/m = 30\%$)",
+    id=61029,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+zprime_tt_m_1600_w_16 = zprime_tt.add_process(
+    name="zprime_tt_m_1600_w_16",
+    label=rf"{zprime_tt.label} ($m = 1600$ GeV, $\Gamma/m = 1\%$)",
+    id=61030,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+# width / mass = 10%
+
+zprime_tt_m_1800_w_180 = zprime_tt.add_process(
+    name="zprime_tt_m_1800_w_180",
+    label=rf"{zprime_tt.label} ($m = 1800$ GeV, $\Gamma/m = 10\%$)",
+    id=61031,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+zprime_tt_m_1800_w_540 = zprime_tt.add_process(
+    name="zprime_tt_m_1800_w_540",
+    label=rf"{zprime_tt.label} ($m = 1800$ GeV, $\Gamma/m = 30\%$)",
+    id=61032,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+zprime_tt_m_1800_w_18 = zprime_tt.add_process(
+    name="zprime_tt_m_1800_w_18",
+    label=rf"{zprime_tt.label} ($m = 1800$ GeV, $\Gamma/m = 1\%$)",
+    id=61033,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+# width / mass = 10%
+
+zprime_tt_m_2000_w_200 = zprime_tt.add_process(
+    name="zprime_tt_m_2000_w_200",
+    label=rf"{zprime_tt.label} ($m = 2000$ GeV, $\Gamma/m = 10\%$)",
+    id=61034,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+zprime_tt_m_2000_w_600 = zprime_tt.add_process(
+    name="zprime_tt_m_2000_w_600",
+    label=rf"{zprime_tt.label} ($m = 2000$ GeV, $\Gamma/m = 30\%$)",
+    id=61035,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+zprime_tt_m_2000_w_20 = zprime_tt.add_process(
+    name="zprime_tt_m_2000_w_20",
+    label=rf"{zprime_tt.label} ($m = 2000$ GeV, $\Gamma/m = 1\%$)",
+    id=61036,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+# width / mass = 10%
+
+zprime_tt_m_2500_w_250 = zprime_tt.add_process(
+    name="zprime_tt_m_2500_w_250",
+    label=rf"{zprime_tt.label} ($m = 2500$ GeV, $\Gamma/m = 10\%$)",
+    id=61037,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+zprime_tt_m_2500_w_750 = zprime_tt.add_process(
+    name="zprime_tt_m_2500_w_750",
+    label=rf"{zprime_tt.label} ($m = 2500$ GeV, $\Gamma/m = 30\%$)",
+    id=61038,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+zprime_tt_m_2500_w_25 = zprime_tt.add_process(
+    name="zprime_tt_m_2500_w_25",
+    label=rf"{zprime_tt.label} ($m = 2500$ GeV, $\Gamma/m = 1\%$)",
+    id=61039,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+# width / mass = 10%
+
+zprime_tt_m_3000_w_300 = zprime_tt.add_process(
+    name="zprime_tt_m_3000_w_300",
+    label=rf"{zprime_tt.label} ($m = 3000$ GeV, $\Gamma/m = 10\%$)",
+    id=61040,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+zprime_tt_m_3000_w_900 = zprime_tt.add_process(
+    name="zprime_tt_m_3000_w_900",
+    label=rf"{zprime_tt.label} ($m = 3000$ GeV, $\Gamma/m = 30\%$)",
+    id=61041,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+zprime_tt_m_3000_w_30 = zprime_tt.add_process(
+    name="zprime_tt_m_3000_w_30",
+    label=rf"{zprime_tt.label} ($m = 3000$ GeV, $\Gamma/m = 1\%$)",
+    id=61042,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+# width / mass = 10%
+
+zprime_tt_m_3500_w_350 = zprime_tt.add_process(
+    name="zprime_tt_m_3500_w_350",
+    label=rf"{zprime_tt.label} ($m = 3500$ GeV, $\Gamma/m = 10\%$)",
+    id=61043,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+zprime_tt_m_3500_w_1050 = zprime_tt.add_process(
+    name="zprime_tt_m_3500_w_1050",
+    label=rf"{zprime_tt.label} ($m = 3500$ GeV, $\Gamma/m = 30\%$)",
+    id=61044,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+zprime_tt_m_3500_w_35 = zprime_tt.add_process(
+    name="zprime_tt_m_3500_w_35",
+    label=rf"{zprime_tt.label} ($m = 3500$ GeV, $\Gamma/m = 1\%$)",
+    id=61045,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+# width / mass = 10%
+
+zprime_tt_m_4000_w_400 = zprime_tt.add_process(
+    name="zprime_tt_m_4000_w_400",
+    label=rf"{zprime_tt.label} ($m = 4000$ GeV, $\Gamma/m = 10\%$)",
+    id=61046,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+zprime_tt_m_4000_w_1200 = zprime_tt.add_process(
+    name="zprime_tt_m_4000_w_1200",
+    label=rf"{zprime_tt.label} ($m = 4000$ GeV, $\Gamma/m = 30\%$)",
+    id=61047,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+zprime_tt_m_4000_w_40 = zprime_tt.add_process(
+    name="zprime_tt_m_4000_w_40",
+    label=rf"{zprime_tt.label} ($m = 4000$ GeV, $\Gamma/m = 1\%$)",
+    id=61048,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+# width / mass = 10%
+
+zprime_tt_m_4500_w_450 = zprime_tt.add_process(
+    name="zprime_tt_m_4500_w_450",
+    label=rf"{zprime_tt.label} ($m = 4500$ GeV, $\Gamma/m = 10\%$)",
+    id=61049,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+zprime_tt_m_4500_w_1350 = zprime_tt.add_process(
+    name="zprime_tt_m_4500_w_1350",
+    label=rf"{zprime_tt.label} ($m = 4500$ GeV, $\Gamma/m = 30\%$)",
+    id=61050,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+zprime_tt_m_4500_w_45 = zprime_tt.add_process(
+    name="zprime_tt_m_4500_w_45",
+    label=rf"{zprime_tt.label} ($m = 4500$ GeV, $\Gamma/m = 1\%$)",
+    id=61051,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+# width / mass = 10%
+
+zprime_tt_m_5000_w_500 = zprime_tt.add_process(
+    name="zprime_tt_m_5000_w_500",
+    label=rf"{zprime_tt.label} ($m = 5000$ GeV, $\Gamma/m = 10\%$)",
+    id=61052,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+zprime_tt_m_5000_w_1500 = zprime_tt.add_process(
+    name="zprime_tt_m_5000_w_1500",
+    label=rf"{zprime_tt.label} ($m = 5000$ GeV, $\Gamma/m = 30\%$)",
+    id=61053,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+zprime_tt_m_5000_w_50 = zprime_tt.add_process(
+    name="zprime_tt_m_5000_w_50",
+    label=rf"{zprime_tt.label} ($m = 5000$ GeV, $\Gamma/m = 1\%$)",
+    id=61054,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+# width / mass = 10%
+
+zprime_tt_m_6000_w_600 = zprime_tt.add_process(
+    name="zprime_tt_m_6000_w_600",
+    label=rf"{zprime_tt.label} ($m = 6000$ GeV, $\Gamma/m = 10\%$)",
+    id=61055,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+zprime_tt_m_6000_w_1800 = zprime_tt.add_process(
+    name="zprime_tt_m_6000_w_1800",
+    label=rf"{zprime_tt.label} ($m = 6000$ GeV, $\Gamma/m = 30\%$)",
+    id=61056,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+zprime_tt_m_6000_w_60 = zprime_tt.add_process(
+    name="zprime_tt_m_6000_w_60",
+    label=rf"{zprime_tt.label} ($m = 6000$ GeV, $\Gamma/m = 1\%$)",
+    id=61057,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+# width / mass = 10%
+
+zprime_tt_m_7000_w_700 = zprime_tt.add_process(
+    name="zprime_tt_m_7000_w_700",
+    label=rf"{zprime_tt.label} ($m = 7000$ GeV, $\Gamma/m = 10\%$)",
+    id=61058,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+zprime_tt_m_7000_w_2100 = zprime_tt.add_process(
+    name="zprime_tt_m_7000_w_2100",
+    label=rf"{zprime_tt.label} ($m = 7000$ GeV, $\Gamma/m = 30\%$)",
+    id=61059,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+zprime_tt_m_7000_w_70 = zprime_tt.add_process(
+    name="zprime_tt_m_7000_w_70",
+    label=rf"{zprime_tt.label} ($m = 7000$ GeV, $\Gamma/m = 1\%$)",
+    id=61060,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+# width / mass = 10%
+
+zprime_tt_m_8000_w_800 = zprime_tt.add_process(
+    name="zprime_tt_m_8000_w_800",
+    label=rf"{zprime_tt.label} ($m = 8000$ GeV, $\Gamma/m = 10\%$)",
+    id=61061,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+zprime_tt_m_8000_w_2400 = zprime_tt.add_process(
+    name="zprime_tt_m_8000_w_2400",
+    label=rf"{zprime_tt.label} ($m = 8000$ GeV, $\Gamma/m = 30\%$)",
+    id=61062,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+zprime_tt_m_8000_w_80 = zprime_tt.add_process(
+    name="zprime_tt_m_8000_w_80",
+    label=rf"{zprime_tt.label} ($m = 8000$ GeV, $\Gamma/m = 1\%$)",
+    id=61063,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+# width / mass = 10%
+
+zprime_tt_m_9000_w_900 = zprime_tt.add_process(
+    name="zprime_tt_m_9000_w_900",
+    label=rf"{zprime_tt.label} ($m = 9000$ GeV, $\Gamma/m = 10\%$)",
+    id=61064,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+zprime_tt_m_9000_w_2700 = zprime_tt.add_process(
+    name="zprime_tt_m_9000_w_2700",
+    label=rf"{zprime_tt.label} ($m = 9000$ GeV, $\Gamma/m = 30\%$)",
+    id=61065,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+zprime_tt_m_9000_w_90 = zprime_tt.add_process(
+    name="zprime_tt_m_9000_w_90",
+    label=rf"{zprime_tt.label} ($m = 9000$ GeV, $\Gamma/m = 1\%$)",
+    id=61066,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+#
+# Scalar heavy Higgs
+#
+
+hscalar_tt = Process(
+    name="hscalar_tt",
+    label=r"H $\rightarrow t\bar{t}$",
+    id=70000,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+hscalar_tt_sl = hscalar_tt.add_process(
+    name="hscalar_tt_sl",
+    label=rf"{hscalar_tt.label} $\rightarrow \ell\nu + \mathrm{{jets}}$",
+    id=70100,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+# width / mass = 25%
+
+hscalar_tt_sl_m_365_w_91p25 = hscalar_tt_sl.add_process(
+    name="hscalar_tt_sl_m_365_w_91p25",
+    label=rf"{hscalar_tt_sl.label} ($m = 365$ GeV, $\Gamma/m = 25\%$)",
+    id=70101,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hscalar_tt_sl_m_365_w_91p25_res = hscalar_tt_sl_m_365_w_91p25.add_process(
+    name="hscalar_tt_sl_m_365_w_91p25_res",
+    label=rf"{hscalar_tt_sl_m_365_w_91p25.label}, res",
+    id=70102,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hscalar_tt_sl_m_365_w_91p25_int = hscalar_tt_sl_m_365_w_91p25.add_process(
+    name="hscalar_tt_sl_m_365_w_91p25_int",
+    label=rf"{hscalar_tt_sl_m_365_w_91p25.label}, int",
+    id=70103,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hscalar_tt_sl_m_400_w_100p0 = hscalar_tt_sl.add_process(
+    name="hscalar_tt_sl_m_400_w_100p0",
+    label=rf"{hscalar_tt_sl.label} ($m = 400$ GeV, $\Gamma/m = 25\%$)",
+    id=70104,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hscalar_tt_sl_m_400_w_100p0_res = hscalar_tt_sl_m_400_w_100p0.add_process(
+    name="hscalar_tt_sl_m_400_w_100p0_res",
+    label=rf"{hscalar_tt_sl_m_400_w_100p0.label}, res",
+    id=70105,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hscalar_tt_sl_m_400_w_100p0_int = hscalar_tt_sl_m_400_w_100p0.add_process(
+    name="hscalar_tt_sl_m_400_w_100p0_int",
+    label=rf"{hscalar_tt_sl_m_400_w_100p0.label}, int",
+    id=70106,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hscalar_tt_sl_m_500_w_125p0 = hscalar_tt_sl.add_process(
+    name="hscalar_tt_sl_m_500_w_125p0",
+    label=rf"{hscalar_tt_sl.label} ($m = 500$ GeV, $\Gamma/m = 25\%$)",
+    id=70107,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hscalar_tt_sl_m_500_w_125p0_res = hscalar_tt_sl_m_500_w_125p0.add_process(
+    name="hscalar_tt_sl_m_500_w_125p0_res",
+    label=rf"{hscalar_tt_sl_m_500_w_125p0.label}, res",
+    id=70108,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hscalar_tt_sl_m_500_w_125p0_int = hscalar_tt_sl_m_500_w_125p0.add_process(
+    name="hscalar_tt_sl_m_500_w_125p0_int",
+    label=rf"{hscalar_tt_sl_m_500_w_125p0.label}, int",
+    id=70109,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+# width / mass = 25%
+
+hscalar_tt_sl_m_600_w_150p0 = hscalar_tt_sl.add_process(
+    name="hscalar_tt_sl_m_600_w_150p0",
+    label=rf"{hscalar_tt_sl.label} ($m = 600$ GeV, $\Gamma/m = 25\%$)",
+    id=70110,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hscalar_tt_sl_m_600_w_150p0_res = hscalar_tt_sl_m_600_w_150p0.add_process(
+    name="hscalar_tt_sl_m_600_w_150p0_res",
+    label=rf"{hscalar_tt_sl_m_600_w_150p0.label}, res",
+    id=70111,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hscalar_tt_sl_m_600_w_150p0_int = hscalar_tt_sl_m_600_w_150p0.add_process(
+    name="hscalar_tt_sl_m_600_w_150p0_int",
+    label=rf"{hscalar_tt_sl_m_600_w_150p0.label}, int",
+    id=70112,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hscalar_tt_sl_m_800_w_200p0 = hscalar_tt_sl.add_process(
+    name="hscalar_tt_sl_m_800_w_200p0",
+    label=rf"{hscalar_tt_sl.label} ($m = 800$ GeV, $\Gamma/m = 25\%$)",
+    id=70113,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hscalar_tt_sl_m_800_w_200p0_res = hscalar_tt_sl_m_800_w_200p0.add_process(
+    name="hscalar_tt_sl_m_800_w_200p0_res",
+    label=rf"{hscalar_tt_sl_m_800_w_200p0.label}, res",
+    id=70114,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hscalar_tt_sl_m_800_w_200p0_int = hscalar_tt_sl_m_800_w_200p0.add_process(
+    name="hscalar_tt_sl_m_800_w_200p0_int",
+    label=rf"{hscalar_tt_sl_m_800_w_200p0.label}, int",
+    id=70115,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hscalar_tt_sl_m_1000_w_250p0 = hscalar_tt_sl.add_process(
+    name="hscalar_tt_sl_m_1000_w_250p0",
+    label=rf"{hscalar_tt_sl.label} ($m = 1000$ GeV, $\Gamma/m = 25\%$)",
+    id=70116,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hscalar_tt_sl_m_1000_w_250p0_res = hscalar_tt_sl_m_1000_w_250p0.add_process(
+    name="hscalar_tt_sl_m_1000_w_250p0_res",
+    label=rf"{hscalar_tt_sl_m_1000_w_250p0.label}, res",
+    id=70117,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hscalar_tt_sl_m_1000_w_250p0_int = hscalar_tt_sl_m_1000_w_250p0.add_process(
+    name="hscalar_tt_sl_m_1000_w_250p0_int",
+    label=rf"{hscalar_tt_sl_m_1000_w_250p0.label}, int",
+    id=70118,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+# width / mass = 10%
+
+hscalar_tt_sl_m_365_w_36p5 = hscalar_tt_sl.add_process(
+    name="hscalar_tt_sl_m_365_w_36p5",
+    label=rf"{hscalar_tt_sl.label} ($m = 365$ GeV, $\Gamma/m = 10\%$)",
+    id=70119,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hscalar_tt_sl_m_365_w_36p5_res = hscalar_tt_sl_m_365_w_36p5.add_process(
+    name="hscalar_tt_sl_m_365_w_36p5_res",
+    label=rf"{hscalar_tt_sl_m_365_w_36p5.label}, res",
+    id=70120,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hscalar_tt_sl_m_365_w_36p5_int = hscalar_tt_sl_m_365_w_36p5.add_process(
+    name="hscalar_tt_sl_m_365_w_36p5_int",
+    label=rf"{hscalar_tt_sl_m_365_w_36p5.label}, int",
+    id=70121,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hscalar_tt_sl_m_400_w_40p0 = hscalar_tt_sl.add_process(
+    name="hscalar_tt_sl_m_400_w_40p0",
+    label=rf"{hscalar_tt_sl.label} ($m = 400$ GeV, $\Gamma/m = 10\%$)",
+    id=70122,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hscalar_tt_sl_m_400_w_40p0_res = hscalar_tt_sl_m_400_w_40p0.add_process(
+    name="hscalar_tt_sl_m_400_w_40p0_res",
+    label=rf"{hscalar_tt_sl_m_400_w_40p0.label}, res",
+    id=70123,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hscalar_tt_sl_m_400_w_40p0_int = hscalar_tt_sl_m_400_w_40p0.add_process(
+    name="hscalar_tt_sl_m_400_w_40p0_int",
+    label=rf"{hscalar_tt_sl_m_400_w_40p0.label}, int",
+    id=70124,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hscalar_tt_sl_m_500_w_50p0 = hscalar_tt_sl.add_process(
+    name="hscalar_tt_sl_m_500_w_50p0",
+    label=rf"{hscalar_tt_sl.label} ($m = 500$ GeV, $\Gamma/m = 10\%$)",
+    id=70125,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hscalar_tt_sl_m_500_w_50p0_res = hscalar_tt_sl_m_500_w_50p0.add_process(
+    name="hscalar_tt_sl_m_500_w_50p0_res",
+    label=rf"{hscalar_tt_sl_m_500_w_50p0.label}, res",
+    id=70126,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hscalar_tt_sl_m_500_w_50p0_int = hscalar_tt_sl_m_500_w_50p0.add_process(
+    name="hscalar_tt_sl_m_500_w_50p0_int",
+    label=rf"{hscalar_tt_sl_m_500_w_50p0.label}, int",
+    id=70127,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+# width / mass = 10%
+
+hscalar_tt_sl_m_600_w_60p0 = hscalar_tt_sl.add_process(
+    name="hscalar_tt_sl_m_600_w_60p0",
+    label=rf"{hscalar_tt_sl.label} ($m = 600$ GeV, $\Gamma/m = 10\%$)",
+    id=70128,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hscalar_tt_sl_m_600_w_60p0_res = hscalar_tt_sl_m_600_w_60p0.add_process(
+    name="hscalar_tt_sl_m_600_w_60p0_res",
+    label=rf"{hscalar_tt_sl_m_600_w_60p0.label}, res",
+    id=70129,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hscalar_tt_sl_m_600_w_60p0_int = hscalar_tt_sl_m_600_w_60p0.add_process(
+    name="hscalar_tt_sl_m_600_w_60p0_int",
+    label=rf"{hscalar_tt_sl_m_600_w_60p0.label}, int",
+    id=70130,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hscalar_tt_sl_m_800_w_80p0 = hscalar_tt_sl.add_process(
+    name="hscalar_tt_sl_m_800_w_80p0",
+    label=rf"{hscalar_tt_sl.label} ($m = 800$ GeV, $\Gamma/m = 10\%$)",
+    id=70131,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hscalar_tt_sl_m_800_w_80p0_res = hscalar_tt_sl_m_800_w_80p0.add_process(
+    name="hscalar_tt_sl_m_800_w_80p0_res",
+    label=rf"{hscalar_tt_sl_m_800_w_80p0.label}, res",
+    id=70132,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hscalar_tt_sl_m_800_w_80p0_int = hscalar_tt_sl_m_800_w_80p0.add_process(
+    name="hscalar_tt_sl_m_800_w_80p0_int",
+    label=rf"{hscalar_tt_sl_m_800_w_80p0.label}, int",
+    id=70133,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hscalar_tt_sl_m_1000_w_100p0 = hscalar_tt_sl.add_process(
+    name="hscalar_tt_sl_m_1000_w_100p0",
+    label=rf"{hscalar_tt_sl.label} ($m = 1000$ GeV, $\Gamma/m = 10\%$)",
+    id=70134,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hscalar_tt_sl_m_1000_w_100p0_res = hscalar_tt_sl_m_1000_w_100p0.add_process(
+    name="hscalar_tt_sl_m_1000_w_100p0_res",
+    label=rf"{hscalar_tt_sl_m_1000_w_100p0.label}, res",
+    id=70135,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hscalar_tt_sl_m_1000_w_100p0_int = hscalar_tt_sl_m_1000_w_100p0.add_process(
+    name="hscalar_tt_sl_m_1000_w_100p0_int",
+    label=rf"{hscalar_tt_sl_m_1000_w_100p0.label}, int",
+    id=70136,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+# width / mass = 2.5%
+
+hscalar_tt_sl_m_365_w_9p125 = hscalar_tt_sl.add_process(
+    name="hscalar_tt_sl_m_365_w_9p125",
+    label=rf"{hscalar_tt_sl.label} ($m = 365$ GeV, $\Gamma/m = 2\%$)",
+    id=70137,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hscalar_tt_sl_m_365_w_9p125_res = hscalar_tt_sl_m_365_w_9p125.add_process(
+    name="hscalar_tt_sl_m_365_w_9p125_res",
+    label=rf"{hscalar_tt_sl_m_365_w_9p125.label}, res",
+    id=70138,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hscalar_tt_sl_m_365_w_9p125_int = hscalar_tt_sl_m_365_w_9p125.add_process(
+    name="hscalar_tt_sl_m_365_w_9p125_int",
+    label=rf"{hscalar_tt_sl_m_365_w_9p125.label}, int",
+    id=70139,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hscalar_tt_sl_m_400_w_10p0 = hscalar_tt_sl.add_process(
+    name="hscalar_tt_sl_m_400_w_10p0",
+    label=rf"{hscalar_tt_sl.label} ($m = 400$ GeV, $\Gamma/m = 2\%$)",
+    id=70140,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hscalar_tt_sl_m_400_w_10p0_res = hscalar_tt_sl_m_400_w_10p0.add_process(
+    name="hscalar_tt_sl_m_400_w_10p0_res",
+    label=rf"{hscalar_tt_sl_m_400_w_10p0.label}, res",
+    id=70141,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hscalar_tt_sl_m_400_w_10p0_int = hscalar_tt_sl_m_400_w_10p0.add_process(
+    name="hscalar_tt_sl_m_400_w_10p0_int",
+    label=rf"{hscalar_tt_sl_m_400_w_10p0.label}, int",
+    id=70142,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hscalar_tt_sl_m_500_w_12p5 = hscalar_tt_sl.add_process(
+    name="hscalar_tt_sl_m_500_w_12p5",
+    label=rf"{hscalar_tt_sl.label} ($m = 500$ GeV, $\Gamma/m = 2\%$)",
+    id=70143,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hscalar_tt_sl_m_500_w_12p5_res = hscalar_tt_sl_m_500_w_12p5.add_process(
+    name="hscalar_tt_sl_m_500_w_12p5_res",
+    label=rf"{hscalar_tt_sl_m_500_w_12p5.label}, res",
+    id=70144,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hscalar_tt_sl_m_500_w_12p5_int = hscalar_tt_sl_m_500_w_12p5.add_process(
+    name="hscalar_tt_sl_m_500_w_12p5_int",
+    label=rf"{hscalar_tt_sl_m_500_w_12p5.label}, int",
+    id=70145,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+# width / mass = 2.5%
+
+hscalar_tt_sl_m_600_w_15p0 = hscalar_tt_sl.add_process(
+    name="hscalar_tt_sl_m_600_w_15p0",
+    label=rf"{hscalar_tt_sl.label} ($m = 600$ GeV, $\Gamma/m = 2\%$)",
+    id=70146,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hscalar_tt_sl_m_600_w_15p0_res = hscalar_tt_sl_m_600_w_15p0.add_process(
+    name="hscalar_tt_sl_m_600_w_15p0_res",
+    label=rf"{hscalar_tt_sl_m_600_w_15p0.label}, res",
+    id=70147,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hscalar_tt_sl_m_600_w_15p0_int = hscalar_tt_sl_m_600_w_15p0.add_process(
+    name="hscalar_tt_sl_m_600_w_15p0_int",
+    label=rf"{hscalar_tt_sl_m_600_w_15p0.label}, int",
+    id=70148,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hscalar_tt_sl_m_800_w_20p0 = hscalar_tt_sl.add_process(
+    name="hscalar_tt_sl_m_800_w_20p0",
+    label=rf"{hscalar_tt_sl.label} ($m = 800$ GeV, $\Gamma/m = 2\%$)",
+    id=70149,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hscalar_tt_sl_m_800_w_20p0_res = hscalar_tt_sl_m_800_w_20p0.add_process(
+    name="hscalar_tt_sl_m_800_w_20p0_res",
+    label=rf"{hscalar_tt_sl_m_800_w_20p0.label}, res",
+    id=70150,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hscalar_tt_sl_m_800_w_20p0_int = hscalar_tt_sl_m_800_w_20p0.add_process(
+    name="hscalar_tt_sl_m_800_w_20p0_int",
+    label=rf"{hscalar_tt_sl_m_800_w_20p0.label}, int",
+    id=70151,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hscalar_tt_sl_m_1000_w_25p0 = hscalar_tt_sl.add_process(
+    name="hscalar_tt_sl_m_1000_w_25p0",
+    label=rf"{hscalar_tt_sl.label} ($m = 1000$ GeV, $\Gamma/m = 2\%$)",
+    id=70152,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hscalar_tt_sl_m_1000_w_25p0_res = hscalar_tt_sl_m_1000_w_25p0.add_process(
+    name="hscalar_tt_sl_m_1000_w_25p0_res",
+    label=rf"{hscalar_tt_sl_m_1000_w_25p0.label}, res",
+    id=70153,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hscalar_tt_sl_m_1000_w_25p0_int = hscalar_tt_sl_m_1000_w_25p0.add_process(
+    name="hscalar_tt_sl_m_1000_w_25p0_int",
+    label=rf"{hscalar_tt_sl_m_1000_w_25p0.label}, int",
+    id=70154,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+#
+# Pseudoscalar heavy Higgs
+#
+
+hpseudo_tt = Process(
+    name="hpseudo_tt",
+    label=r"A $\rightarrow t\bar{t}$",
+    id=71000,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hpseudo_tt_sl = hpseudo_tt.add_process(
+    name="hpseudo_tt_sl",
+    label=rf"{hpseudo_tt.label} $\rightarrow \ell\nu + \mathrm{{jets}}$",
+    id=71100,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+# width / mass = 25%
+
+hpseudo_tt_sl_m_365_w_91p25 = hpseudo_tt_sl.add_process(
+    name="hpseudo_tt_sl_m_365_w_91p25",
+    label=rf"{hpseudo_tt_sl.label} ($m = 365$ GeV, $\Gamma/m = 25\%$)",
+    id=71101,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hpseudo_tt_sl_m_365_w_91p25_res = hpseudo_tt_sl_m_365_w_91p25.add_process(
+    name="hpseudo_tt_sl_m_365_w_91p25_res",
+    label=rf"{hpseudo_tt_sl_m_365_w_91p25.label}, res",
+    id=71102,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hpseudo_tt_sl_m_365_w_91p25_int = hpseudo_tt_sl_m_365_w_91p25.add_process(
+    name="hpseudo_tt_sl_m_365_w_91p25_int",
+    label=rf"{hpseudo_tt_sl_m_365_w_91p25.label}, int",
+    id=71103,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hpseudo_tt_sl_m_400_w_100p0 = hpseudo_tt_sl.add_process(
+    name="hpseudo_tt_sl_m_400_w_100p0",
+    label=rf"{hpseudo_tt_sl.label} ($m = 400$ GeV, $\Gamma/m = 25\%$)",
+    id=71104,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hpseudo_tt_sl_m_400_w_100p0_res = hpseudo_tt_sl_m_400_w_100p0.add_process(
+    name="hpseudo_tt_sl_m_400_w_100p0_res",
+    label=rf"{hpseudo_tt_sl_m_400_w_100p0.label}, res",
+    id=71105,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hpseudo_tt_sl_m_400_w_100p0_int = hpseudo_tt_sl_m_400_w_100p0.add_process(
+    name="hpseudo_tt_sl_m_400_w_100p0_int",
+    label=rf"{hpseudo_tt_sl_m_400_w_100p0.label}, int",
+    id=71106,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hpseudo_tt_sl_m_500_w_125p0 = hpseudo_tt_sl.add_process(
+    name="hpseudo_tt_sl_m_500_w_125p0",
+    label=rf"{hpseudo_tt_sl.label} ($m = 500$ GeV, $\Gamma/m = 25\%$)",
+    id=71107,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hpseudo_tt_sl_m_500_w_125p0_res = hpseudo_tt_sl_m_500_w_125p0.add_process(
+    name="hpseudo_tt_sl_m_500_w_125p0_res",
+    label=rf"{hpseudo_tt_sl_m_500_w_125p0.label}, res",
+    id=71108,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hpseudo_tt_sl_m_500_w_125p0_int = hpseudo_tt_sl_m_500_w_125p0.add_process(
+    name="hpseudo_tt_sl_m_500_w_125p0_int",
+    label=rf"{hpseudo_tt_sl_m_500_w_125p0.label}, int",
+    id=71109,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+# width / mass = 25%
+
+hpseudo_tt_sl_m_600_w_150p0 = hpseudo_tt_sl.add_process(
+    name="hpseudo_tt_sl_m_600_w_150p0",
+    label=rf"{hpseudo_tt_sl.label} ($m = 600$ GeV, $\Gamma/m = 25\%$)",
+    id=71110,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hpseudo_tt_sl_m_600_w_150p0_res = hpseudo_tt_sl_m_600_w_150p0.add_process(
+    name="hpseudo_tt_sl_m_600_w_150p0_res",
+    label=rf"{hpseudo_tt_sl_m_600_w_150p0.label}, res",
+    id=71111,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hpseudo_tt_sl_m_600_w_150p0_int = hpseudo_tt_sl_m_600_w_150p0.add_process(
+    name="hpseudo_tt_sl_m_600_w_150p0_int",
+    label=rf"{hpseudo_tt_sl_m_600_w_150p0.label}, int",
+    id=71112,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hpseudo_tt_sl_m_800_w_200p0 = hpseudo_tt_sl.add_process(
+    name="hpseudo_tt_sl_m_800_w_200p0",
+    label=rf"{hpseudo_tt_sl.label} ($m = 800$ GeV, $\Gamma/m = 25\%$)",
+    id=71113,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hpseudo_tt_sl_m_800_w_200p0_res = hpseudo_tt_sl_m_800_w_200p0.add_process(
+    name="hpseudo_tt_sl_m_800_w_200p0_res",
+    label=rf"{hpseudo_tt_sl_m_800_w_200p0.label}, res",
+    id=71114,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hpseudo_tt_sl_m_800_w_200p0_int = hpseudo_tt_sl_m_800_w_200p0.add_process(
+    name="hpseudo_tt_sl_m_800_w_200p0_int",
+    label=rf"{hpseudo_tt_sl_m_800_w_200p0.label}, int",
+    id=71115,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hpseudo_tt_sl_m_1000_w_250p0 = hpseudo_tt_sl.add_process(
+    name="hpseudo_tt_sl_m_1000_w_250p0",
+    label=rf"{hpseudo_tt_sl.label} ($m = 1000$ GeV, $\Gamma/m = 25\%$)",
+    id=71116,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hpseudo_tt_sl_m_1000_w_250p0_res = hpseudo_tt_sl_m_1000_w_250p0.add_process(
+    name="hpseudo_tt_sl_m_1000_w_250p0_res",
+    label=rf"{hpseudo_tt_sl_m_1000_w_250p0.label}, res",
+    id=71117,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hpseudo_tt_sl_m_1000_w_250p0_int = hpseudo_tt_sl_m_1000_w_250p0.add_process(
+    name="hpseudo_tt_sl_m_1000_w_250p0_int",
+    label=rf"{hpseudo_tt_sl_m_1000_w_250p0.label}, int",
+    id=71118,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+# width / mass = 10%
+
+hpseudo_tt_sl_m_365_w_36p5 = hpseudo_tt_sl.add_process(
+    name="hpseudo_tt_sl_m_365_w_36p5",
+    label=rf"{hpseudo_tt_sl.label} ($m = 365$ GeV, $\Gamma/m = 10\%$)",
+    id=71119,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hpseudo_tt_sl_m_365_w_36p5_res = hpseudo_tt_sl_m_365_w_36p5.add_process(
+    name="hpseudo_tt_sl_m_365_w_36p5_res",
+    label=rf"{hpseudo_tt_sl_m_365_w_36p5.label}, res",
+    id=71120,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hpseudo_tt_sl_m_365_w_36p5_int = hpseudo_tt_sl_m_365_w_36p5.add_process(
+    name="hpseudo_tt_sl_m_365_w_36p5_int",
+    label=rf"{hpseudo_tt_sl_m_365_w_36p5.label}, int",
+    id=71121,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hpseudo_tt_sl_m_400_w_40p0 = hpseudo_tt_sl.add_process(
+    name="hpseudo_tt_sl_m_400_w_40p0",
+    label=rf"{hpseudo_tt_sl.label} ($m = 400$ GeV, $\Gamma/m = 10\%$)",
+    id=71122,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hpseudo_tt_sl_m_400_w_40p0_res = hpseudo_tt_sl_m_400_w_40p0.add_process(
+    name="hpseudo_tt_sl_m_400_w_40p0_res",
+    label=rf"{hpseudo_tt_sl_m_400_w_40p0.label}, res",
+    id=71123,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hpseudo_tt_sl_m_400_w_40p0_int = hpseudo_tt_sl_m_400_w_40p0.add_process(
+    name="hpseudo_tt_sl_m_400_w_40p0_int",
+    label=rf"{hpseudo_tt_sl_m_400_w_40p0.label}, int",
+    id=71124,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hpseudo_tt_sl_m_500_w_50p0 = hpseudo_tt_sl.add_process(
+    name="hpseudo_tt_sl_m_500_w_50p0",
+    label=rf"{hpseudo_tt_sl.label} ($m = 500$ GeV, $\Gamma/m = 10\%$)",
+    id=71125,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hpseudo_tt_sl_m_500_w_50p0_res = hpseudo_tt_sl_m_500_w_50p0.add_process(
+    name="hpseudo_tt_sl_m_500_w_50p0_res",
+    label=rf"{hpseudo_tt_sl_m_500_w_50p0.label}, res",
+    id=71126,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hpseudo_tt_sl_m_500_w_50p0_int = hpseudo_tt_sl_m_500_w_50p0.add_process(
+    name="hpseudo_tt_sl_m_500_w_50p0_int",
+    label=rf"{hpseudo_tt_sl_m_500_w_50p0.label}, int",
+    id=71127,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+# width / mass = 10%
+
+hpseudo_tt_sl_m_600_w_60p0 = hpseudo_tt_sl.add_process(
+    name="hpseudo_tt_sl_m_600_w_60p0",
+    label=rf"{hpseudo_tt_sl.label} ($m = 600$ GeV, $\Gamma/m = 10\%$)",
+    id=71128,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hpseudo_tt_sl_m_600_w_60p0_res = hpseudo_tt_sl_m_600_w_60p0.add_process(
+    name="hpseudo_tt_sl_m_600_w_60p0_res",
+    label=rf"{hpseudo_tt_sl_m_600_w_60p0.label}, res",
+    id=71129,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hpseudo_tt_sl_m_600_w_60p0_int = hpseudo_tt_sl_m_600_w_60p0.add_process(
+    name="hpseudo_tt_sl_m_600_w_60p0_int",
+    label=rf"{hpseudo_tt_sl_m_600_w_60p0.label}, int",
+    id=71130,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hpseudo_tt_sl_m_800_w_80p0 = hpseudo_tt_sl.add_process(
+    name="hpseudo_tt_sl_m_800_w_80p0",
+    label=rf"{hpseudo_tt_sl.label} ($m = 800$ GeV, $\Gamma/m = 10\%$)",
+    id=71131,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hpseudo_tt_sl_m_800_w_80p0_res = hpseudo_tt_sl_m_800_w_80p0.add_process(
+    name="hpseudo_tt_sl_m_800_w_80p0_res",
+    label=rf"{hpseudo_tt_sl_m_800_w_80p0.label}, res",
+    id=71132,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hpseudo_tt_sl_m_800_w_80p0_int = hpseudo_tt_sl_m_800_w_80p0.add_process(
+    name="hpseudo_tt_sl_m_800_w_80p0_int",
+    label=rf"{hpseudo_tt_sl_m_800_w_80p0.label}, int",
+    id=71133,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hpseudo_tt_sl_m_1000_w_100p0 = hpseudo_tt_sl.add_process(
+    name="hpseudo_tt_sl_m_1000_w_100p0",
+    label=rf"{hpseudo_tt_sl.label} ($m = 1000$ GeV, $\Gamma/m = 10\%$)",
+    id=71134,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hpseudo_tt_sl_m_1000_w_100p0_res = hpseudo_tt_sl_m_1000_w_100p0.add_process(
+    name="hpseudo_tt_sl_m_1000_w_100p0_res",
+    label=rf"{hpseudo_tt_sl_m_1000_w_100p0.label}, res",
+    id=71135,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hpseudo_tt_sl_m_1000_w_100p0_int = hpseudo_tt_sl_m_1000_w_100p0.add_process(
+    name="hpseudo_tt_sl_m_1000_w_100p0_int",
+    label=rf"{hpseudo_tt_sl_m_1000_w_100p0.label}, int",
+    id=71136,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+# width / mass = 2.5%
+
+hpseudo_tt_sl_m_365_w_9p125 = hpseudo_tt_sl.add_process(
+    name="hpseudo_tt_sl_m_365_w_9p125",
+    label=rf"{hpseudo_tt_sl.label} ($m = 365$ GeV, $\Gamma/m = 2\%$)",
+    id=71137,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hpseudo_tt_sl_m_365_w_9p125_res = hpseudo_tt_sl_m_365_w_9p125.add_process(
+    name="hpseudo_tt_sl_m_365_w_9p125_res",
+    label=rf"{hpseudo_tt_sl_m_365_w_9p125.label}, res",
+    id=71138,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hpseudo_tt_sl_m_365_w_9p125_int = hpseudo_tt_sl_m_365_w_9p125.add_process(
+    name="hpseudo_tt_sl_m_365_w_9p125_int",
+    label=rf"{hpseudo_tt_sl_m_365_w_9p125.label}, int",
+    id=71139,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hpseudo_tt_sl_m_400_w_10p0 = hpseudo_tt_sl.add_process(
+    name="hpseudo_tt_sl_m_400_w_10p0",
+    label=rf"{hpseudo_tt_sl.label} ($m = 400$ GeV, $\Gamma/m = 2\%$)",
+    id=71140,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hpseudo_tt_sl_m_400_w_10p0_res = hpseudo_tt_sl_m_400_w_10p0.add_process(
+    name="hpseudo_tt_sl_m_400_w_10p0_res",
+    label=rf"{hpseudo_tt_sl_m_400_w_10p0.label}, res",
+    id=71141,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hpseudo_tt_sl_m_400_w_10p0_int = hpseudo_tt_sl_m_400_w_10p0.add_process(
+    name="hpseudo_tt_sl_m_400_w_10p0_int",
+    label=rf"{hpseudo_tt_sl_m_400_w_10p0.label}, int",
+    id=71142,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hpseudo_tt_sl_m_500_w_12p5 = hpseudo_tt_sl.add_process(
+    name="hpseudo_tt_sl_m_500_w_12p5",
+    label=rf"{hpseudo_tt_sl.label} ($m = 500$ GeV, $\Gamma/m = 2\%$)",
+    id=71143,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hpseudo_tt_sl_m_500_w_12p5_res = hpseudo_tt_sl_m_500_w_12p5.add_process(
+    name="hpseudo_tt_sl_m_500_w_12p5_res",
+    label=rf"{hpseudo_tt_sl_m_500_w_12p5.label}, res",
+    id=71144,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hpseudo_tt_sl_m_500_w_12p5_int = hpseudo_tt_sl_m_500_w_12p5.add_process(
+    name="hpseudo_tt_sl_m_500_w_12p5_int",
+    label=rf"{hpseudo_tt_sl_m_500_w_12p5.label}, int",
+    id=71145,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+# width / mass = 2.5%
+
+hpseudo_tt_sl_m_600_w_15p0 = hpseudo_tt_sl.add_process(
+    name="hpseudo_tt_sl_m_600_w_15p0",
+    label=rf"{hpseudo_tt_sl.label} ($m = 600$ GeV, $\Gamma/m = 2\%$)",
+    id=71146,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hpseudo_tt_sl_m_600_w_15p0_res = hpseudo_tt_sl_m_600_w_15p0.add_process(
+    name="hpseudo_tt_sl_m_600_w_15p0_res",
+    label=rf"{hpseudo_tt_sl_m_600_w_15p0.label}, res",
+    id=71147,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hpseudo_tt_sl_m_600_w_15p0_int = hpseudo_tt_sl_m_600_w_15p0.add_process(
+    name="hpseudo_tt_sl_m_600_w_15p0_int",
+    label=rf"{hpseudo_tt_sl_m_600_w_15p0.label}, int",
+    id=71148,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hpseudo_tt_sl_m_800_w_20p0 = hpseudo_tt_sl.add_process(
+    name="hpseudo_tt_sl_m_800_w_20p0",
+    label=rf"{hpseudo_tt_sl.label} ($m = 800$ GeV, $\Gamma/m = 2\%$)",
+    id=71149,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hpseudo_tt_sl_m_800_w_20p0_res = hpseudo_tt_sl_m_800_w_20p0.add_process(
+    name="hpseudo_tt_sl_m_800_w_20p0_res",
+    label=rf"{hpseudo_tt_sl_m_800_w_20p0.label}, res",
+    id=71150,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hpseudo_tt_sl_m_800_w_20p0_int = hpseudo_tt_sl_m_800_w_20p0.add_process(
+    name="hpseudo_tt_sl_m_800_w_20p0_int",
+    label=rf"{hpseudo_tt_sl_m_800_w_20p0.label}, int",
+    id=71151,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hpseudo_tt_sl_m_1000_w_25p0 = hpseudo_tt_sl.add_process(
+    name="hpseudo_tt_sl_m_1000_w_25p0",
+    label=rf"{hpseudo_tt_sl.label} ($m = 1000$ GeV, $\Gamma/m = 2\%$)",
+    id=71152,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hpseudo_tt_sl_m_1000_w_25p0_res = hpseudo_tt_sl_m_1000_w_25p0.add_process(
+    name="hpseudo_tt_sl_m_1000_w_25p0_res",
+    label=rf"{hpseudo_tt_sl_m_1000_w_25p0.label}, res",
+    id=71153,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+hpseudo_tt_sl_m_1000_w_25p0_int = hpseudo_tt_sl_m_1000_w_25p0.add_process(
+    name="hpseudo_tt_sl_m_1000_w_25p0_int",
+    label=rf"{hpseudo_tt_sl_m_1000_w_25p0.label}, int",
+    id=71154,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+#
+# Kaluza-Klein gluon
+#
+
+rsgluon_tt = Process(
+    name="rsgluon_tt",
+    label=r"$g_\mathrm{KK}$",
+    id=80000,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+rsgluon_tt_m_500 = rsgluon_tt.add_process(
+    name="rsgluon_tt_m_500",
+    label=rf"{rsgluon_tt.label} ($m = 500$ GeV)",
+    id=80001,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+rsgluon_tt_m_1000 = rsgluon_tt.add_process(
+    name="rsgluon_tt_m_1000",
+    label=rf"{rsgluon_tt.label} ($m = 1000$ GeV)",
+    id=80002,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+rsgluon_tt_m_1500 = rsgluon_tt.add_process(
+    name="rsgluon_tt_m_1500",
+    label=rf"{rsgluon_tt.label} ($m = 1500$ GeV)",
+    id=80003,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+rsgluon_tt_m_2000 = rsgluon_tt.add_process(
+    name="rsgluon_tt_m_2000",
+    label=rf"{rsgluon_tt.label} ($m = 2000$ GeV)",
+    id=80004,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+rsgluon_tt_m_2500 = rsgluon_tt.add_process(
+    name="rsgluon_tt_m_2500",
+    label=rf"{rsgluon_tt.label} ($m = 2500$ GeV)",
+    id=80005,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+rsgluon_tt_m_3000 = rsgluon_tt.add_process(
+    name="rsgluon_tt_m_3000",
+    label=rf"{rsgluon_tt.label} ($m = 3000$ GeV)",
+    id=80006,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+rsgluon_tt_m_3500 = rsgluon_tt.add_process(
+    name="rsgluon_tt_m_3500",
+    label=rf"{rsgluon_tt.label} ($m = 3500$ GeV)",
+    id=80007,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+rsgluon_tt_m_4000 = rsgluon_tt.add_process(
+    name="rsgluon_tt_m_4000",
+    label=rf"{rsgluon_tt.label} ($m = 4000$ GeV)",
+    id=80008,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+rsgluon_tt_m_4500 = rsgluon_tt.add_process(
+    name="rsgluon_tt_m_4500",
+    label=rf"{rsgluon_tt.label} ($m = 4500$ GeV)",
+    id=80009,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+rsgluon_tt_m_5000 = rsgluon_tt.add_process(
+    name="rsgluon_tt_m_5000",
+    label=rf"{rsgluon_tt.label} ($m = 5000$ GeV)",
+    id=80010,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+rsgluon_tt_m_5500 = rsgluon_tt.add_process(
+    name="rsgluon_tt_m_5500",
+    label=rf"{rsgluon_tt.label} ($m = 5500$ GeV)",
+    id=80011,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+rsgluon_tt_m_6000 = rsgluon_tt.add_process(
+    name="rsgluon_tt_m_6000",
+    label=rf"{rsgluon_tt.label} ($m = 6000$ GeV)",
+    id=80012,
+    xsecs={13: Number(0.1)},  # TODO
+)

--- a/cmsdb/processes/qcd.py
+++ b/cmsdb/processes/qcd.py
@@ -28,53 +28,53 @@ qcd = Process(
 qcd_ht50to100 = qcd.add_process(
     name="qcd_ht50to100",
     id=31001,
-    xsecs={13: Number(0.1)},  # TODO
+    xsecs={13: Number(185900000)},  # AN-19-197_v3
 )
 
 qcd_ht100to200 = qcd.add_process(
     name="qcd_ht100to200",
     id=31002,
-    xsecs={13: Number(0.1)},  # TODO
+    xsecs={13: Number(23610000)},  # AN-19-197_v3
 )
 
 qcd_ht200to300 = qcd.add_process(
     name="qcd_ht200to300",
     id=31003,
-    xsecs={13: Number(0.1)},  # TODO
+    xsecs={13: Number(1551000)},  # AN-19-197_v3
 )
 
 qcd_ht300to500 = qcd.add_process(
     name="qcd_ht300to500",
     id=31004,
-    xsecs={13: Number(0.1)},  # TODO
+    xsecs={13: Number(324300)},  # AN-19-197_v3
 )
 
 qcd_ht500to700 = qcd.add_process(
     name="qcd_ht500to700",
     id=31005,
-    xsecs={13: Number(0.1)},  # TODO
+    xsecs={13: Number(30340)},  # AN-19-197_v3
 )
 
 qcd_ht700to1000 = qcd.add_process(
     name="qcd_ht700to1000",
     id=31006,
-    xsecs={13: Number(0.1)},  # TODO
+    xsecs={13: Number(6440)},  # AN-19-197_v3
 )
 
 qcd_ht1000to1500 = qcd.add_process(
     name="qcd_ht1000to1500",
     id=31007,
-    xsecs={13: Number(0.1)},  # TODO
+    xsecs={13: Number(1118)},  # AN-19-197_v3
 )
 
 qcd_ht1500to2000 = qcd.add_process(
     name="qcd_ht1500to2000",
     id=31008,
-    xsecs={13: Number(0.1)},  # TODO
+    xsecs={13: Number(108)},  # AN-19-197_v3
 )
 
 qcd_ht2000 = qcd.add_process(
     name="qcd_ht2000",
     id=31090,
-    xsecs={13: Number(0.1)},  # TODO
+    xsecs={13: Number(22)},  # AN-19-197_v3
 )


### PR DESCRIPTION
This PR adds some of the samples needed for the m(ttbar) line search analysis that we are looking to implement with `columnflow`. This includes signal samples for heavy resonances decaying to ttbar (Z prime, heavy Higgs and Kaluza-Klein gluons) and the `SinglePhoton` data sample. Only 2017 UL samples are added for now.

For the new processes I used IDs in the 60000s (Z prime), 70000s (heavy Higgs) and 80000s (KK gluons), since we do not yet have a planned process ID scheme [#1]. Please check for any interference with other groups' plans.

I've also filled in some missing cross section information for the di-boson and QCD processes based on the numbers given in the current analysis note ([AN-19-197_v3](http://cms.cern.ch/iCMS/jsp/openfile.jsp?tp=draft&files=AN2019_197_v3.pdf)).

