### PR TITLE
Rename data_pho -> data_gamma.

### DIFF
--- a/cmsdb/campaigns/run2_2017_nano_v9/data.py
+++ b/cmsdb/campaigns/run2_2017_nano_v9/data.py
@@ -333,10 +333,10 @@ cpn.add_dataset(
 #
 
 cpn.add_dataset(
-    name="data_pho_b",
+    name="data_gamma_b",
     id=14226103,
     is_data=True,
-    processes=[procs.data_pho],
+    processes=[procs.data_gamma],
     keys=[
         "/SinglePhoton/Run2017B-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD",
     ],
@@ -348,10 +348,10 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="data_pho_c",
+    name="data_gamma_c",
     id=14226292,
     is_data=True,
-    processes=[procs.data_pho],
+    processes=[procs.data_gamma],
     keys=[
         "/SinglePhoton/Run2017C-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD",
     ],
@@ -363,10 +363,10 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="data_pho_d",
+    name="data_gamma_d",
     id=14226047,
     is_data=True,
-    processes=[procs.data_pho],
+    processes=[procs.data_gamma],
     keys=[
         "/SinglePhoton/Run2017D-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD",
     ],
@@ -378,10 +378,10 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="data_pho_e",
+    name="data_gamma_e",
     id=14226326,
     is_data=True,
-    processes=[procs.data_pho],
+    processes=[procs.data_gamma],
     keys=[
         "/SinglePhoton/Run2017E-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD",
     ],
@@ -393,10 +393,10 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="data_pho_f",
+    name="data_gamma_f",
     id=14226332,
     is_data=True,
-    processes=[procs.data_pho],
+    processes=[procs.data_gamma],
     keys=[
         "/SinglePhoton/Run2017F-UL2017_MiniAODv2_NanoAODv9-v1/NANOAOD",
     ],

--- a/cmsdb/processes/data.py
+++ b/cmsdb/processes/data.py
@@ -5,7 +5,7 @@ Data process definitions.
 """
 
 __all__ = [
-    "data", "data_e", "data_mu", "data_tau", "data_met", "data_pho", "data_jetht",
+    "data", "data_e", "data_mu", "data_tau", "data_met", "data_gamma", "data_jetht",
 ]
 
 from order import Process
@@ -51,8 +51,8 @@ data_met = data.add_process(
     label=r"Data MET",
 )
 
-data_pho = data.add_process(
-    name="data_pho",
+data_gamma = data.add_process(
+    name="data_gamma",
     id=50,
     is_data=True,
     label=r"Data $\gamma$",


### PR DESCRIPTION
With #13 close to being merged (among others, adding the `data_egamma` process), I noticed that the "single photon" process and some datasets are named `data_pho(_*)` which might be a bit inconsistent.

This PR renames all (not many though) occurrence to `data_gamma`.