### PR TITLE
correct paths data samples for campaign 2016 run 2

### DIFF
--- a/cmsdb/campaigns/run2_2016_nano_uhh_v12/data.py
+++ b/cmsdb/campaigns/run2_2016_nano_uhh_v12/data.py
@@ -19,7 +19,7 @@ cpn.add_dataset(
     is_data=True,
     processes=[procs.data_e],
     keys=[
-        "/SingleElectron/Run2016F-UL2016_NanoAODv12-v2/NANOAOD",  # noqa
+        "/SingleElectron/Run2016F-UL2016_MiniAODv2-v2/NANOAOD",  # noqa
     ],
     n_files=4,
     n_events=8858206,
@@ -34,7 +34,7 @@ cpn.add_dataset(
     is_data=True,
     processes=[procs.data_e],
     keys=[
-        "/SingleElectron/Run2016G-UL2016_NanoAODv12-v2/NANOAOD",  # noqa
+        "/SingleElectron/Run2016G-UL2016_MiniAODv2-v2/NANOAOD",  # noqa
     ],
     n_files=64,
     n_events=153363109,
@@ -49,7 +49,7 @@ cpn.add_dataset(
     is_data=True,
     processes=[procs.data_e],
     keys=[
-        "/SingleElectron/Run2016H-UL2016_NanoAODv12-v2/NANOAOD",  # noqa
+        "/SingleElectron/Run2016H-UL2016_MiniAODv2-v2/NANOAOD",  # noqa
     ],
     n_files=56,
     n_events=129021893,
@@ -69,7 +69,7 @@ cpn.add_dataset(
     is_data=True,
     processes=[procs.data_mu],
     keys=[
-        "/SingleMuon/Run2016F-UL2016_NanoAODv12-v2/NANOAOD",  # noqa
+        "/SingleMuon/Run2016F-UL2016_MiniAODv2-v2/NANOAOD",  # noqa
     ],
     n_files=3,
     n_events=8024195,
@@ -84,7 +84,7 @@ cpn.add_dataset(
     is_data=True,
     processes=[procs.data_mu],
     keys=[
-        "/SingleMuon/Run2016G-UL2016_NanoAODv12-v2/NANOAOD",  # noqa
+        "/SingleMuon/Run2016G-UL2016_MiniAODv2-v2/NANOAOD",  # noqa
     ],
     n_files=52,
     n_events=149916849,
@@ -99,7 +99,7 @@ cpn.add_dataset(
     is_data=True,
     processes=[procs.data_mu],
     keys=[
-        "/SingleMuon/Run2016H-UL2016_NanoAODv12-v2/NANOAOD",  # noqa
+        "/SingleMuon/Run2016H-UL2016_MiniAODv2-v2/NANOAOD",  # noqa
     ],
     n_files=62,
     n_events=174035164,
@@ -118,7 +118,7 @@ cpn.add_dataset(
     is_data=True,
     processes=[procs.data_tau],
     keys=[
-        "/Tau/Run2016F-UL2016_NanoAODv12-v1/NANOAOD",  # noqa
+        "/Tau/Run2016F-UL2016_MiniAODv2-v1/NANOAOD",  # noqa
     ],
     n_files=3,
     n_events=4360106,
@@ -133,7 +133,7 @@ cpn.add_dataset(
     is_data=True,
     processes=[procs.data_tau],
     keys=[
-        "/Tau/Run2016G-UL2016_NanoAODv12-v1/NANOAOD",  # noqa
+        "/Tau/Run2016G-UL2016_MiniAODv2-v1/NANOAOD",  # noqa
     ],
     n_files=39,
     n_events=79578661,
@@ -148,7 +148,7 @@ cpn.add_dataset(
     is_data=True,
     processes=[procs.data_tau],
     keys=[
-        "/Tau/Run2016H-UL2016_NanoAODv12-v1/NANOAOD",  # noqa
+        "/Tau/Run2016H-UL2016_MiniAODv2-v1/NANOAOD",  # noqa
     ],
     n_files=39,
     n_events=76758754,
@@ -168,7 +168,7 @@ cpn.add_dataset(
     is_data=True,
     processes=[procs.data_met],
     keys=[
-        "/MET/Run2016F-UL2016_NanoAODv12-v2/NANOAOD",  # noqa
+        "/MET/Run2016F-UL2016_MiniAODv2-v2/NANOAOD",  # noqa
     ],
     n_files=1,
     n_events=1383250,
@@ -183,7 +183,7 @@ cpn.add_dataset(
     is_data=True,
     processes=[procs.data_met],
     keys=[
-        "/MET/Run2016G-UL2016_NanoAODv12-v2/NANOAOD",  # noqa
+        "/MET/Run2016G-UL2016_MiniAODv2-v2/NANOAOD",  # noqa
     ],
     n_files=13,
     n_events=26974131,
@@ -198,7 +198,7 @@ cpn.add_dataset(
     is_data=True,
     processes=[procs.data_met],
     keys=[
-        "/MET/Run2016H-UL2016_NanoAODv12-v2/NANOAOD",  # noqa
+        "/MET/Run2016H-UL2016_MiniAODv2-v2/NANOAOD",  # noqa
     ],
     n_files=18,
     n_events=39773485,


### PR DESCRIPTION
Paths in pnfs are with MiniAOD and not NanoAOD, so corrected.