### PR TITLE
Add Run3 2022 NanoAOD v11 samples

### DIFF
--- a/cmsdb/campaigns/run3_2022_postEE_nano_v11/__init__.py
+++ b/cmsdb/campaigns/run3_2022_postEE_nano_v11/__init__.py
@@ -1,0 +1,35 @@
+# coding: utf-8
+
+"""
+Common, analysis independent definition of the 2022 post-EE data-taking campaign
+with datasets at NanoAOD tier in version 11.
+See https://python-order.readthedocs.io/en/latest/quickstart.html#analysis-campaign-and-config.
+
+Dataset ids are identical to those in DAS (https://cmsweb.cern.ch/das).
+"""
+
+from order import Campaign
+
+
+#
+# campaign
+#
+
+campaign_run3_2022_postEE_nano_v11 = Campaign(
+    name="run3_2022_postEE_nano_v11",
+    id=320221102,  # 3 2022 11 02(u)
+    ecm=13.6,
+    bx=25,
+    aux={
+        "tier": "NanoAOD",
+        "year": 2022,
+        "version": 11,
+    },
+)
+
+
+# trailing imports to load datasets
+import cmsdb.campaigns.run3_2022_postEE_nano_v11.data  # noqa
+import cmsdb.campaigns.run3_2022_postEE_nano_v11.top  # noqa
+import cmsdb.campaigns.run3_2022_postEE_nano_v11.ewk  # noqa
+import cmsdb.campaigns.run3_2022_postEE_nano_v11.qcd  # noqa

--- a/cmsdb/campaigns/run3_2022_postEE_nano_v11/data.py
+++ b/cmsdb/campaigns/run3_2022_postEE_nano_v11/data.py
@@ -1,0 +1,108 @@
+# coding: utf-8
+
+"""
+CMS datasets from the 2022 post-EE data-taking campaign
+"""
+
+import cmsdb.processes as procs
+from cmsdb.campaigns.run3_2022_postEE_nano_v11 import campaign_run3_2022_postEE_nano_v11 as cpn
+
+
+
+#
+# Muon
+#
+
+cpn.add_dataset(
+    name="data_mu_e",
+    id=14665058,
+    is_data=True,
+    processes=[procs.data_mu],
+    keys=[
+        "/Muon/Run2022E-ReRecoNanoAODv11-v1/NANOAOD",
+    ],
+    n_files=98,
+    n_events=142785268,
+    aux={
+        "era": "E",
+    },
+)
+
+cpn.add_dataset(
+    name="data_mu_f",
+    id=14578756,
+    is_data=True,
+    processes=[procs.data_mu],
+    keys=[
+        "/Muon/Run2022F-PromptNanoAODv11_v1-v2/NANOAOD",
+    ],
+    n_files=290,
+    n_events=449906805,
+    aux={
+        "era": "F",
+    },
+)
+
+cpn.add_dataset(
+    name="data_mu_g",
+    id=14578734,
+    is_data=True,
+    processes=[procs.data_mu],
+    keys=[
+        "/Muon/Run2022G-PromptNanoAODv11_v1-v2/NANOAOD",
+    ],
+    n_files=51,
+    n_events=76689396,
+    aux={
+        "era": "G",
+    },
+)
+
+#
+# E/Gamma
+#
+
+cpn.add_dataset(
+    name="data_egamma_e",
+    id=14670601,
+    is_data=True,
+    processes=[procs.data_egamma],
+    keys=[
+        "/EGamma/Run2022E-ReRecoNanoAODv11-v1/NANOAOD",
+    ],
+    n_files=99,
+    n_events=149463867,
+    aux={
+        "era": "E",
+    },
+)
+
+cpn.add_dataset(
+    name="data_egamma_f",
+    id=14579815,
+    is_data=True,
+    processes=[procs.data_egamma],
+    keys=[
+        "/EGamma/Run2022F-PromptNanoAODv11_v1-v2/NANOAOD",
+    ],
+    n_files=343,
+    n_events=464472966,
+    aux={
+        "era": "F",
+    },
+)
+
+cpn.add_dataset(
+    name="data_egamma_g",
+    id=14579488,
+    is_data=True,
+    processes=[procs.data_egamma],
+    keys=[
+        "/EGamma/Run2022G-PromptNanoAODv11_v1-v2/NANOAOD",
+    ],
+    n_files=60,
+    n_events=76828141,
+    aux={
+        "era": "G",
+    },
+)

--- a/cmsdb/campaigns/run3_2022_postEE_nano_v11/ewk.py
+++ b/cmsdb/campaigns/run3_2022_postEE_nano_v11/ewk.py
@@ -1,0 +1,130 @@
+# coding: utf-8
+
+"""
+Electroweak datasets for the 2022 post-EE data-taking campaign
+"""
+
+import cmsdb.processes as procs
+from cmsdb.campaigns.run3_2022_postEE_nano_v11 import campaign_run3_2022_postEE_nano_v11 as cpn
+
+
+#
+# Drell-Yan
+#
+
+# inclusive (MadGraph)
+# GrASP: https://cms-pdmv.cern.ch/grasp/samples?campaign=Run3Summer22EEwmLHEGS&dataset=DYJetsToLL_M-50&nanoaod_version=v11
+cpn.add_dataset(
+    name="dy_lep_m50_madgraph",
+    id=14679709,
+    is_data=False,
+    processes=[procs.dy_lep_m50],
+    keys=[
+        "/DYJetsToLL_M-50_TuneCP5_13p6TeV-madgraphMLM-pythia8/Run3Summer22EENanoAODv11-forPOG_126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+    ],
+    n_files=55,
+    n_events=96296977,
+)
+
+# inclusive (aMC@NLO)
+# GrASP: https://cms-pdmv.cern.ch/grasp/samples?campaign=Run3Summer22EEwmLHEGS&dataset=DYto2L-2Jets_MLL-50&nanoaod_version=v11
+cpn.add_dataset(
+    name="dy_lep_m50_amcatnlo",
+    id=14615268,
+    is_data=False,
+    processes=[procs.dy_lep_m50],
+    keys=[
+        "/DYto2L-2Jets_MLL-50_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+    ],
+    n_files=125,
+    n_events=215543566,
+)
+
+# MadGraph (n-jet binned)
+# GrASP: https://cms-pdmv.cern.ch/grasp/samples?campaign=Run3Summer22EEwmLHEGS&dataset=DYto2L-4
+# missing as of 2023-07-01
+
+# POWHEG (decay to muons, MLL-binned)
+# GrASP: https://cms-pdmv.cern.ch/grasp/samples?campaign=Run3Summer22EEwmLHEGS&dataset=DYto2Mu
+# DAS entries:
+#     /DYto2Mu_MLL-10to50_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v2/NANOAODSIM
+#     /DYto2Mu_MLL-50to120_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v2/NANOAODSIM
+#     /DYto2Mu_MLL-120to200_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v2/NANOAODSIM
+#     /DYto2Mu_MLL-200to400_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v2/NANOAODSIM
+#     /DYto2Mu_MLL-400to800_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v2/NANOAODSIM
+#     /DYto2Mu_MLL-800to1500_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v2/NANOAODSIM
+#     /DYto2Mu_MLL-1500to2500_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v2/NANOAODSIM
+#     /DYto2Mu_MLL-2500to4000_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v2/NANOAODSIM
+#     /DYto2Mu_MLL-4000to6000_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v2/NANOAODSIM
+#     /DYto2Mu_MLL-4000_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v2/NANOAODSIM
+
+# POWHEG (decay to electrons, MLL-binned)
+# GrASP: https://cms-pdmv.cern.ch/grasp/samples?campaign=Run3Summer22EEwmLHEGS&dataset=DYto2E_MLL
+# missing as of 2023-07-01
+
+
+#
+# W boson production
+#
+
+# inclusive (aMC@NLO)
+# GrASP: https://cms-pdmv.cern.ch/grasp/samples?campaign=Run3Summer22EEwmLHEGS&dataset=WtoLNu-2Jets&nanoaod_version=v11
+cpn.add_dataset(
+    name="w_lnu_amcatnlo",
+    id=14716346,
+    is_data=False,
+    processes=[procs.w_lnu],
+    keys=[
+        "/WtoLNu-2Jets_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+    ],
+    n_files=161,
+    n_events=291650146,
+)
+
+# MadGraph (n-jet binned)
+# GrASP: https://cms-pdmv.cern.ch/grasp/samples?campaign=Run3Summer22EEwmLHEGS&dataset=WtoLNu-4Jets_%281%7C2%7C3%7C4%29J&nanoaod_version=v11
+# missing as of 2023-07-01
+
+
+#
+# Diboson
+#
+
+# GrASP: https://cms-pdmv.cern.ch/grasp/samples?campaign=Run3Summer22EEGS&nanoaod_version=v11&short_name=VV
+
+# missing as of 2023-07-01
+# cpn.add_dataset(
+#     name="zz_pythia",
+#     id=None,
+#     is_data=False,
+#     processes=[procs.zz],
+#     keys=[
+#         "/ZZ_TuneCP5_13p6TeV_pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+#     ],
+#     n_files=None,
+#     n_events=None,
+# )
+
+cpn.add_dataset(
+    name="wz_pythia",
+    id=14597897,
+    is_data=False,
+    processes=[procs.wz],
+    keys=[
+        "/WZ_TuneCP5_13p6TeV_pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+    ],
+    n_files=18,
+    n_events=27291718,
+)
+
+cpn.add_dataset(
+    name="ww_pythia",
+    id=14596976,
+    is_data=False,
+    processes=[procs.ww],
+    keys=[
+        "/WW_TuneCP5_13p6TeV_pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+    ],
+    n_files=32,
+    n_events=54649280,
+)

--- a/cmsdb/campaigns/run3_2022_postEE_nano_v11/qcd.py
+++ b/cmsdb/campaigns/run3_2022_postEE_nano_v11/qcd.py
@@ -1,0 +1,397 @@
+# coding: utf-8
+
+"""
+QCD datasets for the 2022 post-EE data-taking campaign
+"""
+
+import cmsdb.processes as procs
+from cmsdb.campaigns.run3_2022_postEE_nano_v11 import campaign_run3_2022_postEE_nano_v11 as cpn
+
+
+#
+# QCD flat samples
+#
+
+# GrASP: https://cms-pdmv.cern.ch/grasp/samples?campaign=Run3Summer22EEGS&nanoaod_version=v11&dataset=QCD_PT-15*Flat2018&chained_request=Premix
+# missing as of 2023-07-01
+# cpn.add_dataset(
+#     name="qcd_flat2018_pythia",
+#     id=None,
+#     is_data=False,
+#     processes=[procs.qcd_flat],
+#     keys=[
+#         "/QCD_PT-15_TuneCP5_Flat2018_13p6TeV_pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v2/NANOAODSIM",
+#     ],
+#     n_files=None,
+#     n_events=None,
+# )
+
+# GrASP: https://cms-pdmv.cern.ch/grasp/samples?campaign=Run3Summer22EEGS&nanoaod_version=v11&dataset=QCD_PT-15*Flat2018&chained_request=EpsilonPU
+cpn.add_dataset(
+    name="qcd_flat2018_epsilonPU_pythia",
+    id=14685056,
+    is_data=False,
+    processes=[procs.qcd_flat],
+    keys=[
+        "/QCD_PT-15to7000_TuneCP5_Flat2018_13p6TeV_pythia8/Run3Summer22EENanoAODv11-EpsilonPU_126X_mcRun3_2022_realistic_postEE_v1-v2/NANOAODSIM",
+    ],
+    n_files=3,
+    n_events=499399,
+)
+
+
+#
+# QCD (MadGraph HT-binned)
+#
+
+# missing as of 2023-07-01
+
+
+#
+# QCD (Pythia pT-binned)
+#
+
+# GrASP: https://cms-pdmv.cern.ch/grasp/samples?campaign=Run3Summer22EEGS&nanoaod_version=v11&dataset=QCD_PT-*%28to*%29%3F0_TuneCP5&chained_request=Premix
+
+# missing as of 2023-07-01
+# cpn.add_dataset(
+#     name="qcd_pt15to30_pythia",
+#     id=None,
+#     is_data=False,
+#     processes=[procs.qcd_pt15to30],
+#     keys=[
+#         "/QCD_PT-15to30_TuneCP5_13p6TeV_pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+#     ],
+#     n_files=2,
+#     n_events=1149000,
+# )
+
+# missing as of 2023-07-01
+# cpn.add_dataset(
+#     name="qcd_pt30to50_pythia",
+#     id=None,
+#     is_data=False,
+#     processes=[procs.qcd_pt30to50],
+#     keys=[
+#         "/QCD_PT-30to50_TuneCP5_13p6TeV_pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+#     ],
+#     n_files=2,
+#     n_events=1189766,
+# )
+
+cpn.add_dataset(
+    name="qcd_pt50to80_pythia",
+    id=14693393,
+    is_data=False,
+    processes=[procs.qcd_pt50to80],
+    keys=[
+        "/QCD_PT-50to80_TuneCP5_13p6TeV_pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+    ],
+    n_files=12,
+    n_events=19940303,
+)
+
+cpn.add_dataset(
+    name="qcd_pt80to120_pythia",
+    id=14694837,
+    is_data=False,
+    processes=[procs.qcd_pt80to120],
+    keys=[
+        "/QCD_PT-80to120_TuneCP5_13p6TeV_pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+    ],
+    n_files=18,
+    n_events=29751976,
+)
+
+cpn.add_dataset(
+    name="qcd_pt120to170_pythia",
+    id=14693403,
+    is_data=False,
+    processes=[procs.qcd_pt120to170],
+    keys=[
+        "/QCD_PT-120to170_TuneCP5_13p6TeV_pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1_ext1-v1/NANOAODSIM",
+    ],
+    n_files=19,
+    n_events=26612745,
+)
+
+cpn.add_dataset(
+    name="qcd_pt170to300_pythia",
+    id=14694848,
+    is_data=False,
+    processes=[procs.qcd_pt170to300],
+    keys=[
+        "/QCD_PT-170to300_TuneCP5_13p6TeV_pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1_ext1-v1/NANOAODSIM",
+    ],
+    n_files=21,
+    n_events=27857315,
+)
+
+cpn.add_dataset(
+    name="qcd_pt300to470_pythia",
+    id=14646803,
+    is_data=False,
+    processes=[procs.qcd_pt300to470],
+    keys=[
+        "/QCD_PT-300to470_TuneCP5_13p6TeV_pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1_ext1-v1/NANOAODSIM",
+    ],
+    n_files=47,
+    n_events=55758810,
+)
+
+cpn.add_dataset(
+    name="qcd_pt470to600_pythia",
+    id=14650352,
+    is_data=False,
+    processes=[procs.qcd_pt470to600],
+    keys=[
+        "/QCD_PT-470to600_TuneCP5_13p6TeV_pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1_ext1-v1/NANOAODSIM",
+    ],
+    n_files=23,
+    n_events=26859708,
+)
+
+cpn.add_dataset(
+    name="qcd_pt600to800_pythia",
+    id=14694849,
+    is_data=False,
+    processes=[procs.qcd_pt600to800],
+    keys=[
+        "/QCD_PT-600to800_TuneCP5_13p6TeV_pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1_ext1-v1/NANOAODSIM",
+    ],
+    n_files=52,
+    n_events=62618820,
+)
+
+cpn.add_dataset(
+    name="qcd_pt800to1000_pythia",
+    id=14694802,
+    is_data=False,
+    processes=[procs.qcd_pt800to1000],
+    keys=[
+        "/QCD_PT-800to1000_TuneCP5_13p6TeV_pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1_ext1-v1/NANOAODSIM",
+    ],
+    n_files=32,
+    n_events=37290125,
+)
+
+cpn.add_dataset(
+    name="qcd_pt1000to1400_pythia",
+    id=14646103,
+    is_data=False,
+    processes=[procs.qcd_pt1000to1400],
+    keys=[
+        "/QCD_PT-1000to1400_TuneCP5_13p6TeV_pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1_ext1-v1/NANOAODSIM",
+    ],
+    n_files=20,
+    n_events=19351665,
+)
+
+cpn.add_dataset(
+    name="qcd_pt1400to1800_pythia",
+    id=14693445,
+    is_data=False,
+    processes=[procs.qcd_pt1400to1800],
+    keys=[
+        "/QCD_PT-1400to1800_TuneCP5_13p6TeV_pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1_ext1-v1/NANOAODSIM",
+    ],
+    n_files=6,
+    n_events=5471723,
+)
+
+cpn.add_dataset(
+    name="qcd_pt1800to2400_pythia",
+    id=14645373,
+    is_data=False,
+    processes=[procs.qcd_pt1800to2400],
+    keys=[
+        "/QCD_PT-1800to2400_TuneCP5_13p6TeV_pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1_ext1-v1/NANOAODSIM",
+    ],
+    n_files=3,
+    n_events=2814872,
+)
+
+cpn.add_dataset(
+    name="qcd_pt2400to3200_pythia",
+    id=14645367,
+    is_data=False,
+    processes=[procs.qcd_pt2400to3200],
+    keys=[
+        "/QCD_PT-2400to3200_TuneCP5_13p6TeV_pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1_ext1-v1/NANOAODSIM",
+    ],
+    n_files=3,
+    n_events=1904460,
+)
+
+cpn.add_dataset(
+    name="qcd_pt3200_pythia",
+    id=14645371,
+    is_data=False,
+    processes=[procs.qcd_pt3200],
+    keys=[
+        "/QCD_PT-3200_TuneCP5_13p6TeV_pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1_ext1-v1/NANOAODSIM",
+    ],
+    n_files=2,
+    n_events=800000,
+)
+
+
+#
+# QCD (Pythia pT-binned, muon-enriched)
+#
+
+# GrASP: https://cms-pdmv.cern.ch/grasp/samples?campaign=Run3Summer22EEGS&nanoaod_version=v11&dataset=QCD_PT-*%28to*%29%3F_MuEnrichedPt5_TuneCP5&chained_request=Premix
+
+cpn.add_dataset(
+    name="qcd_mu_pt15to20_pythia",
+    id=14665668,
+    is_data=False,
+    processes=[procs.qcd_mu_pt15to20],
+    keys=[
+        "/QCD_PT-15to20_MuEnrichedPt5_TuneCP5_13p6TeV_pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+    ],
+    n_files=10,
+    n_events=16191725,
+)
+
+# missing as of 2023-07-01
+# cpn.add_dataset(
+#     name="qcd_mu_pt20to30_pythia",
+#     id=None,
+#     is_data=False,
+#     processes=[procs.qcd_mu_pt20to30],
+#     keys=[
+#         "/QCD_PT-20to30_MuEnrichedPt5_TuneCP5_13p6TeV_pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+#     ],
+#     n_files=None,
+#     n_events=None,
+# )
+
+cpn.add_dataset(
+    name="qcd_mu_pt30to50_pythia",
+    id=14686504,
+    is_data=False,
+    processes=[procs.qcd_mu_pt30to50],
+    keys=[
+        "/QCD_PT-30to50_MuEnrichedPt5_TuneCP5_13p6TeV_pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+    ],
+    n_files=62,
+    n_events=102973356,
+)
+
+cpn.add_dataset(
+    name="qcd_mu_pt50to80_pythia",
+    id=14693382,
+    is_data=False,
+    processes=[procs.qcd_mu_pt50to80],
+    keys=[
+        "/QCD_PT-50to80_MuEnrichedPt5_TuneCP5_13p6TeV_pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+    ],
+    n_files=25,
+    n_events=39807191,
+)
+
+cpn.add_dataset(
+    name="qcd_mu_pt80to120_pythia",
+    id=14626691,
+    is_data=False,
+    processes=[procs.qcd_mu_pt80to120],
+    keys=[
+        "/QCD_PT-80to120_MuEnrichedPt5_TuneCP5_13p6TeV_pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+    ],
+    n_files=58,
+    n_events=88063539,
+)
+
+cpn.add_dataset(
+    name="qcd_mu_pt120to170_pythia",
+    id=14687921,
+    is_data=False,
+    processes=[procs.qcd_mu_pt120to170],
+    keys=[
+        "/QCD_PT-120to170_MuEnrichedPt5_TuneCP5_13p6TeV_pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+    ],
+    n_files=56,
+    n_events=69916479,
+)
+
+cpn.add_dataset(
+    name="qcd_mu_pt170to300_pythia",
+    id=14689691,
+    is_data=False,
+    processes=[procs.qcd_mu_pt170to300],
+    keys=[
+        "/QCD_PT-170to300_MuEnrichedPt5_TuneCP5_13p6TeV_pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+    ],
+    n_files=91,
+    n_events=109775023,
+)
+
+cpn.add_dataset(
+    name="qcd_mu_pt300to470_pythia",
+    id=14686495,
+    is_data=False,
+    processes=[procs.qcd_mu_pt300to470],
+    keys=[
+        "/QCD_PT-300to470_MuEnrichedPt5_TuneCP5_13p6TeV_pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+    ],
+    n_files=94,
+    n_events=103836309,
+)
+
+cpn.add_dataset(
+    name="qcd_mu_pt470to600_pythia",
+    id=14687895,
+    is_data=False,
+    processes=[procs.qcd_mu_pt470to600],
+    keys=[
+        "/QCD_PT-470to600_MuEnrichedPt5_TuneCP5_13p6TeV_pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+    ],
+    n_files=69,
+    n_events=72243705,
+)
+
+cpn.add_dataset(
+    name="qcd_mu_pt600to800_pythia",
+    id=14686293,
+    is_data=False,
+    processes=[procs.qcd_mu_pt600to800],
+    keys=[
+        "/QCD_PT-600to800_MuEnrichedPt5_TuneCP5_13p6TeV_pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+    ],
+    n_files=72,
+    n_events=73248078,
+)
+
+# missing as of 2023-07-01
+# cpn.add_dataset(
+#     name="qcd_mu_pt800to1000_pythia",
+#     id=None,
+#     is_data=False,
+#     processes=[procs.qcd_mu_pt800to1000],
+#     keys=[
+#         "/QCD_PT-800to1000_MuEnrichedPt5_TuneCP5_13p6TeV_pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+#     ],
+#     n_files=None,
+#     n_events=None,
+# )
+
+cpn.add_dataset(
+    name="qcd_mu_pt1000_pythia",
+    id=14687958,
+    is_data=False,
+    processes=[procs.qcd_mu_pt1000],
+    keys=[
+        "/QCD_PT-1000_MuEnrichedPt5_TuneCP5_13p6TeV_pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+    ],
+    n_files=52,
+    n_events=47564636,
+)
+
+
+#
+# QCD (Pythia pT-binned, EM-enriched)
+#
+
+# GrASP: https://cms-pdmv.cern.ch/grasp/samples?campaign=Run3Summer22EEGS&nanoaod_version=v11&dataset=QCD_PT-*%28to*%29%3F_EMEnriched_TuneCP5&chained_request=Premix
+# missing as of 2023-07-01

--- a/cmsdb/campaigns/run3_2022_postEE_nano_v11/top.py
+++ b/cmsdb/campaigns/run3_2022_postEE_nano_v11/top.py
@@ -1,0 +1,563 @@
+# coding: utf-8
+
+"""
+top quark datasets for the 2022 post-EE data-taking campaign
+"""
+
+from order import DatasetInfo
+
+import cmsdb.processes as procs
+from cmsdb.campaigns.run3_2022_postEE_nano_v11 import campaign_run3_2022_postEE_nano_v11 as cpn
+
+#
+# ttbar
+#
+
+# semileptonic decay
+# GrASP: https://cms-pdmv.cern.ch/grasp/samples?campaign=Run3Summer22EEwmLHEGS&nanoaod_version=v11&dataset=TTtoLNu2Q%28_Hdamp-*%7C_MT-17%281%7C3%29p5%29%3F_TuneCP5%28%7CUp%7CDown%7CCR1%7CCR2%29_13p6TeV&chained_request=Premix
+cpn.add_dataset(
+    name="tt_sl_powheg",
+    id=14693443,
+    is_data=False,
+    processes=[procs.tt_sl],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/TTtoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+            ],
+            n_files=218,
+            n_events=268418648,
+        ),
+        tune_up=DatasetInfo(
+            keys=[
+                "/TTtoLNu2Q_TuneCP5Up_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+            ],
+            n_files=90,
+            n_events=107949071,
+        ),
+        tune_down=DatasetInfo(
+            keys=[
+                "/TTtoLNu2Q_TuneCP5Down_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+            ],
+            n_files=92,
+            n_events=109342509,
+        ),
+        hdamp_up=DatasetInfo(
+            keys=[
+                "/TTtoLNu2Q_Hdamp-418_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+            ],
+            n_files=89,
+            n_events=107779545,
+        ),
+        hdamp_down=DatasetInfo(
+            keys=[
+                "/TTtoLNu2Q_Hdamp-158_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+            ],
+            n_files=88,
+            n_events=105437846,
+        ),
+        cr_1=DatasetInfo(
+            keys=[
+                "/TTtoLNu2Q_TuneCP5CR1_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+            ],
+            n_files=95,
+            n_events=115411674,
+        ),
+        cr_2=DatasetInfo(
+            keys=[
+                "/TTtoLNu2Q_TuneCP5CR2_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+            ],
+            n_files=89,
+            n_events=108182255,
+        ),
+        mtop_up=DatasetInfo(
+            keys=[
+                "/TTtoLNu2Q_MT-173p5_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+            ],
+        ),
+        mtop_down=DatasetInfo(
+            keys=[
+                "/TTtoLNu2Q_MT-171p5_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+            ],
+        ),
+    ),
+)
+
+
+# dileptonic decay
+# GrASP: https://cms-pdmv.cern.ch/grasp/samples?campaign=Run3Summer22EEwmLHEGS&nanoaod_version=v11&dataset=TTto2L2Nu%28_Hdamp-*%7C_MT-17%281%7C3%29p5%29%3F_TuneCP5%28%7CUp%7CDown%7CCR1%7CCR2%29_13p6TeV&chained_request=Premix
+cpn.add_dataset(
+    name="tt_dl_powheg",
+    id=14636855,
+    is_data=False,
+    processes=[procs.tt_dl],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/TTto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+            ],
+            n_files=70,
+            n_events=83909624,
+        ),
+        tune_up=DatasetInfo(
+            keys=[
+                "/TTto2L2Nu_TuneCP5Up_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+            ],
+            n_files=29,
+            n_events=34876454,
+        ),
+        tune_down=DatasetInfo(
+            keys=[
+                "/TTto2L2Nu_TuneCP5Down_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+            ],
+            n_files=28,
+            n_events=32775020,
+        ),
+        hdamp_up=DatasetInfo(
+            keys=[
+                "/TTto2L2Nu_Hdamp-418_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+            ],
+            n_files=30,
+            n_events=34310080,
+        ),
+        hdamp_down=DatasetInfo(
+            keys=[
+                "/TTto2L2Nu_Hdamp-158_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+            ],
+            n_files=30,
+            n_events=34068776,
+        ),
+        cr_1=DatasetInfo(
+            keys=[
+                "/TTto2L2Nu_TuneCP5CR1_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+            ],
+            n_files=29,
+            n_events=33610745,
+        ),
+        cr_2=DatasetInfo(
+            keys=[
+                "/TTto2L2Nu_TuneCP5CR2_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+            ],
+            n_files=31,
+            n_events=33847420,
+        ),
+        mtop_up=DatasetInfo(
+            keys=[
+                "/TTto2L2Nu_MT-173p5_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+            ],
+        ),
+        mtop_down=DatasetInfo(
+            keys=[
+                "/TTto2L2Nu_MT-173p5_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+            ],
+        ),
+    ),
+)
+
+
+# fully hadronic decay
+# GrASP: https://cms-pdmv.cern.ch/grasp/samples?campaign=Run3Summer22EEwmLHEGS&nanoaod_version=v11&dataset=TTto4Q%28_Hdamp-*%7C_MT-17%281%7C3%29p5%29%3F_TuneCP5%28%7CUp%7CDown%7CCR1%7CCR2%29_13p6TeV&chained_request=Premix
+cpn.add_dataset(
+    name="tt_fh_powheg",
+    id=14694881,
+    is_data=False,
+    processes=[procs.tt_fh],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/TTto4Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+            ],
+            n_files=146,
+            n_events=180771725,
+        ),
+        tune_up=DatasetInfo(
+            keys=[
+                "/TTto4Q_TuneCP5Up_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+            ],
+            n_files=62,
+            n_events=73737184,
+        ),
+        tune_down=DatasetInfo(
+            keys=[
+                "/TTto4Q_TuneCP5Down_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+            ],
+            n_files=67,
+            n_events=76996336,
+        ),
+        hdamp_up=DatasetInfo(
+            keys=[
+                "/TTto4Q_Hdamp-418_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+            ],
+            n_files=63,
+            n_events=75616556,
+        ),
+        hdamp_down=DatasetInfo(
+            keys=[
+                "/TTto4Q_Hdamp-158_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+            ],
+            n_files=67,
+            n_events=80077495,
+        ),
+        cr_1=DatasetInfo(
+            keys=[
+                "/TTto4Q_TuneCP5CR1_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+            ],
+            n_files=65,
+            n_events=78138120,
+        ),
+        cr_2=DatasetInfo(
+            keys=[
+                "/TTto4Q_TuneCP5CR2_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+            ],
+            n_files=68,
+            n_events=77216300,
+        ),
+        mtop_up=DatasetInfo(
+            keys=[
+                "/TTtoLNu2Q_MT-173p5_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+            ],
+        ),
+        mtop_down=DatasetInfo(
+            keys=[
+                "/TTtoLNu2Q_MT-171p5_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+            ],
+        ),
+    ),
+)
+
+#
+# single top (t-channel)
+#
+
+# GrASP: https://cms-pdmv.cern.ch/grasp/samples?campaign=Run3Summer22EEwmLHEGS&nanoaod_version=v11&dataset=%28TBbar%7CTbarB%29Q_t-channel&chained_request=Premix
+
+# t-channel (top)
+cpn.add_dataset(
+    name="st_tchannel_t_powheg",
+    id=14636179,
+    is_data=False,
+    processes=[procs.st_tchannel_t],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/TBbarQ_t-channel_4FS_TuneCP5_13p6TeV_powheg-madspin-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+            ],
+            n_files=9,
+            n_events=10403540,
+        ),
+    ),
+)
+
+# t-channel (anti-top)
+cpn.add_dataset(
+    name="st_tchannel_tbar_powheg",
+    id=14625205,
+    is_data=False,
+    processes=[procs.st_tchannel_tbar],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/TbarBQ_t-channel_4FS_TuneCP5_13p6TeV_powheg-madspin-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+            ],
+            n_files=5,
+            n_events=5210840,
+        ),
+    ),
+)
+
+#
+# single-top (tW-channel)
+#
+
+# semileptonic decay (top)
+# GrASP: https://cms-pdmv.cern.ch/grasp/samples?campaign=Run3Summer22EEwmLHEGS&nanoaod_version=v11&dataset=TWminustoLNu2Q*_TuneCP5%28%7CUp%7CDown%7CCR1%7CCR2%29_13p6TeV&chained_request=Premix
+cpn.add_dataset(
+    name="st_twchannel_t_sl_powheg",
+    id=14691146,
+    is_data=False,
+    processes=[procs.st_twchannel_t_sl],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/TWminustoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+            ],
+            n_files=15,
+            n_events=17032110,
+        ),
+        tune_up=DatasetInfo(
+            keys=[
+                "/TWminustoLNu2Q_TuneCP5Up_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+            ],
+            n_files=15,
+            n_events=17519371,
+        ),
+        # missing as of 2023-07-01
+        # tune_down=DatasetInfo(
+        #     keys=[
+        #         "/TWminustoLNu2Q_TuneCP5Down_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+        #     ],
+        #     n_files=None,
+        #     n_events=None,
+        # ),
+        # missing as of 2023-07-01
+        # cr_1=DatasetInfo(
+        #     keys=[
+        #         "/TWminustoLNu2Q_TuneCP5CR1_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+        #     ],
+        #     n_files=None,
+        #     n_events=None,
+        # ),
+        # missing as of 2023-07-01
+        # cr_2=DatasetInfo(
+        #     keys=[
+        #         "/TWminustoLNu2Q_TuneCP5CR2_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+        #     ],
+        #     n_files=None,
+        #     n_events=None,
+        # ),
+    ),
+)
+
+# semileptonic decay (anti-top)
+# GrASP: https://cms-pdmv.cern.ch/grasp/samples?campaign=Run3Summer22EEwmLHEGS&nanoaod_version=v11&dataset=TbarWplustoLNu2Q*_TuneCP5%28%7CUp%7CDown%7CCR1%7CCR2%29_13p6TeV&chained_request=Premix
+cpn.add_dataset(
+    name="st_twchannel_tbar_sl_powheg",
+    id=14691192,
+    is_data=False,
+    processes=[procs.st_twchannel_tbar_sl],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/TbarWplustoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+            ],
+            n_files=15,
+            n_events=16804298,
+        ),
+        # missing as of 2023-07-01
+        # tune_up=DatasetInfo(
+        #     keys=[
+        #         "/TbarWplustoLNu2Q_TuneCP5Up_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+        #     ],
+        #     n_files=None,
+        #     n_events=None,
+        # ),
+        tune_down=DatasetInfo(
+            keys=[
+                "/TbarWplustoLNu2Q_TuneCP5Down_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+            ],
+            n_files=15,
+            n_events=17361554,
+        ),
+        # missing as of 2023-07-01
+        # cr_1=DatasetInfo(
+        #     keys=[
+        #         "/TbarWplustoLNu2Q_TuneCP5CR1_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+        #     ],
+        #     n_files=None,
+        #     n_events=None,
+        # ),
+        # missing as of 2023-07-01
+        # cr_2=DatasetInfo(
+        #     keys=[
+        #         "/TbarWplustoLNu2Q_TuneCP5CR2_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+        #     ],
+        #     n_files=None,
+        #     n_events=None,
+        # ),
+    ),
+)
+
+# dileptonic decay (top)
+# GrASP: https://cms-pdmv.cern.ch/grasp/samples?campaign=Run3Summer22EEwmLHEGS&nanoaod_version=v11&dataset=TWminusto2L2Nu*_TuneCP5%28%7CUp%7CDown%7CCR1%7CCR2%29_13p6TeV&chained_request=Premix
+cpn.add_dataset(
+    name="st_twchannel_t_dl_powheg",
+    id=14691190,
+    is_data=False,
+    processes=[procs.st_twchannel_t_dl],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/TWminusto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+            ],
+            n_files=8,
+            n_events=8326616,
+        ),
+        # missing as of 2023-07-01
+        # tune_up=DatasetInfo(
+        #     keys=[
+        #         "/TWminusto2L2Nu_TuneCP5Up_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+        #     ],
+        #     n_files=None,
+        #     n_events=None,
+        # ),
+        # missing as of 2023-07-01
+        # tune_down=DatasetInfo(
+        #     keys=[
+        #         "/TWminusto2L2Nu_TuneCP5Down_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+        #     ],
+        #     n_files=None,
+        #     n_events=None,
+        # ),
+        # missing as of 2023-07-01
+        # cr_1=DatasetInfo(
+        #     keys=[
+        #         "/TWminusto2L2Nu_TuneCP5CR1_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+        #     ],
+        #     n_files=None,
+        #     n_events=None,
+        # ),
+        # missing as of 2023-07-01
+        # cr_2=DatasetInfo(
+        #     keys=[
+        #         "/TWminusto2L2Nu_TuneCP5CR2_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+        #     ],
+        #     n_files=None,
+        #     n_events=None,
+        # ),
+    ),
+)
+
+# dileptonic decay (anti-top)
+# GrASP: https://cms-pdmv.cern.ch/grasp/samples?campaign=Run3Summer22EEwmLHEGS&nanoaod_version=v11&dataset=TbarWplusto2L2Nu*_TuneCP5%28%7CUp%7CDown%7CCR1%7CCR2%29_13p6TeV&chained_request=Premix
+cpn.add_dataset(
+    name="st_twchannel_tbar_dl_powheg",
+    id=14691259,
+    is_data=False,
+    processes=[procs.st_twchannel_tbar_dl],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/TbarWplusto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+            ],
+            n_files=8,
+            n_events=8549264,
+        ),
+        # missing as of 2023-07-01
+        # tune_up=DatasetInfo(
+        #     keys=[
+        #         "/TbarWplusto2L2Nu_TuneCP5Up_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+        #     ],
+        #     n_files=None,
+        #     n_events=None,
+        # ),
+        # missing as of 2023-07-01
+        # tune_down=DatasetInfo(
+        #     keys=[
+        #         "/TbarWplusto2L2Nu_TuneCP5Down_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+        #     ],
+        #     n_files=None,
+        #     n_events=None,
+        # ),
+        # missing as of 2023-07-01
+        # cr_1=DatasetInfo(
+        #     keys=[
+        #         "/TbarWplusto2L2Nu_TuneCP5CR1_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+        #     ],
+        #     n_files=None,
+        #     n_events=None,
+        # ),
+        cr_2=DatasetInfo(
+            keys=[
+                "/TbarWplusto2L2Nu_TuneCP5CR2_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+            ],
+            n_files=7,
+            n_events=8274400,
+        ),
+    ),
+)
+
+
+# fully hadronic decay (top)
+# GrASP: https://cms-pdmv.cern.ch/grasp/samples?campaign=Run3Summer22EEwmLHEGS&nanoaod_version=v11&dataset=TWminusto4Q*_TuneCP5%28%7CUp%7CDown%7CCR1%7CCR2%29_13p6TeV&chained_request=Premix
+cpn.add_dataset(
+    name="st_twchannel_t_fh_powheg",
+    id=14691441,
+    is_data=False,
+    processes=[procs.st_twchannel_t_fh],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/TWminusto4Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+            ],
+            n_files=11,
+            n_events=13480012,
+        ),
+        # missing as of 2023-07-01
+        # tune_up=DatasetInfo(
+        #     keys=[
+        #         "/TWminusto4Q_TuneCP5Up_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+        #     ],
+        #     n_files=None,
+        #     n_events=None,
+        # ),
+        tune_down=DatasetInfo(
+            keys=[
+                "/TWminusto4Q_TuneCP5Down_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+            ],
+            n_files=12,
+            n_events=13372624,
+        ),
+        cr_1=DatasetInfo(
+            keys=[
+                "/TWminusto4Q_TuneCP5CR1_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+            ],
+            n_files=11,
+            n_events=13348008,
+        ),
+        cr_2=DatasetInfo(
+            keys=[
+                "/TWminusto4Q_TuneCP5CR2_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+            ],
+            n_files=12,
+            n_events=13977131,
+        ),
+    ),
+)
+
+
+# fully hadronic decay (anti-top)
+# GrASP: https://cms-pdmv.cern.ch/grasp/samples?campaign=Run3Summer22EEwmLHEGS&nanoaod_version=v11&dataset=TbarWplusto4Q*_TuneCP5%28%7CUp%7CDown%7CCR1%7CCR2%29_13p6TeV&chained_request=Premix
+# nominal missing as of 2023-07-01
+# cpn.add_dataset(
+#     name="st_twchannel_tbar_fh_powheg",
+#     id=None,
+#     is_data=False,
+#     processes=[procs.st_twchannel_tbar_fh],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/TbarWplusto4Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+#             ],
+#             n_files=None,
+#             n_events=None,
+#         ),
+#         tune_up=DatasetInfo(
+#             keys=[
+#                 "/TbarWplusto4Q_TuneCP5Up_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+#             ],
+#             n_files=None,
+#             n_events=None,
+#         ),
+#         tune_down=DatasetInfo(
+#             keys=[
+#                 "/TbarWplusto4Q_TuneCP5Down_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+#             ],
+#             n_files=None,
+#             n_events=None,
+#         ),
+#         cr_1=DatasetInfo(
+#             keys=[
+#                 "/TbarWplusto4Q_TuneCP5CR1_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+#             ],
+#             n_files=None,
+#             n_events=None,
+#         ),
+#         cr_2=DatasetInfo(
+#             keys=[
+#                 "/TbarWplusto4Q_TuneCP5CR2_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv11-126X_mcRun3_2022_realistic_postEE_v1-v1/NANOAODSIM",
+#             ],
+#             n_files=13,
+#             n_events=13896218,
+#         ),
+#     ),
+# )

--- a/cmsdb/campaigns/run3_2022_preEE_nano_v11/__init__.py
+++ b/cmsdb/campaigns/run3_2022_preEE_nano_v11/__init__.py
@@ -1,0 +1,35 @@
+# coding: utf-8
+
+"""
+Common, analysis independent definition of the 2022 pre-EE data-taking campaign
+with datasets at NanoAOD tier in version 11.
+See https://python-order.readthedocs.io/en/latest/quickstart.html#analysis-campaign-and-config.
+
+Dataset ids are identical to those in DAS (https://cmsweb.cern.ch/das).
+"""
+
+from order import Campaign
+
+
+#
+# campaign
+#
+
+campaign_run3_2022_preEE_nano_v11 = Campaign(
+    name="run3_2022_preEE_nano_v11",
+    id=320221101,  # 3 2022 11 01(u)
+    ecm=13.6,
+    bx=25,
+    aux={
+        "tier": "NanoAOD",
+        "year": 2022,
+        "version": 11,
+    },
+)
+
+
+# trailing imports to load datasets
+import cmsdb.campaigns.run3_2022_preEE_nano_v11.data  # noqa
+import cmsdb.campaigns.run3_2022_preEE_nano_v11.top  # noqa
+import cmsdb.campaigns.run3_2022_preEE_nano_v11.ewk  # noqa
+import cmsdb.campaigns.run3_2022_preEE_nano_v11.qcd  # noqa

--- a/cmsdb/campaigns/run3_2022_preEE_nano_v11/data.py
+++ b/cmsdb/campaigns/run3_2022_preEE_nano_v11/data.py
@@ -1,0 +1,78 @@
+# coding: utf-8
+
+"""
+CMS datasets from the 2022 pre-EE data-taking campaign
+"""
+
+import cmsdb.processes as procs
+from cmsdb.campaigns.run3_2022_preEE_nano_v11 import campaign_run3_2022_preEE_nano_v11 as cpn
+
+
+
+#
+# Muon
+#
+
+cpn.add_dataset(
+    name="data_mu_c",
+    id=14670816,
+    is_data=True,
+    processes=[procs.data_mu],
+    keys=[
+        "/Muon/Run2022C-ReRecoNanoAODv11-v1/NANOAOD",
+    ],
+    n_files=85,
+    n_events=138018846,
+    aux={
+        "era": "C",
+    },
+)
+
+cpn.add_dataset(
+    name="data_mu_d",
+    id=14665037,
+    is_data=True,
+    processes=[procs.data_mu],
+    keys=[
+        "/Muon/Run2022D-ReRecoNanoAODv11-v1/NANOAOD",
+    ],
+    n_files=55,
+    n_events=75494657,
+    aux={
+        "era": "D",
+    },
+)
+
+#
+# E/Gamma
+#
+
+cpn.add_dataset(
+    name="data_egamma_c",
+    id=14665314,
+    is_data=True,
+    processes=[procs.data_egamma],
+    keys=[
+        "/EGamma/Run2022C-ReRecoNanoAODv11-v1/NANOAOD",
+    ],
+    n_files=164,
+    n_events=263336263,
+    aux={
+        "era": "C",
+    },
+)
+
+cpn.add_dataset(
+    name="data_egamma_d",
+    id=14665654,
+    is_data=True,
+    processes=[procs.data_egamma],
+    keys=[
+        "/EGamma/Run2022D-ReRecoNanoAODv11-v1/NANOAOD",
+    ],
+    n_files=62,
+    n_events=88530905,
+    aux={
+        "era": "D",
+    },
+)

--- a/cmsdb/campaigns/run3_2022_preEE_nano_v11/ewk.py
+++ b/cmsdb/campaigns/run3_2022_preEE_nano_v11/ewk.py
@@ -1,0 +1,129 @@
+# coding: utf-8
+
+"""
+Electroweak datasets for the 2022 pre-EE data-taking campaign
+"""
+
+import cmsdb.processes as procs
+from cmsdb.campaigns.run3_2022_preEE_nano_v11 import campaign_run3_2022_preEE_nano_v11 as cpn
+
+
+#
+# Drell-Yan
+#
+
+# inclusive (MadGraph)
+# GrASP: https://cms-pdmv.cern.ch/grasp/samples?campaign=Run3Summer22wmLHEGS&dataset=DYJetsToLL_M-50&nanoaod_version=v11
+cpn.add_dataset(
+    name="dy_lep_m50_madgraph",
+    id=14679260,
+    is_data=False,
+    processes=[procs.dy_lep_m50],
+    keys=[
+        "/DYJetsToLL_M-50_TuneCP5_13p6TeV-madgraphMLM-pythia8/Run3Summer22NanoAODv11-forPOG_126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+    ],
+    n_files=18,
+    n_events=26047237,
+)
+
+# inclusive (aMC@NLO)
+# GrASP: https://cms-pdmv.cern.ch/grasp/samples?campaign=Run3Summer22wmLHEGS&dataset=DYto2L-2Jets_MLL-50&nanoaod_version=v11
+cpn.add_dataset(
+    name="dy_lep_m50_amcatnlo",
+    id=14637757,
+    is_data=False,
+    processes=[procs.dy_lep_m50],
+    keys=[
+        "/DYto2L-2Jets_MLL-50_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+    ],
+    n_files=44,
+    n_events=71028905,
+)
+
+# MadGraph (n-jet binned)
+# GrASP: https://cms-pdmv.cern.ch/grasp/samples?campaign=Run3Summer22wmLHEGS&dataset=DYto2L-4
+# missing as of 2023-07-01
+
+# POWHEG (decay to muons, MLL-binned)
+# GrASP: https://cms-pdmv.cern.ch/grasp/samples?campaign=Run3Summer22wmLHEGS&dataset=DYto2Mu
+# DAS entries:
+#     /DYto2Mu_MLL-10to50_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v2/NANOAODSIM
+#     /DYto2Mu_MLL-50to120_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v2/NANOAODSIM
+#     /DYto2Mu_MLL-120to200_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v2/NANOAODSIM
+#     /DYto2Mu_MLL-200to400_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v2/NANOAODSIM
+#     /DYto2Mu_MLL-400to800_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v2/NANOAODSIM
+#     /DYto2Mu_MLL-800to1500_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v2/NANOAODSIM
+#     /DYto2Mu_MLL-1500to2500_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v2/NANOAODSIM
+#     /DYto2Mu_MLL-2500to4000_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v2/NANOAODSIM
+#     /DYto2Mu_MLL-4000to6000_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v2/NANOAODSIM
+#     /DYto2Mu_MLL-4000_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v2/NANOAODSIM
+
+# POWHEG (decay to electrons, MLL-binned)
+# GrASP: https://cms-pdmv.cern.ch/grasp/samples?campaign=Run3Summer22wmLHEGS&dataset=DYto2E_MLL
+# missing as of 2023-07-01
+
+
+#
+# W boson production
+#
+
+# inclusive (aMC@NLO)
+# GrASP: https://cms-pdmv.cern.ch/grasp/samples?campaign=Run3Summer22wmLHEGS&dataset=WtoLNu-2Jets&nanoaod_version=v11
+cpn.add_dataset(
+    name="w_lnu_amcatnlo",
+    id=14611721,
+    is_data=False,
+    processes=[procs.w_lnu],
+    keys=[
+        "/WtoLNu-2Jets_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+    ],
+    n_files=45,
+    n_events=80257100,
+)
+
+# MadGraph (n-jet binned)
+# GrASP: https://cms-pdmv.cern.ch/grasp/samples?campaign=Run3Summer22wmLHEGS&dataset=WtoLNu-4Jets_%281%7C2%7C3%7C4%29J&nanoaod_version=v11
+# missing as of 2023-07-01
+
+
+#
+# Diboson
+#
+
+# GrASP: https://cms-pdmv.cern.ch/grasp/samples?campaign=Run3Summer22GS&nanoaod_version=v11&short_name=VV
+
+cpn.add_dataset(
+    name="zz_pythia",
+    id=14587173,
+    is_data=False,
+    processes=[procs.zz],
+    keys=[
+        "/ZZ_TuneCP5_13p6TeV_pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+    ],
+    n_files=2,
+    n_events=1186860,
+)
+
+cpn.add_dataset(
+    name="wz_pythia",
+    id=14596611,
+    is_data=False,
+    processes=[procs.wz],
+    keys=[
+        "/WZ_TuneCP5_13p6TeV_pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+    ],
+    n_files=6,
+    n_events=7744881,
+)
+
+cpn.add_dataset(
+    name="ww_pythia",
+    id=14694767,
+    is_data=False,
+    processes=[procs.ww],
+    keys=[
+        "/WW_TuneCP5_13p6TeV_pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v2/NANOAODSIM",
+    ],
+    n_files=11,
+    n_events=15474424,
+)

--- a/cmsdb/campaigns/run3_2022_preEE_nano_v11/qcd.py
+++ b/cmsdb/campaigns/run3_2022_preEE_nano_v11/qcd.py
@@ -1,0 +1,394 @@
+# coding: utf-8
+
+"""
+QCD datasets for the 2022 pre-EE data-taking campaign
+"""
+
+import cmsdb.processes as procs
+from cmsdb.campaigns.run3_2022_preEE_nano_v11 import campaign_run3_2022_preEE_nano_v11 as cpn
+
+
+#
+# QCD flat samples
+#
+
+# GrASP: https://cms-pdmv.cern.ch/grasp/samples?campaign=Run3Summer22GS&nanoaod_version=v11&dataset=QCD_PT-15*Flat2018&chained_request=Premix
+cpn.add_dataset(
+    name="qcd_flat2018_pythia",
+    id=14636176,
+    is_data=False,
+    processes=[procs.qcd_flat],
+    keys=[
+        "/QCD_PT-15_TuneCP5_Flat2018_13p6TeV_pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+    ],
+    n_files=8,
+    n_events=9251295,
+)
+
+# GrASP: https://cms-pdmv.cern.ch/grasp/samples?campaign=Run3Summer22GS&nanoaod_version=v11&dataset=QCD_PT-15*Flat2018&chained_request=EpsilonPU
+cpn.add_dataset(
+    name="qcd_flat2018_epsilonPU_pythia",
+    id=14685183,
+    is_data=False,
+    processes=[procs.qcd_flat],
+    keys=[
+        "/QCD_PT-15to7000_TuneCP5_Flat2018_13p6TeV_pythia8/Run3Summer22NanoAODv11-EpsilonPU_126X_mcRun3_2022_realistic_v2-v2/NANOAODSIM",
+    ],
+    n_files=3,
+    n_events=499387,
+)
+
+
+#
+# QCD (MadGraph HT-binned)
+#
+
+# missing as of 2023-07-01
+
+
+#
+# QCD (Pythia pT-binned)
+#
+
+# GrASP: https://cms-pdmv.cern.ch/grasp/samples?campaign=Run3Summer22GS&nanoaod_version=v11&dataset=QCD_PT-*%28to*%29%3F0_TuneCP5&chained_request=Premix
+
+cpn.add_dataset(
+    name="qcd_pt15to30_pythia",
+    id=14689890,
+    is_data=False,
+    processes=[procs.qcd_pt15to30],
+    keys=[
+        "/QCD_PT-15to30_TuneCP5_13p6TeV_pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+    ],
+    n_files=2,
+    n_events=1149000,
+)
+
+cpn.add_dataset(
+    name="qcd_pt30to50_pythia",
+    id=14689122,
+    is_data=False,
+    processes=[procs.qcd_pt30to50],
+    keys=[
+        "/QCD_PT-30to50_TuneCP5_13p6TeV_pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+    ],
+    n_files=2,
+    n_events=1189766,
+)
+
+cpn.add_dataset(
+    name="qcd_pt50to80_pythia",
+    id=14693446,
+    is_data=False,
+    processes=[procs.qcd_pt50to80],
+    keys=[
+        "/QCD_PT-50to80_TuneCP5_13p6TeV_pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2_ext1-v1/NANOAODSIM",
+    ],
+    n_files=12,
+    n_events=19722512,
+)
+
+cpn.add_dataset(
+    name="qcd_pt80to120_pythia",
+    id=14694162,
+    is_data=False,
+    processes=[procs.qcd_pt80to120],
+    keys=[
+        "/QCD_PT-80to120_TuneCP5_13p6TeV_pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2_ext1-v1/NANOAODSIM",
+    ],
+    n_files=17,
+    n_events=29209440,
+)
+
+cpn.add_dataset(
+    name="qcd_pt120to170_pythia",
+    id=14693352,
+    is_data=False,
+    processes=[procs.qcd_pt120to170],
+    keys=[
+        "/QCD_PT-120to170_TuneCP5_13p6TeV_pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2_ext1-v1/NANOAODSIM",
+    ],
+    n_files=21,
+    n_events=29908875,
+)
+
+cpn.add_dataset(
+    name="qcd_pt170to300_pythia",
+    id=14694835,
+    is_data=False,
+    processes=[procs.qcd_pt170to300],
+    keys=[
+        "/QCD_PT-170to300_TuneCP5_13p6TeV_pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2_ext1-v1/NANOAODSIM",
+    ],
+    n_files=21,
+    n_events=28624020,
+)
+
+cpn.add_dataset(
+    name="qcd_pt300to470_pythia",
+    id=14694880,
+    is_data=False,
+    processes=[procs.qcd_pt300to470],
+    keys=[
+        "/QCD_PT-300to470_TuneCP5_13p6TeV_pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2_ext1-v1/NANOAODSIM",
+    ],
+    n_files=45,
+    n_events=57525303,
+)
+
+cpn.add_dataset(
+    name="qcd_pt470to600_pythia",
+    id=14693379,
+    is_data=False,
+    processes=[procs.qcd_pt470to600],
+    keys=[
+        "/QCD_PT-470to600_TuneCP5_13p6TeV_pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2_ext1-v1/NANOAODSIM",
+    ],
+    n_files=22,
+    n_events=27577568,
+)
+
+cpn.add_dataset(
+    name="qcd_pt600to800_pythia",
+    id=14694728,
+    is_data=False,
+    processes=[procs.qcd_pt600to800],
+    keys=[
+        "/QCD_PT-600to800_TuneCP5_13p6TeV_pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2_ext1-v1/NANOAODSIM",
+    ],
+    n_files=57,
+    n_events=66884777,
+)
+
+cpn.add_dataset(
+    name="qcd_pt800to1000_pythia",
+    id=14694323,
+    is_data=False,
+    processes=[procs.qcd_pt800to1000],
+    keys=[
+        "/QCD_PT-800to1000_TuneCP5_13p6TeV_pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2_ext1-v1/NANOAODSIM",
+    ],
+    n_files=35,
+    n_events=39451059,
+)
+
+cpn.add_dataset(
+    name="qcd_pt1000to1400_pythia",
+    id=14694841,
+    is_data=False,
+    processes=[procs.qcd_pt1000to1400],
+    keys=[
+        "/QCD_PT-1000to1400_TuneCP5_13p6TeV_pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2_ext1-v1/NANOAODSIM",
+    ],
+    n_files=21,
+    n_events=19882169,
+)
+
+cpn.add_dataset(
+    name="qcd_pt1400to1800_pythia",
+    id=14637819,
+    is_data=False,
+    processes=[procs.qcd_pt1400to1800],
+    keys=[
+        "/QCD_PT-1400to1800_TuneCP5_13p6TeV_pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2_ext1-v1/NANOAODSIM",
+    ],
+    n_files=8,
+    n_events=5836650,
+)
+
+cpn.add_dataset(
+    name="qcd_pt1800to2400_pythia",
+    id=14641606,
+    is_data=False,
+    processes=[procs.qcd_pt1800to2400],
+    keys=[
+        "/QCD_PT-1800to2400_TuneCP5_13p6TeV_pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2_ext1-v1/NANOAODSIM",
+    ],
+    n_files=4,
+    n_events=2989840,
+)
+
+cpn.add_dataset(
+    name="qcd_pt2400to3200_pythia",
+    id=14693239,
+    is_data=False,
+    processes=[procs.qcd_pt2400to3200],
+    keys=[
+        "/QCD_PT-2400to3200_TuneCP5_13p6TeV_pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2_ext1-v1/NANOAODSIM",
+    ],
+    n_files=3,
+    n_events=1963904,
+)
+
+cpn.add_dataset(
+    name="qcd_pt3200_pythia",
+    id=14645062,
+    is_data=False,
+    processes=[procs.qcd_pt3200],
+    keys=[
+        "/QCD_PT-3200_TuneCP5_13p6TeV_pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2_ext1-v1/NANOAODSIM",
+    ],
+    n_files=1,
+    n_events=782175,
+)
+
+
+#
+# QCD (Pythia pT-binned, muon-enriched)
+#
+
+# GrASP: https://cms-pdmv.cern.ch/grasp/samples?campaign=Run3Summer22GS&nanoaod_version=v11&dataset=QCD_PT-*%28to*%29%3F_MuEnrichedPt5_TuneCP5&chained_request=Premix
+
+cpn.add_dataset(
+    name="qcd_mu_pt15to20_pythia",
+    id=14637754,
+    is_data=False,
+    processes=[procs.qcd_mu_pt15to20],
+    keys=[
+        "/QCD_PT-15to20_MuEnrichedPt5_TuneCP5_13p6TeV_pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+    ],
+    n_files=4,
+    n_events=4529335,
+)
+
+cpn.add_dataset(
+    name="qcd_mu_pt20to30_pythia",
+    id=14689998,
+    is_data=False,
+    processes=[procs.qcd_mu_pt20to30],
+    keys=[
+        "/QCD_PT-20to30_MuEnrichedPt5_TuneCP5_13p6TeV_pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+    ],
+    n_files=19,
+    n_events=29845469,
+)
+
+# missing as of 2023-07-01
+# cpn.add_dataset(
+#     name="qcd_mu_pt30to50_pythia",
+#     id=None,
+#     is_data=False,
+#     processes=[procs.qcd_mu_pt30to50],
+#     keys=[
+#         "/QCD_PT-30to50_MuEnrichedPt5_TuneCP5_13p6TeV_pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+#     ],
+#     n_files=None,
+#     n_events=None,
+# )
+
+cpn.add_dataset(
+    name="qcd_mu_pt50to80_pythia",
+    id=14694803,
+    is_data=False,
+    processes=[procs.qcd_mu_pt50to80],
+    keys=[
+        "/QCD_PT-50to80_MuEnrichedPt5_TuneCP5_13p6TeV_pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+    ],
+    n_files=25,
+    n_events=41159366,
+)
+
+cpn.add_dataset(
+    name="qcd_mu_pt80to120_pythia",
+    id=14625411,
+    is_data=False,
+    processes=[procs.qcd_mu_pt80to120],
+    keys=[
+        "/QCD_PT-80to120_MuEnrichedPt5_TuneCP5_13p6TeV_pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+    ],
+    n_files=18,
+    n_events=25108328,
+)
+
+cpn.add_dataset(
+    name="qcd_mu_pt120to170_pythia",
+    id=14686500,
+    is_data=False,
+    processes=[procs.qcd_mu_pt120to170],
+    keys=[
+        "/QCD_PT-120to170_MuEnrichedPt5_TuneCP5_13p6TeV_pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+    ],
+    n_files=20,
+    n_events=18849346,
+)
+
+cpn.add_dataset(
+    name="qcd_mu_pt170to300_pythia",
+    id=14687812,
+    is_data=False,
+    processes=[procs.qcd_mu_pt170to300],
+    keys=[
+        "/QCD_PT-170to300_MuEnrichedPt5_TuneCP5_13p6TeV_pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+    ],
+    n_files=34,
+    n_events=36140731,
+)
+
+# missing as of 2023-07-01
+# cpn.add_dataset(
+#     name="qcd_mu_pt300to470_pythia",
+#     id=None,
+#     is_data=False,
+#     processes=[procs.qcd_mu_pt300to470],
+#     keys=[
+#         "/QCD_PT-300to470_MuEnrichedPt5_TuneCP5_13p6TeV_pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+#     ],
+#     n_files=None,
+#     n_events=None,
+# )
+
+cpn.add_dataset(
+    name="qcd_mu_pt470to600_pythia",
+    id=14686361,
+    is_data=False,
+    processes=[procs.qcd_mu_pt470to600],
+    keys=[
+        "/QCD_PT-470to600_MuEnrichedPt5_TuneCP5_13p6TeV_pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+    ],
+    n_files=21,
+    n_events=18066469,
+)
+
+cpn.add_dataset(
+    name="qcd_mu_pt600to800_pythia",
+    id=14687893,
+    is_data=False,
+    processes=[procs.qcd_mu_pt600to800],
+    keys=[
+        "/QCD_PT-600to800_MuEnrichedPt5_TuneCP5_13p6TeV_pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+    ],
+    n_files=19,
+    n_events=19989674,
+)
+
+cpn.add_dataset(
+    name="qcd_mu_pt800to1000_pythia",
+    id=14620509,
+    is_data=False,
+    processes=[procs.qcd_mu_pt800to1000],
+    keys=[
+        "/QCD_PT-800to1000_MuEnrichedPt5_TuneCP5_13p6TeV_pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+    ],
+    n_files=44,
+    n_events=39272493,
+)
+
+cpn.add_dataset(
+    name="qcd_mu_pt1000_pythia",
+    id=14694180,
+    is_data=False,
+    processes=[procs.qcd_mu_pt1000],
+    keys=[
+        "/QCD_PT-1000_MuEnrichedPt5_TuneCP5_13p6TeV_pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+    ],
+    n_files=17,
+    n_events=14214939,
+)
+
+
+#
+# QCD (Pythia pT-binned, EM-enriched)
+#
+
+# GrASP: https://cms-pdmv.cern.ch/grasp/samples?campaign=Run3Summer22GS&nanoaod_version=v11&dataset=QCD_PT-*%28to*%29%3F_EMEnriched_TuneCP5&chained_request=Premix
+# missing as of 2023-07-01 (only v10 available)

--- a/cmsdb/campaigns/run3_2022_preEE_nano_v11/top.py
+++ b/cmsdb/campaigns/run3_2022_preEE_nano_v11/top.py
@@ -1,0 +1,553 @@
+# coding: utf-8
+
+"""
+top quark datasets for the 2022 pre-EE data-taking campaign
+"""
+
+from order import DatasetInfo
+
+import cmsdb.processes as procs
+from cmsdb.campaigns.run3_2022_preEE_nano_v11 import campaign_run3_2022_preEE_nano_v11 as cpn
+
+#
+# ttbar
+#
+
+# semileptonic decay
+# GrASP: https://cms-pdmv.cern.ch/grasp/samples?campaign=Run3Summer22wmLHEGS&nanoaod_version=v11&dataset=TTtoLNu2Q%28_Hdamp-*%7C_MT-17%281%7C3%29p5%29%3F_TuneCP5%28%7CUp%7CDown%7CCR1%7CCR2%29_13p6TeV&chained_request=Premix
+cpn.add_dataset(
+    name="tt_sl_powheg",
+    id=14707480,
+    is_data=False,
+    processes=[procs.tt_sl],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/TTtoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+            ],
+            n_files=67,
+            n_events=80484415,
+        ),
+        tune_up=DatasetInfo(
+            keys=[
+                "/TTtoLNu2Q_TuneCP5Up_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+            ],
+            n_files=29,
+            n_events=32259560,
+        ),
+        tune_down=DatasetInfo(
+            keys=[
+                "/TTtoLNu2Q_TuneCP5Down_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+            ],
+            n_files=30,
+            n_events=32703000,
+        ),
+        hdamp_up=DatasetInfo(
+            keys=[
+                "/TTtoLNu2Q_Hdamp-418_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+            ],
+            n_files=28,
+            n_events=31147944,
+        ),
+        hdamp_down=DatasetInfo(
+            keys=[
+                "/TTtoLNu2Q_Hdamp-158_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+            ],
+            n_files=30,
+            n_events=31624817,
+        ),
+        cr_1=DatasetInfo(
+            keys=[
+                "/TTtoLNu2Q_TuneCP5CR1_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+            ],
+            n_files=28,
+            n_events=32268860,
+        ),
+        cr_2=DatasetInfo(
+            keys=[
+                "/TTtoLNu2Q_TuneCP5CR2_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+            ],
+            n_files=29,
+            n_events=31853547,
+        ),
+        mtop_up=DatasetInfo(
+            keys=[
+                "/TTtoLNu2Q_MT-173p5_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+            ],
+        ),
+        mtop_down=DatasetInfo(
+            keys=[
+                "/TTtoLNu2Q_MT-171p5_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+            ],
+        ),
+    ),
+)
+
+
+# dileptonic decay
+# GrASP: https://cms-pdmv.cern.ch/grasp/samples?campaign=Run3Summer22wmLHEGS&nanoaod_version=v11&dataset=TTto2L2Nu%28_Hdamp-*%7C_MT-17%281%7C3%29p5%29%3F_TuneCP5%28%7CUp%7CDown%7CCR1%7CCR2%29_13p6TeV&chained_request=Premix
+cpn.add_dataset(
+    name="tt_dl_powheg",
+    id=14707644,
+    is_data=False,
+    processes=[procs.tt_dl],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/TTto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+            ],
+            n_files=22,
+            n_events=23765566,
+        ),
+        tune_up=DatasetInfo(
+            keys=[
+                "/TTto2L2Nu_TuneCP5Up_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+            ],
+            n_files=11,
+            n_events=9621248,
+        ),
+        tune_down=DatasetInfo(
+            keys=[
+                "/TTto2L2Nu_TuneCP5Down_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+            ],
+            n_files=10,
+            n_events=9943000,
+        ),
+        hdamp_up=DatasetInfo(
+            keys=[
+                "/TTto2L2Nu_Hdamp-418_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+            ],
+            n_files=12,
+            n_events=9824455,
+        ),
+        hdamp_down=DatasetInfo(
+            keys=[
+                "/TTto2L2Nu_Hdamp-158_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+            ],
+            n_files=11,
+            n_events=9943673,
+        ),
+        cr_1=DatasetInfo(
+            keys=[
+                "/TTto2L2Nu_TuneCP5CR1_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+            ],
+            n_files=12,
+            n_events=9831244,
+        ),
+        cr_2=DatasetInfo(
+            keys=[
+                "/TTto2L2Nu_TuneCP5CR2_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+            ],
+            n_files=10,
+            n_events=9730000,
+        ),
+        mtop_up=DatasetInfo(
+            keys=[
+                "/TTto2L2Nu_MT-173p5_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+            ],
+        ),
+        mtop_down=DatasetInfo(
+            keys=[
+                "/TTto2L2Nu_MT-171p5_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+            ],
+        ),
+    ),
+)
+
+
+# fully hadronic decay
+# GrASP: https://cms-pdmv.cern.ch/grasp/samples?campaign=Run3Summer22wmLHEGS&nanoaod_version=v11&dataset=TTto4Q%28_Hdamp-*%7C_MT-17%281%7C3%29p5%29%3F_TuneCP5%28%7CUp%7CDown%7CCR1%7CCR2%29_13p6TeV&chained_request=Premix
+cpn.add_dataset(
+    name="tt_fh_powheg",
+    id=14708054,
+    is_data=False,
+    processes=[procs.tt_fh],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/TTto4Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+            ],
+            n_files=46,
+            n_events=53419472,
+        ),
+        tune_up=DatasetInfo(
+            keys=[
+                "/TTto4Q_TuneCP5Up_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+            ],
+            n_files=22,
+            n_events=22548206,
+        ),
+        # missing as of 2023-07-01
+        # tune_down=DatasetInfo(
+        #     keys=[
+        #         "/TTto4Q_TuneCP5Down_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+        #     ],
+        #     n_files=None,
+        #     n_events=None,
+        # ),
+        hdamp_up=DatasetInfo(
+            keys=[
+                "/TTto4Q_Hdamp-418_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+            ],
+            n_files=22,
+            n_events=21658498,
+        ),
+        hdamp_down=DatasetInfo(
+            keys=[
+                "/TTto4Q_Hdamp-158_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+            ],
+            n_files=20,
+            n_events=23430687,
+        ),
+        cr_1=DatasetInfo(
+            keys=[
+                "/TTto4Q_TuneCP5CR1_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+            ],
+            n_files=20,
+            n_events=21873176,
+        ),
+        # missing as of 2023-07-01
+        # cr_2=DatasetInfo(
+        #     keys=[
+        #         "/TTto4Q_TuneCP5CR2_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+        #     ],
+        #     n_files=None,
+        #     n_events=None,
+        # ),
+        mtop_up=DatasetInfo(
+            keys=[
+                "/TTtoLNu2Q_MT-173p5_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+            ],
+        ),
+        mtop_down=DatasetInfo(
+            keys=[
+                "/TTtoLNu2Q_MT-171p5_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+            ],
+        ),
+    ),
+)
+
+#
+# single top (t-channel)
+#
+
+# GrASP: https://cms-pdmv.cern.ch/grasp/samples?campaign=Run3Summer22wmLHEGS&nanoaod_version=v11&dataset=%28TBbar%7CTbarB%29Q_t-channel&chained_request=Premix
+
+# t-channel (top)
+cpn.add_dataset(
+    name="st_tchannel_t_powheg",
+    id=14635077,
+    is_data=False,
+    processes=[procs.st_tchannel_t],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/TBbarQ_t-channel_4FS_TuneCP5_13p6TeV_powheg-madspin-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+            ],
+            n_files=2,
+            n_events=2973675,
+        ),
+    ),
+)
+
+# t-channel (anti-top)
+cpn.add_dataset(
+    name="st_tchannel_tbar_powheg",
+    id=14619151,
+    is_data=False,
+    processes=[procs.st_tchannel_tbar],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/TbarBQ_t-channel_4FS_TuneCP5_13p6TeV_powheg-madspin-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+            ],
+            n_files=2,
+            n_events=1488752,
+        ),
+    ),
+)
+
+#
+# single-top (tW-channel)
+#
+
+# semileptonic decay (top)
+# GrASP: https://cms-pdmv.cern.ch/grasp/samples?campaign=Run3Summer22wmLHEGS&nanoaod_version=v11&dataset=TWminustoLNu2Q*_TuneCP5%28%7CUp%7CDown%7CCR1%7CCR2%29_13p6TeV&chained_request=Premix
+# nominal missing as of 2023-07-01
+# cpn.add_dataset(
+#     name="st_twchannel_t_sl_powheg",
+#     id=None,
+#     is_data=False,
+#     processes=[procs.st_twchannel_t_sl],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/TWminustoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+#             ],
+#             n_files=None,
+#             n_events=None,
+#         ),
+#         tune_up=DatasetInfo(
+#             keys=[
+#                 "/TWminustoLNu2Q_TuneCP5Up_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+#             ],
+#             n_files=5,
+#             n_events=4943120,
+#         ),
+#         tune_down=DatasetInfo(
+#             keys=[
+#                 "/TWminustoLNu2Q_TuneCP5Down_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+#             ],
+#             n_files=4,
+#             n_events=4587700,
+#         ),
+#         cr_1=DatasetInfo(
+#             keys=[
+#                 "/TWminustoLNu2Q_TuneCP5CR1_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+#             ],
+#             n_files=5,
+#             n_events=4593174,
+#         ),
+#         cr_2=DatasetInfo(
+#             keys=[
+#                 "/TWminustoLNu2Q_TuneCP5CR2_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+#             ],
+#             n_files=4,
+#             n_events=4676221,
+#         ),
+#     ),
+# )
+
+# semileptonic decay (anti-top)
+# GrASP: https://cms-pdmv.cern.ch/grasp/samples?campaign=Run3Summer22wmLHEGS&nanoaod_version=v11&dataset=TbarWplustoLNu2Q*_TuneCP5%28%7CUp%7CDown%7CCR1%7CCR2%29_13p6TeV&chained_request=Premix
+# nominal missing as of 2023-07-01
+# cpn.add_dataset(
+#     name="st_twchannel_tbar_sl_powheg",
+#     id=None,
+#     is_data=False,
+#     processes=[procs.st_twchannel_tbar_sl],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/TbarWplustoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+#             ],
+#             n_files=None,
+#             n_events=None,
+#         ),
+#         tune_up=DatasetInfo(
+#             keys=[
+#                 "/TbarWplustoLNu2Q_TuneCP5Up_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+#             ],
+#             n_files=None,
+#             n_events=None,
+#         ),
+#         tune_down=DatasetInfo(
+#             keys=[
+#                 "/TbarWplustoLNu2Q_TuneCP5Up_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+#             ],
+#             n_files=None,
+#             n_events=None,
+#         ),
+#         cr_1=DatasetInfo(
+#             keys=[
+#                 "/TbarWplustoLNu2Q_TuneCP5CR1_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+#             ],
+#             n_files=4,
+#             n_events=4728679,
+#         ),
+#         cr_2=DatasetInfo(
+#             keys=[
+#                 "/TbarWplustoLNu2Q_TuneCP5CR2_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+#             ],
+#             n_files=4,
+#             n_events=4633416,
+#         ),
+#     ),
+# )
+
+# dileptonic decay (top)
+# GrASP: https://cms-pdmv.cern.ch/grasp/samples?campaign=Run3Summer22wmLHEGS&nanoaod_version=v11&dataset=TWminusto2L2Nu*_TuneCP5%28%7CUp%7CDown%7CCR1%7CCR2%29_13p6TeV&chained_request=Premix
+cpn.add_dataset(
+    name="st_twchannel_t_dl_powheg",
+    id=14678180,
+    is_data=False,
+    processes=[procs.st_twchannel_t_dl],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/TWminusto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+            ],
+            n_files=4,
+            n_events=2435564,
+        ),
+        tune_up=DatasetInfo(
+            keys=[
+                "/TWminusto2L2Nu_TuneCP5Up_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+            ],
+            n_files=4,
+            n_events=2375416,
+        ),
+        tune_down=DatasetInfo(
+            keys=[
+                "/TWminusto2L2Nu_TuneCP5Down_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+            ],
+            n_files=4,
+            n_events=2385737,
+        ),
+        cr_1=DatasetInfo(
+            keys=[
+                "/TWminusto2L2Nu_TuneCP5CR1_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+            ],
+            n_files=4,
+            n_events=2492355,
+        ),
+        cr_2=DatasetInfo(
+            keys=[
+                "/TWminusto2L2Nu_TuneCP5CR2_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+            ],
+            n_files=3,
+            n_events=2497224,
+        ),
+    ),
+)
+
+# dileptonic decay (anti-top)
+# GrASP: https://cms-pdmv.cern.ch/grasp/samples?campaign=Run3Summer22wmLHEGS&nanoaod_version=v11&dataset=TbarWplusto2L2Nu*_TuneCP5%28%7CUp%7CDown%7CCR1%7CCR2%29_13p6TeV&chained_request=Premix
+cpn.add_dataset(
+    name="st_twchannel_tbar_dl_powheg",
+    id=14690995,
+    is_data=False,
+    processes=[procs.st_twchannel_tbar_dl],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/TbarWplusto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+            ],
+            n_files=3,
+            n_events=2401536,
+        ),
+        # missing as of 2023-07-01
+        # tune_up=DatasetInfo(
+        #     keys=[
+        #         "/TbarWplusto2L2Nu_TuneCP5Up_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+        #     ],
+        #     n_files=None,
+        #     n_events=None,
+        # ),
+        tune_down=DatasetInfo(
+            keys=[
+                "/TbarWplusto2L2Nu_TuneCP5Down_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+            ],
+            n_files=2,
+            n_events=2422160,
+        ),
+        cr_1=DatasetInfo(
+            keys=[
+                "/TbarWplusto2L2Nu_TuneCP5CR1_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+            ],
+            n_files=4,
+            n_events=2425480,
+        ),
+        cr_2=DatasetInfo(
+            keys=[
+                "/TbarWplusto2L2Nu_TuneCP5CR2_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+            ],
+            n_files=4,
+            n_events=2496520,
+        ),
+    ),
+)
+
+
+# fully hadronic decay (top)
+# GrASP: https://cms-pdmv.cern.ch/grasp/samples?campaign=Run3Summer22wmLHEGS&nanoaod_version=v11&dataset=TWminusto4Q*_TuneCP5%28%7CUp%7CDown%7CCR1%7CCR2%29_13p6TeV&chained_request=Premix
+cpn.add_dataset(
+    name="st_twchannel_t_fh_powheg",
+    id=14691168,
+    is_data=False,
+    processes=[procs.st_twchannel_t_fh],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/TWminusto4Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+            ],
+            n_files=5,
+            n_events=3924210,
+        ),
+        tune_up=DatasetInfo(
+            keys=[
+                "/TWminusto4Q_TuneCP5Up_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+            ],
+            n_files=4,
+            n_events=3853959,
+        ),
+        tune_down=DatasetInfo(
+            keys=[
+                "/TWminusto4Q_TuneCP5Down_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+            ],
+            n_files=4,
+            n_events=3822520,
+        ),
+        cr_1=DatasetInfo(
+            keys=[
+                "/TWminusto4Q_TuneCP5CR1_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+            ],
+            n_files=4,
+            n_events=3800301,
+        ),
+        cr_2=DatasetInfo(
+            keys=[
+                "/TWminusto4Q_TuneCP5CR2_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+            ],
+            n_files=4,
+            n_events=3862996,
+        ),
+    ),
+)
+
+
+# fully hadronic decay (anti-top)
+# GrASP: https://cms-pdmv.cern.ch/grasp/samples?campaign=Run3Summer22wmLHEGS&nanoaod_version=v11&dataset=TbarWplusto4Q*_TuneCP5%28%7CUp%7CDown%7CCR1%7CCR2%29_13p6TeV&chained_request=Premix
+cpn.add_dataset(
+    name="st_twchannel_tbar_fh_powheg",
+    id=14691156,
+    is_data=False,
+    processes=[procs.st_twchannel_t_fh],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/TbarWplusto4Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+            ],
+            n_files=5,
+            n_events=3957160,
+        ),
+        # tune_up=DatasetInfo(
+        #     keys=[
+        #         "/TbarWplusto4Q_TuneCP5Up_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+        #     ],
+        #     n_files=None,
+        #     n_events=None,
+        # ),
+        tune_down=DatasetInfo(
+            keys=[
+                "/TbarWplusto4Q_TuneCP5Down_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+            ],
+            n_files=5,
+            n_events=3971608,
+        ),
+        cr_1=DatasetInfo(
+            keys=[
+                "/TbarWplusto4Q_TuneCP5CR1_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+            ],
+            n_files=5,
+            n_events=3823795,
+        ),
+        cr_2=DatasetInfo(
+            keys=[
+                "/TbarWplusto4Q_TuneCP5CR2_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv11-126X_mcRun3_2022_realistic_v2-v1/NANOAODSIM",
+            ],
+            n_files=5,
+            n_events=3862163,
+        ),
+    ),
+)

--- a/cmsdb/processes/data.py
+++ b/cmsdb/processes/data.py
@@ -5,7 +5,7 @@ Data process definitions.
 """
 
 __all__ = [
-    "data", "data_e", "data_mu", "data_tau", "data_met", "data_pho", "data_jetht",
+    "data", "data_e", "data_mu", "data_tau", "data_met", "data_pho", "data_egamma", "data_jetht",
 ]
 
 from order import Process
@@ -56,6 +56,13 @@ data_pho = data.add_process(
     id=50,
     is_data=True,
     label=r"Data $\gamma$",
+)
+
+data_egamma = data.add_process(
+    name="data_egamma",
+    id=60,
+    is_data=True,
+    label=r"Data $e/\gamma$",
 )
 
 data_jetht = data.add_process(

--- a/cmsdb/processes/qcd.py
+++ b/cmsdb/processes/qcd.py
@@ -33,6 +33,23 @@ qcd = Process(
     xsecs={13: Number(0.1)},  # TODO
 )
 
+
+#
+# QCD (flat sample)
+#
+
+qcd_flat = Process(
+    name="qcd_flat",
+    id=30001,
+    label="QCD",
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+#
+# QCD HT-binned
+#
+
 qcd_ht50to100 = qcd.add_process(
     name="qcd_ht50to100",
     id=31001,
@@ -115,7 +132,131 @@ qcd_ht2000 = qcd.add_process(
 )
 
 #
-# QCD pt-binned (muon enriched)
+# QCD pT-binned
+#
+
+qcd_pt15to30 = qcd.add_process(
+    name="qcd_pt15to30",
+    id=31901,
+    xsecs={
+        13: Number(0.01),  # TODO
+    },
+)
+
+qcd_pt30to50 = qcd.add_process(
+    name="qcd_pt30to50",
+    id=31902,
+    xsecs={
+        13: Number(0.01),  # TODO
+    },
+)
+
+qcd_pt50to80 = qcd.add_process(
+    name="qcd_pt50to80",
+    id=31903,
+    xsecs={
+        13: Number(0.01),  # TODO
+    },
+)
+
+qcd_pt80to120 = qcd.add_process(
+    name="qcd_pt80to120",
+    id=31904,
+    xsecs={
+        13: Number(0.01),  # TODO
+    },
+)
+
+qcd_pt120to170 = qcd.add_process(
+    name="qcd_pt120to170",
+    id=31905,
+    xsecs={
+        13: Number(0.01),  # TODO
+    },
+)
+
+qcd_pt170to300 = qcd.add_process(
+    name="qcd_pt170to300",
+    id=31906,
+    xsecs={
+        13: Number(0.01),  # TODO
+    },
+)
+
+qcd_pt300to470 = qcd.add_process(
+    name="qcd_pt300to470",
+    id=31907,
+    xsecs={
+        13: Number(0.01),  # TODO
+    },
+)
+
+qcd_pt470to600 = qcd.add_process(
+    name="qcd_pt470to600",
+    id=31908,
+    xsecs={
+        13: Number(0.01),  # TODO
+    },
+)
+
+qcd_pt600to800 = qcd.add_process(
+    name="qcd_pt600to800",
+    id=31909,
+    xsecs={
+        13: Number(0.01),  # TODO
+    },
+)
+
+qcd_pt800to1000 = qcd.add_process(
+    name="qcd_pt800to1000",
+    id=31910,
+    xsecs={
+        13: Number(0.01),  # TODO
+    },
+)
+
+qcd_pt1000to1400 = qcd.add_process(
+    name="qcd_pt1000to1400",
+    id=31911,
+    xsecs={
+        13: Number(0.01),  # TODO
+    },
+)
+
+qcd_pt1400to1800 = qcd.add_process(
+    name="qcd_pt1400to1800",
+    id=31912,
+    xsecs={
+        13: Number(0.01),  # TODO
+    },
+)
+
+qcd_pt1800to2400 = qcd.add_process(
+    name="qcd_pt1800to2400",
+    id=31913,
+    xsecs={
+        13: Number(0.01),  # TODO
+    },
+)
+
+qcd_pt2400to3200 = qcd.add_process(
+    name="qcd_pt2400to3200",
+    id=31914,
+    xsecs={
+        13: Number(0.01),  # TODO
+    },
+)
+
+qcd_pt3200 = qcd.add_process(
+    name="qcd_pt3200",
+    id=31915,
+    xsecs={
+        13: Number(0.01),  # TODO
+    },
+)
+
+#
+# QCD pT-binned (muon enriched)
 #
 
 qcd_mu = qcd.add_process(
@@ -222,7 +363,7 @@ qcd_mu_pt1000 = qcd_mu.add_process(
 )
 
 #
-# QCD pt-binned (EM enriched)
+# QCD pT-binned (EM enriched)
 #
 
 qcd_em = qcd.add_process(
@@ -297,7 +438,7 @@ qcd_em_pt300toInf = qcd_em.add_process(
 )
 
 #
-# QCD pt-binned (bcToE)
+# QCD pT-binned (bcToE)
 #
 
 qcd_bctoe = qcd.add_process(

--- a/cmsdb/processes/top.py
+++ b/cmsdb/processes/top.py
@@ -10,6 +10,9 @@ __all__ = [
     "st",
     "st_tchannel", "st_tchannel_t", "st_tchannel_tbar",
     "st_twchannel", "st_twchannel_t", "st_twchannel_tbar",
+    "st_twchannel_t_sl", "st_twchannel_tbar_sl",
+    "st_twchannel_t_dl", "st_twchannel_tbar_dl",
+    "st_twchannel_t_fh", "st_twchannel_tbar_fh",
     "st_schannel", "st_schannel_lep", "st_schannel_had",
     "st_schannel_t", "st_schannel_t_lep", "st_schannel_t_had",
     "st_schannel_tbar", "st_schannel_tbar_lep", "st_schannel_tbar_had",
@@ -153,6 +156,24 @@ st_twchannel_t = st_twchannel.add_process(
     },
 )
 
+st_twchannel_t_sl = st_twchannel_t.add_process(
+    name="st_twchannel_t_sl",
+    id=2211,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+st_twchannel_t_dl = st_twchannel_t.add_process(
+    name="st_twchannel_t_dl",
+    id=2212,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+st_twchannel_t_fh = st_twchannel_t.add_process(
+    name="st_twchannel_t_fh",
+    id=2213,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
 st_twchannel_tbar = st_twchannel.add_process(
     name="st_twchannel_tbar",
     id=2220,
@@ -162,6 +183,24 @@ st_twchannel_tbar = st_twchannel.add_process(
             pdf=1.70,
         )),
     },
+)
+
+st_twchannel_tbar_sl = st_twchannel_tbar.add_process(
+    name="st_twchannel_tbar_sl",
+    id=2221,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+st_twchannel_tbar_dl = st_twchannel_tbar.add_process(
+    name="st_twchannel_tbar_dl",
+    id=2222,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+st_twchannel_tbar_fh = st_twchannel_tbar.add_process(
+    name="st_twchannel_tbar_fh",
+    id=2223,
+    xsecs={13: Number(0.1)},  # TODO
 )
 
 st_schannel = st.add_process(


### PR DESCRIPTION
This PR adds the central NanoAOD v11 samples for the 2022 data taking period of Run3.

The samples are split into two campaigns, `run3_2022_preEE_nano_v11` and `run3_2022_postEE_nano_v11`, corresponding to the data taking before the 2022 ECAL leak (eras `C` & `D`) and after (eras `E`, `F` & `G`).

**Note**: some of the samples have not yet been produced or are still growing in terms of event numbers, so an update in the future will be needed. However, having some structure already in place is useful for first Run3 studies. The number of files and events in this PR have been taken from DAS queries performed on 2023-07-01, and for samples unavailable in DAS at that time only placeholder have been added and commented out.

A number of processes are also added:
* `qcd_pt*`: vanilla (i.e. not lepton-enriched) QCD
* `st_twchannel_(t|tbar)_(sl|dl|fh)`: single top W-associated subprocesses distinguished by decay type
  - in contrast to Run2, there are now separate datasets available consistently for these subprocesses