### PR TITLE
Processes/hh2bbvv

### DIFF
--- a/cmsdb/campaigns/run2_2017_nano_v9/hh2bbww.py
+++ b/cmsdb/campaigns/run2_2017_nano_v9/hh2bbww.py
@@ -12,9 +12,9 @@ from cmsdb.campaigns.run2_2017_nano_v9 import campaign_run2_2017_nano_v9 as cpn
 #
 
 cpn.add_dataset(
-    name="ggHH_kl_0_kt_1_sl_hbbhvv_powheg",
+    name="ggHH_kl_0_kt_1_qqlnu_hbbhvv_powheg",
     id=14057341,
-    processes=[procs.ggHH_kl_0_kt_1_sl_hbbhvv],
+    processes=[procs.ggHH_kl_0_kt_1_qqlnu_hbbhvv],
     keys=[
         "/GluGluToHHTo2B2VLNu2J_node_cHHH0_TuneCP5_PSWeights_13TeV-powheg-pythia8/RunIIFall17NanoAODv7-PU2017_12Apr2018_Nano02Apr2020_102X_mc2017_realistic_v8-v1/NANOAODSIM",  # noqa
     ],
@@ -23,9 +23,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="ggHH_kl_1_kt_1_sl_hbbhvv_powheg",
+    name="ggHH_kl_1_kt_1_qqlnu_hbbhvv_powheg",
     id=14065482,
-    processes=[procs.ggHH_kl_1_kt_1_sl_hbbhvv],
+    processes=[procs.ggHH_kl_1_kt_1_qqlnu_hbbhvv],
     keys=[
         "/GluGluToHHTo2B2VLNu2J_node_cHHH1_TuneCP5_PSWeights_13TeV-powheg-pythia8/RunIIFall17NanoAODv7-PU2017_12Apr2018_Nano02Apr2020_102X_mc2017_realistic_v8-v1/NANOAODSIM", # noqa
     ],
@@ -34,9 +34,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="ggHH_kl_2p45_kt_1_sl_hbbhvv_powheg",
+    name="ggHH_kl_2p45_kt_1_qqlnu_hbbhvv_powheg",
     id=14066581,
-    processes=[procs.ggHH_kl_2p45_kt_1_sl_hbbhvv],
+    processes=[procs.ggHH_kl_2p45_kt_1_qqlnu_hbbhvv],
     keys=[
         "/GluGluToHHTo2B2VLNu2J_node_cHHH2p45_TuneCP5_PSWeights_13TeV-powheg-pythia8/RunIIFall17NanoAODv7-PU2017_12Apr2018_Nano02Apr2020_102X_mc2017_realistic_v8-v1/NANOAODSIM",  # noqa
     ],
@@ -45,9 +45,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="ggHH_kl_5_kt_1_sl_hbbhvv_powheg",
+    name="ggHH_kl_5_kt_1_qqlnu_hbbhvv_powheg",
     id=14058363,
-    processes=[procs.ggHH_kl_5_kt_1_sl_hbbhvv],
+    processes=[procs.ggHH_kl_5_kt_1_qqlnu_hbbhvv],
     keys=[
         "/GluGluToHHTo2B2VLNu2J_node_cHHH5_TuneCP5_PSWeights_13TeV-powheg-pythia8/RunIIFall17NanoAODv7-PU2017_12Apr2018_Nano02Apr2020_102X_mc2017_realistic_v8-v1/NANOAODSIM",  # noqa
     ],
@@ -60,9 +60,9 @@ cpn.add_dataset(
 #
 
 cpn.add_dataset(
-    name="ggHH_kl_0_kt_1_dl_hbbhvv_powheg",
+    name="ggHH_kl_0_kt_1_2l2nu_hbbhvv_powheg",
     id=14062942,
-    processes=[procs.ggHH_kl_0_kt_1_dl_hbbhvv],
+    processes=[procs.ggHH_kl_0_kt_1_2l2nu_hbbhvv],
     keys=[
         "/GluGluToHHTo2B2VTo2L2Nu_node_cHHH0_TuneCP5_PSWeights_13TeV-powheg-pythia8/RunIIFall17NanoAODv7-PU2017_12Apr2018_Nano02Apr2020_102X_mc2017_realistic_v8-v1/NANOAODSIM",  # noqa
     ],
@@ -71,9 +71,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="ggHH_kl_1_kt_1_dl_hbbhvv_powheg",
+    name="ggHH_kl_1_kt_1_2l2nu_hbbhvv_powheg",
     id=14057872,
-    processes=[procs.ggHH_kl_1_kt_1_dl_hbbhvv],
+    processes=[procs.ggHH_kl_1_kt_1_2l2nu_hbbhvv],
     keys=[
         "/GluGluToHHTo2B2VTo2L2Nu_node_cHHH1_TuneCP5_PSWeights_13TeV-powheg-pythia8/RunIIFall17NanoAODv7-PU2017_12Apr2018_Nano02Apr2020_102X_mc2017_realistic_v8-v1/NANOAODSIM",  # noqa
     ],
@@ -82,9 +82,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="ggHH_kl_2p45_kt_1_dl_hbbhvv_powheg",
+    name="ggHH_kl_2p45_kt_1_2l2nu_hbbhvv_powheg",
     id=14057488,
-    processes=[procs.ggHH_kl_2p45_kt_1_dl_hbbhvv],
+    processes=[procs.ggHH_kl_2p45_kt_1_2l2nu_hbbhvv],
     keys=[
         "/GluGluToHHTo2B2VTo2L2Nu_node_cHHH2p45_TuneCP5_PSWeights_13TeV-powheg-pythia8/RunIIFall17NanoAODv7-PU2017_12Apr2018_Nano02Apr2020_102X_mc2017_realistic_v8-v1/NANOAODSIM",  # noqa
     ],
@@ -93,9 +93,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="ggHH_kl_5_kt_1_dl_hbbhvv_powheg",
+    name="ggHH_kl_5_kt_1_2l2nu_hbbhvv_powheg",
     id=14067172,
-    processes=[procs.ggHH_kl_5_kt_1_dl_hbbhvv],
+    processes=[procs.ggHH_kl_5_kt_1_2l2nu_hbbhvv],
     keys=[
         "/GluGluToHHTo2B2VTo2L2Nu_node_cHHH5_TuneCP5_PSWeights_13TeV-powheg-pythia8/RunIIFall17NanoAODv7-PU2017_12Apr2018_Nano02Apr2020_102X_mc2017_realistic_v8-v1/NANOAODSIM",  # noqa
     ],
@@ -108,9 +108,9 @@ cpn.add_dataset(
 #
 
 cpn.add_dataset(
-    name="qqHH_CV_1_C2V_1_kl_1_sl_hbbhvv_madgraph",
+    name="qqHH_CV_1_C2V_1_kl_1_qqlnu_hbbhvv_madgraph",
     id=14152276,
-    processes=[procs.qqHH_CV_1_C2V_1_kl_1_sl_hbbhvv],
+    processes=[procs.qqHH_CV_1_C2V_1_kl_1_qqlnu_hbbhvv],
     keys=[
         "/VBFHHTo2B2WToLNu2J_CV_1_C2V_1_C3_1_dipoleRecoilOff-TuneCP5_PSweights_13TeV-madgraph-pythia8/RunIIFall17NanoAODv7-PU2017_12Apr2018_Nano02Apr2020_102X_mc2017_realistic_v8-v1/NANOAODSIM",  # noqa
     ],
@@ -119,9 +119,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="qqHH_CV_1_C2V_1_kl_0_sl_hbbhvv_madgraph",
+    name="qqHH_CV_1_C2V_1_kl_0_qqlnu_hbbhvv_madgraph",
     id=14153107,
-    processes=[procs.qqHH_CV_1_C2V_1_kl_0_sl_hbbhvv],
+    processes=[procs.qqHH_CV_1_C2V_1_kl_0_qqlnu_hbbhvv],
     keys=[
         "/VBFHHTo2B2WToLNu2J_CV_1_C2V_1_C3_0_dipoleRecoilOff-TuneCP5_PSweights_13TeV-madgraph-pythia8/RunIIFall17NanoAODv7-PU2017_12Apr2018_Nano02Apr2020_102X_mc2017_realistic_v8-v1/NANOAODSIM",  # noqa
     ],
@@ -130,9 +130,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="qqHH_CV_1_C2V_1_kl_2_sl_hbbhvv_madgraph",
+    name="qqHH_CV_1_C2V_1_kl_2_qqlnu_hbbhvv_madgraph",
     id=14152113,
-    processes=[procs.qqHH_CV_1_C2V_1_kl_2_sl_hbbhvv],
+    processes=[procs.qqHH_CV_1_C2V_1_kl_2_qqlnu_hbbhvv],
     keys=[
         "/VBFHHTo2B2WToLNu2J_CV_1_C2V_1_C3_2_dipoleRecoilOff-TuneCP5_PSweights_13TeV-madgraph-pythia8/RunIIFall17NanoAODv7-PU2017_12Apr2018_Nano02Apr2020_102X_mc2017_realistic_v8-v1/NANOAODSIM",  # noqa
     ],
@@ -141,9 +141,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="qqHH_CV_1_C2V_0_kl_1_sl_hbbhvv_madgraph",
+    name="qqHH_CV_1_C2V_0_kl_1_qqlnu_hbbhvv_madgraph",
     id=14154259,
-    processes=[procs.qqHH_CV_1_C2V_0_kl_1_sl_hbbhvv],
+    processes=[procs.qqHH_CV_1_C2V_0_kl_1_qqlnu_hbbhvv],
     keys=[
         "/VBFHHTo2B2WToLNu2J_CV_1_C2V_0_C3_1_dipoleRecoilOff-TuneCP5_PSweights_13TeV-madgraph-pythia8/RunIIFall17NanoAODv7-PU2017_12Apr2018_Nano02Apr2020_102X_mc2017_realistic_v8-v1/NANOAODSIM",  # noqa
     ],
@@ -152,9 +152,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="qqHH_CV_1_C2V_2_kl_1_sl_hbbhvv_madgraph",
+    name="qqHH_CV_1_C2V_2_kl_1_qqlnu_hbbhvv_madgraph",
     id=14149758,
-    processes=[procs.qqHH_CV_1_C2V_2_kl_1_sl_hbbhvv],
+    processes=[procs.qqHH_CV_1_C2V_2_kl_1_qqlnu_hbbhvv],
     keys=[
         "/VBFHHTo2B2WToLNu2J_CV_1_C2V_2_C3_1_dipoleRecoilOff-TuneCP5_PSweights_13TeV-madgraph-pythia8/RunIIFall17NanoAODv7-PU2017_12Apr2018_Nano02Apr2020_102X_mc2017_realistic_v8-v1/NANOAODSIM",  # noqa
     ],
@@ -163,9 +163,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="qqHH_CV_0p5_C2V_1_kl_1_sl_hbbhvv_madgraph",
+    name="qqHH_CV_0p5_C2V_1_kl_1_qqlnu_hbbhvv_madgraph",
     id=14151042,
-    processes=[procs.qqHH_CV_0p5_C2V_1_kl_1_sl_hbbhvv],
+    processes=[procs.qqHH_CV_0p5_C2V_1_kl_1_qqlnu_hbbhvv],
     keys=[
         "/VBFHHTo2B2WToLNu2J_CV_0_5_C2V_1_C3_1_dipoleRecoilOff-TuneCP5_PSweights_13TeV-madgraph-pythia8/RunIIFall17NanoAODv7-PU2017_12Apr2018_Nano02Apr2020_102X_mc2017_realistic_v8-v1/NANOAODSIM",  # noqa
     ],
@@ -174,9 +174,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="qqHH_CV_1p5_C2V_1_kl_1_sl_hbbhvv_madgraph",
+    name="qqHH_CV_1p5_C2V_1_kl_1_qqlnu_hbbhvv_madgraph",
     id=14149171,
-    processes=[procs.qqHH_CV_1p5_C2V_1_kl_1_sl_hbbhvv],
+    processes=[procs.qqHH_CV_1p5_C2V_1_kl_1_qqlnu_hbbhvv],
     keys=[
         "/VBFHHTo2B2WToLNu2J_CV_1_5_C2V_1_C3_1_dipoleRecoilOff-TuneCP5_PSweights_13TeV-madgraph-pythia8/RunIIFall17NanoAODv7-PU2017_12Apr2018_Nano02Apr2020_102X_mc2017_realistic_v8-v1/NANOAODSIM",  # noqa
     ],
@@ -189,9 +189,9 @@ cpn.add_dataset(
 #
 
 cpn.add_dataset(
-    name="qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhvv_madgraph",
+    name="qqHH_CV_0p5_C2V_1_kl_1_2l2nu_hbbhvv_madgraph",
     id=14154110,
-    processes=[procs.qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhvv],
+    processes=[procs.qqHH_CV_0p5_C2V_1_kl_1_2l2nu_hbbhvv],
     keys=[
         "/VBFHHTo2B2VTo2L2Nu_CV_0_5_C2V_1_C3_1_dipoleRecoilOff-TuneCP5_PSweights_13TeV-madgraph-pythia8/RunIIFall17NanoAODv7-PU2017_12Apr2018_Nano02Apr2020_102X_mc2017_realistic_v8-v1/NANOAODSIM",  # noqa
     ],
@@ -200,9 +200,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhvv_madgraph",
+    name="qqHH_CV_1p5_C2V_1_kl_1_2l2nu_hbbhvv_madgraph",
     id=14151539,
-    processes=[procs.qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhvv],
+    processes=[procs.qqHH_CV_1p5_C2V_1_kl_1_2l2nu_hbbhvv],
     keys=[
         "/VBFHHTo2B2VTo2L2Nu_CV_1_5_C2V_1_C3_1_dipoleRecoilOff-TuneCP5_PSweights_13TeV-madgraph-pythia8/RunIIFall17NanoAODv7-PU2017_12Apr2018_Nano02Apr2020_102X_mc2017_realistic_v8-v1/NANOAODSIM",  # noqa
     ],
@@ -211,9 +211,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="qqHH_CV_1_C2V_0_kl_1_dl_hbbhvv_madgraph",
+    name="qqHH_CV_1_C2V_0_kl_1_2l2nu_hbbhvv_madgraph",
     id=14153811,
-    processes=[procs.qqHH_CV_1_C2V_0_kl_1_dl_hbbhvv],
+    processes=[procs.qqHH_CV_1_C2V_0_kl_1_2l2nu_hbbhvv],
     keys=[
         "/VBFHHTo2B2VTo2L2Nu_CV_1_C2V_0_C3_1_dipoleRecoilOff-TuneCP5_PSweights_13TeV-madgraph-pythia8/RunIIFall17NanoAODv7-PU2017_12Apr2018_Nano02Apr2020_102X_mc2017_realistic_v8-v1/NANOAODSIM",  # noqa
     ],
@@ -222,9 +222,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="qqHH_CV_1_C2V_1_kl_0_dl_hbbhvv_madgraph",
+    name="qqHH_CV_1_C2V_1_kl_0_2l2nu_hbbhvv_madgraph",
     id=14151850,
-    processes=[procs.qqHH_CV_1_C2V_1_kl_0_dl_hbbhvv],
+    processes=[procs.qqHH_CV_1_C2V_1_kl_0_2l2nu_hbbhvv],
     keys=[
         "/VBFHHTo2B2VTo2L2Nu_CV_1_C2V_1_C3_0_dipoleRecoilOff-TuneCP5_PSweights_13TeV-madgraph-pythia8/RunIIFall17NanoAODv7-PU2017_12Apr2018_Nano02Apr2020_102X_mc2017_realistic_v8-v1/NANOAODSIM",  # noqa
     ],
@@ -233,9 +233,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="qqHH_CV_1_C2V_1_kl_1_dl_hbbhvv_madgraph",
+    name="qqHH_CV_1_C2V_1_kl_1_2l2nu_hbbhvv_madgraph",
     id=14159390,
-    processes=[procs.qqHH_CV_1_C2V_1_kl_1_dl_hbbhvv],
+    processes=[procs.qqHH_CV_1_C2V_1_kl_1_2l2nu_hbbhvv],
     keys=[
         "/VBFHHTo2B2VTo2L2Nu_CV_1_C2V_1_C3_1_dipoleRecoilOff-TuneCP5_PSweights_13TeV-madgraph-pythia8/RunIIFall17NanoAODv7-PU2017_12Apr2018_Nano02Apr2020_102X_mc2017_realistic_v8-v1/NANOAODSIM",  # noqa
     ],
@@ -244,9 +244,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="qqHH_CV_1_C2V_1_kl_2_dl_hbbhvv_madgraph",
+    name="qqHH_CV_1_C2V_1_kl_2_2l2nu_hbbhvv_madgraph",
     id=14149920,
-    processes=[procs.qqHH_CV_1_C2V_1_kl_2_dl_hbbhvv],
+    processes=[procs.qqHH_CV_1_C2V_1_kl_2_2l2nu_hbbhvv],
     keys=[
         "/VBFHHTo2B2VTo2L2Nu_CV_1_C2V_1_C3_2_dipoleRecoilOff-TuneCP5_PSweights_13TeV-madgraph-pythia8/RunIIFall17NanoAODv7-PU2017_12Apr2018_Nano02Apr2020_102X_mc2017_realistic_v8-v1/NANOAODSIM",  # noqa
     ],
@@ -255,9 +255,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="qqHH_CV_1_C2V_2_kl_1_dl_hbbhvv_madgraph",
+    name="qqHH_CV_1_C2V_2_kl_1_2l2nu_hbbhvv_madgraph",
     id=14153964,
-    processes=[procs.qqHH_CV_1_C2V_2_kl_1_dl_hbbhvv],
+    processes=[procs.qqHH_CV_1_C2V_2_kl_1_2l2nu_hbbhvv],
     keys=[
         "/VBFHHTo2B2VTo2L2Nu_CV_1_C2V_2_C3_1_dipoleRecoilOff-TuneCP5_PSweights_13TeV-madgraph-pythia8/RunIIFall17NanoAODv7-PU2017_12Apr2018_Nano02Apr2020_102X_mc2017_realistic_v8-v1/NANOAODSIM",  # noqa
     ],

--- a/cmsdb/campaigns/run2_2017_nano_v9/hh2bbww.py
+++ b/cmsdb/campaigns/run2_2017_nano_v9/hh2bbww.py
@@ -12,9 +12,9 @@ from cmsdb.campaigns.run2_2017_nano_v9 import campaign_run2_2017_nano_v9 as cpn
 #
 
 cpn.add_dataset(
-    name="ggHH_kl_0_kt_1_sl_hbbhww_powheg",
+    name="ggHH_kl_0_kt_1_sl_hbbhvv_powheg",
     id=14057341,
-    processes=[procs.ggHH_kl_0_kt_1_sl_hbbhww],
+    processes=[procs.ggHH_kl_0_kt_1_sl_hbbhvv],
     keys=[
         "/GluGluToHHTo2B2VLNu2J_node_cHHH0_TuneCP5_PSWeights_13TeV-powheg-pythia8/RunIIFall17NanoAODv7-PU2017_12Apr2018_Nano02Apr2020_102X_mc2017_realistic_v8-v1/NANOAODSIM",  # noqa
     ],
@@ -23,9 +23,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="ggHH_kl_1_kt_1_sl_hbbhww_powheg",
+    name="ggHH_kl_1_kt_1_sl_hbbhvv_powheg",
     id=14065482,
-    processes=[procs.ggHH_kl_1_kt_1_sl_hbbhww],
+    processes=[procs.ggHH_kl_1_kt_1_sl_hbbhvv],
     keys=[
         "/GluGluToHHTo2B2VLNu2J_node_cHHH1_TuneCP5_PSWeights_13TeV-powheg-pythia8/RunIIFall17NanoAODv7-PU2017_12Apr2018_Nano02Apr2020_102X_mc2017_realistic_v8-v1/NANOAODSIM", # noqa
     ],
@@ -34,9 +34,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="ggHH_kl_2p45_kt_1_sl_hbbhww_powheg",
+    name="ggHH_kl_2p45_kt_1_sl_hbbhvv_powheg",
     id=14066581,
-    processes=[procs.ggHH_kl_2p45_kt_1_sl_hbbhww],
+    processes=[procs.ggHH_kl_2p45_kt_1_sl_hbbhvv],
     keys=[
         "/GluGluToHHTo2B2VLNu2J_node_cHHH2p45_TuneCP5_PSWeights_13TeV-powheg-pythia8/RunIIFall17NanoAODv7-PU2017_12Apr2018_Nano02Apr2020_102X_mc2017_realistic_v8-v1/NANOAODSIM",  # noqa
     ],
@@ -45,9 +45,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="ggHH_kl_5_kt_1_sl_hbbhww_powheg",
+    name="ggHH_kl_5_kt_1_sl_hbbhvv_powheg",
     id=14058363,
-    processes=[procs.ggHH_kl_5_kt_1_sl_hbbhww],
+    processes=[procs.ggHH_kl_5_kt_1_sl_hbbhvv],
     keys=[
         "/GluGluToHHTo2B2VLNu2J_node_cHHH5_TuneCP5_PSWeights_13TeV-powheg-pythia8/RunIIFall17NanoAODv7-PU2017_12Apr2018_Nano02Apr2020_102X_mc2017_realistic_v8-v1/NANOAODSIM",  # noqa
     ],
@@ -60,9 +60,9 @@ cpn.add_dataset(
 #
 
 cpn.add_dataset(
-    name="ggHH_kl_0_kt_1_dl_hbbhww_powheg",
+    name="ggHH_kl_0_kt_1_dl_hbbhvv_powheg",
     id=14062942,
-    processes=[procs.ggHH_kl_0_kt_1_dl_hbbhww],
+    processes=[procs.ggHH_kl_0_kt_1_dl_hbbhvv],
     keys=[
         "/GluGluToHHTo2B2VTo2L2Nu_node_cHHH0_TuneCP5_PSWeights_13TeV-powheg-pythia8/RunIIFall17NanoAODv7-PU2017_12Apr2018_Nano02Apr2020_102X_mc2017_realistic_v8-v1/NANOAODSIM",  # noqa
     ],
@@ -71,9 +71,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="ggHH_kl_1_kt_1_dl_hbbhww_powheg",
+    name="ggHH_kl_1_kt_1_dl_hbbhvv_powheg",
     id=14057872,
-    processes=[procs.ggHH_kl_1_kt_1_dl_hbbhww],
+    processes=[procs.ggHH_kl_1_kt_1_dl_hbbhvv],
     keys=[
         "/GluGluToHHTo2B2VTo2L2Nu_node_cHHH1_TuneCP5_PSWeights_13TeV-powheg-pythia8/RunIIFall17NanoAODv7-PU2017_12Apr2018_Nano02Apr2020_102X_mc2017_realistic_v8-v1/NANOAODSIM",  # noqa
     ],
@@ -82,9 +82,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="ggHH_kl_2p45_kt_1_dl_hbbhww_powheg",
+    name="ggHH_kl_2p45_kt_1_dl_hbbhvv_powheg",
     id=14057488,
-    processes=[procs.ggHH_kl_2p45_kt_1_dl_hbbhww],
+    processes=[procs.ggHH_kl_2p45_kt_1_dl_hbbhvv],
     keys=[
         "/GluGluToHHTo2B2VTo2L2Nu_node_cHHH2p45_TuneCP5_PSWeights_13TeV-powheg-pythia8/RunIIFall17NanoAODv7-PU2017_12Apr2018_Nano02Apr2020_102X_mc2017_realistic_v8-v1/NANOAODSIM",  # noqa
     ],
@@ -93,9 +93,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="ggHH_kl_5_kt_1_dl_hbbhww_powheg",
+    name="ggHH_kl_5_kt_1_dl_hbbhvv_powheg",
     id=14067172,
-    processes=[procs.ggHH_kl_5_kt_1_dl_hbbhww],
+    processes=[procs.ggHH_kl_5_kt_1_dl_hbbhvv],
     keys=[
         "/GluGluToHHTo2B2VTo2L2Nu_node_cHHH5_TuneCP5_PSWeights_13TeV-powheg-pythia8/RunIIFall17NanoAODv7-PU2017_12Apr2018_Nano02Apr2020_102X_mc2017_realistic_v8-v1/NANOAODSIM",  # noqa
     ],
@@ -108,9 +108,9 @@ cpn.add_dataset(
 #
 
 cpn.add_dataset(
-    name="qqHH_CV_1_C2V_1_kl_1_sl_hbbhww_madgraph",
+    name="qqHH_CV_1_C2V_1_kl_1_sl_hbbhvv_madgraph",
     id=14152276,
-    processes=[procs.qqHH_CV_1_C2V_1_kl_1_sl_hbbhww],
+    processes=[procs.qqHH_CV_1_C2V_1_kl_1_sl_hbbhvv],
     keys=[
         "/VBFHHTo2B2WToLNu2J_CV_1_C2V_1_C3_1_dipoleRecoilOff-TuneCP5_PSweights_13TeV-madgraph-pythia8/RunIIFall17NanoAODv7-PU2017_12Apr2018_Nano02Apr2020_102X_mc2017_realistic_v8-v1/NANOAODSIM",  # noqa
     ],
@@ -119,9 +119,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="qqHH_CV_1_C2V_1_kl_0_sl_hbbhww_madgraph",
+    name="qqHH_CV_1_C2V_1_kl_0_sl_hbbhvv_madgraph",
     id=14153107,
-    processes=[procs.qqHH_CV_1_C2V_1_kl_0_sl_hbbhww],
+    processes=[procs.qqHH_CV_1_C2V_1_kl_0_sl_hbbhvv],
     keys=[
         "/VBFHHTo2B2WToLNu2J_CV_1_C2V_1_C3_0_dipoleRecoilOff-TuneCP5_PSweights_13TeV-madgraph-pythia8/RunIIFall17NanoAODv7-PU2017_12Apr2018_Nano02Apr2020_102X_mc2017_realistic_v8-v1/NANOAODSIM",  # noqa
     ],
@@ -130,9 +130,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="qqHH_CV_1_C2V_1_kl_2_sl_hbbhww_madgraph",
+    name="qqHH_CV_1_C2V_1_kl_2_sl_hbbhvv_madgraph",
     id=14152113,
-    processes=[procs.qqHH_CV_1_C2V_1_kl_2_sl_hbbhww],
+    processes=[procs.qqHH_CV_1_C2V_1_kl_2_sl_hbbhvv],
     keys=[
         "/VBFHHTo2B2WToLNu2J_CV_1_C2V_1_C3_2_dipoleRecoilOff-TuneCP5_PSweights_13TeV-madgraph-pythia8/RunIIFall17NanoAODv7-PU2017_12Apr2018_Nano02Apr2020_102X_mc2017_realistic_v8-v1/NANOAODSIM",  # noqa
     ],
@@ -141,9 +141,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="qqHH_CV_1_C2V_0_kl_1_sl_hbbhww_madgraph",
+    name="qqHH_CV_1_C2V_0_kl_1_sl_hbbhvv_madgraph",
     id=14154259,
-    processes=[procs.qqHH_CV_1_C2V_0_kl_1_sl_hbbhww],
+    processes=[procs.qqHH_CV_1_C2V_0_kl_1_sl_hbbhvv],
     keys=[
         "/VBFHHTo2B2WToLNu2J_CV_1_C2V_0_C3_1_dipoleRecoilOff-TuneCP5_PSweights_13TeV-madgraph-pythia8/RunIIFall17NanoAODv7-PU2017_12Apr2018_Nano02Apr2020_102X_mc2017_realistic_v8-v1/NANOAODSIM",  # noqa
     ],
@@ -152,9 +152,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="qqHH_CV_1_C2V_2_kl_1_sl_hbbhww_madgraph",
+    name="qqHH_CV_1_C2V_2_kl_1_sl_hbbhvv_madgraph",
     id=14149758,
-    processes=[procs.qqHH_CV_1_C2V_2_kl_1_sl_hbbhww],
+    processes=[procs.qqHH_CV_1_C2V_2_kl_1_sl_hbbhvv],
     keys=[
         "/VBFHHTo2B2WToLNu2J_CV_1_C2V_2_C3_1_dipoleRecoilOff-TuneCP5_PSweights_13TeV-madgraph-pythia8/RunIIFall17NanoAODv7-PU2017_12Apr2018_Nano02Apr2020_102X_mc2017_realistic_v8-v1/NANOAODSIM",  # noqa
     ],
@@ -163,9 +163,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="qqHH_CV_0p5_C2V_1_kl_1_sl_hbbhww_madgraph",
+    name="qqHH_CV_0p5_C2V_1_kl_1_sl_hbbhvv_madgraph",
     id=14151042,
-    processes=[procs.qqHH_CV_0p5_C2V_1_kl_1_sl_hbbhww],
+    processes=[procs.qqHH_CV_0p5_C2V_1_kl_1_sl_hbbhvv],
     keys=[
         "/VBFHHTo2B2WToLNu2J_CV_0_5_C2V_1_C3_1_dipoleRecoilOff-TuneCP5_PSweights_13TeV-madgraph-pythia8/RunIIFall17NanoAODv7-PU2017_12Apr2018_Nano02Apr2020_102X_mc2017_realistic_v8-v1/NANOAODSIM",  # noqa
     ],
@@ -174,9 +174,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="qqHH_CV_1p5_C2V_1_kl_1_sl_hbbhww_madgraph",
+    name="qqHH_CV_1p5_C2V_1_kl_1_sl_hbbhvv_madgraph",
     id=14149171,
-    processes=[procs.qqHH_CV_1p5_C2V_1_kl_1_sl_hbbhww],
+    processes=[procs.qqHH_CV_1p5_C2V_1_kl_1_sl_hbbhvv],
     keys=[
         "/VBFHHTo2B2WToLNu2J_CV_1_5_C2V_1_C3_1_dipoleRecoilOff-TuneCP5_PSweights_13TeV-madgraph-pythia8/RunIIFall17NanoAODv7-PU2017_12Apr2018_Nano02Apr2020_102X_mc2017_realistic_v8-v1/NANOAODSIM",  # noqa
     ],
@@ -189,9 +189,9 @@ cpn.add_dataset(
 #
 
 cpn.add_dataset(
-    name="qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhww_madgraph",
+    name="qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhvv_madgraph",
     id=14154110,
-    processes=[procs.qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhww],
+    processes=[procs.qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhvv],
     keys=[
         "/VBFHHTo2B2VTo2L2Nu_CV_0_5_C2V_1_C3_1_dipoleRecoilOff-TuneCP5_PSweights_13TeV-madgraph-pythia8/RunIIFall17NanoAODv7-PU2017_12Apr2018_Nano02Apr2020_102X_mc2017_realistic_v8-v1/NANOAODSIM",  # noqa
     ],
@@ -200,9 +200,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhww_madgraph",
+    name="qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhvv_madgraph",
     id=14151539,
-    processes=[procs.qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhww],
+    processes=[procs.qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhvv],
     keys=[
         "/VBFHHTo2B2VTo2L2Nu_CV_1_5_C2V_1_C3_1_dipoleRecoilOff-TuneCP5_PSweights_13TeV-madgraph-pythia8/RunIIFall17NanoAODv7-PU2017_12Apr2018_Nano02Apr2020_102X_mc2017_realistic_v8-v1/NANOAODSIM",  # noqa
     ],
@@ -211,9 +211,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="qqHH_CV_1_C2V_0_kl_1_dl_hbbhww_madgraph",
+    name="qqHH_CV_1_C2V_0_kl_1_dl_hbbhvv_madgraph",
     id=14153811,
-    processes=[procs.qqHH_CV_1_C2V_0_kl_1_dl_hbbhww],
+    processes=[procs.qqHH_CV_1_C2V_0_kl_1_dl_hbbhvv],
     keys=[
         "/VBFHHTo2B2VTo2L2Nu_CV_1_C2V_0_C3_1_dipoleRecoilOff-TuneCP5_PSweights_13TeV-madgraph-pythia8/RunIIFall17NanoAODv7-PU2017_12Apr2018_Nano02Apr2020_102X_mc2017_realistic_v8-v1/NANOAODSIM",  # noqa
     ],
@@ -222,9 +222,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="qqHH_CV_1_C2V_1_kl_0_dl_hbbhww_madgraph",
+    name="qqHH_CV_1_C2V_1_kl_0_dl_hbbhvv_madgraph",
     id=14151850,
-    processes=[procs.qqHH_CV_1_C2V_1_kl_0_dl_hbbhww],
+    processes=[procs.qqHH_CV_1_C2V_1_kl_0_dl_hbbhvv],
     keys=[
         "/VBFHHTo2B2VTo2L2Nu_CV_1_C2V_1_C3_0_dipoleRecoilOff-TuneCP5_PSweights_13TeV-madgraph-pythia8/RunIIFall17NanoAODv7-PU2017_12Apr2018_Nano02Apr2020_102X_mc2017_realistic_v8-v1/NANOAODSIM",  # noqa
     ],
@@ -233,9 +233,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="qqHH_CV_1_C2V_1_kl_1_dl_hbbhww_madgraph",
+    name="qqHH_CV_1_C2V_1_kl_1_dl_hbbhvv_madgraph",
     id=14159390,
-    processes=[procs.qqHH_CV_1_C2V_1_kl_1_dl_hbbhww],
+    processes=[procs.qqHH_CV_1_C2V_1_kl_1_dl_hbbhvv],
     keys=[
         "/VBFHHTo2B2VTo2L2Nu_CV_1_C2V_1_C3_1_dipoleRecoilOff-TuneCP5_PSweights_13TeV-madgraph-pythia8/RunIIFall17NanoAODv7-PU2017_12Apr2018_Nano02Apr2020_102X_mc2017_realistic_v8-v1/NANOAODSIM",  # noqa
     ],
@@ -244,9 +244,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="qqHH_CV_1_C2V_1_kl_2_dl_hbbhww_madgraph",
+    name="qqHH_CV_1_C2V_1_kl_2_dl_hbbhvv_madgraph",
     id=14149920,
-    processes=[procs.qqHH_CV_1_C2V_1_kl_2_dl_hbbhww],
+    processes=[procs.qqHH_CV_1_C2V_1_kl_2_dl_hbbhvv],
     keys=[
         "/VBFHHTo2B2VTo2L2Nu_CV_1_C2V_1_C3_2_dipoleRecoilOff-TuneCP5_PSweights_13TeV-madgraph-pythia8/RunIIFall17NanoAODv7-PU2017_12Apr2018_Nano02Apr2020_102X_mc2017_realistic_v8-v1/NANOAODSIM",  # noqa
     ],
@@ -255,9 +255,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="qqHH_CV_1_C2V_2_kl_1_dl_hbbhww_madgraph",
+    name="qqHH_CV_1_C2V_2_kl_1_dl_hbbhvv_madgraph",
     id=14153964,
-    processes=[procs.qqHH_CV_1_C2V_2_kl_1_dl_hbbhww],
+    processes=[procs.qqHH_CV_1_C2V_2_kl_1_dl_hbbhvv],
     keys=[
         "/VBFHHTo2B2VTo2L2Nu_CV_1_C2V_2_C3_1_dipoleRecoilOff-TuneCP5_PSweights_13TeV-madgraph-pythia8/RunIIFall17NanoAODv7-PU2017_12Apr2018_Nano02Apr2020_102X_mc2017_realistic_v8-v1/NANOAODSIM",  # noqa
     ],

--- a/cmsdb/campaigns/run3_2022_postEE_nano_v12/hh2bbww.py
+++ b/cmsdb/campaigns/run3_2022_postEE_nano_v12/hh2bbww.py
@@ -12,26 +12,25 @@ from cmsdb.campaigns.run3_2022_postEE_nano_v12 import campaign_run3_2022_postEE_
 # ggf, HH -> bbVV inclusive
 #
 
-# commented out since the corresponding process is missing
-# cpn.add_dataset(
-#     name="ggHH_kl_1_kt_1_hbbhww_powheg",
-#     id=14857512,
-#     processes=[procs.ggHH_kl_1_kt_1_hbbhww],
-#     keys=[
-#         "/GluGlutoHHto2B2V_kl-1p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v3/NANOAODSIM",  # noqa
-#     ],
-#     n_files=40,
-#     n_events=769320,
-# )
+cpn.add_dataset(
+    name="ggHH_kl_1_kt_1_hbbhvv_powheg",
+    id=14857512,
+    processes=[procs.ggHH_kl_1_kt_1_hbbhvv],
+    keys=[
+        "/GluGlutoHHto2B2V_kl-1p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v3/NANOAODSIM",  # noqa
+    ],
+    n_files=40,
+    n_events=769320,
+)
 
 #
 # ggf, HH -> bbVV single lepton
 #
 
 cpn.add_dataset(
-    name="ggHH_kl_1_kt_1_sl_hbbhww_powheg",
+    name="ggHH_kl_1_kt_1_sl_hbbhvv_powheg",
     id=14870918,
-    processes=[procs.ggHH_kl_1_kt_1_sl_hbbhww],
+    processes=[procs.ggHH_kl_1_kt_1_sl_hbbhvv],
     keys=[
         "/GluGlutoHHto2B2WtoLNu2Q_kl-1p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v3/NANOAODSIM",  # noqa
     ],
@@ -44,9 +43,9 @@ cpn.add_dataset(
 #
 
 cpn.add_dataset(
-    name="ggHH_kl_1_kt_1_dl_hbbhww_powheg",
+    name="ggHH_kl_1_kt_1_dl_hbbhvv_powheg",
     id=14857784,
-    processes=[procs.ggHH_kl_1_kt_1_dl_hbbhww],
+    processes=[procs.ggHH_kl_1_kt_1_dl_hbbhvv],
     keys=[
         "/GluGlutoHHto2B2Vto2L2Nu_kl-1p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
     ],

--- a/cmsdb/campaigns/run3_2022_postEE_nano_v12/hh2bbww.py
+++ b/cmsdb/campaigns/run3_2022_postEE_nano_v12/hh2bbww.py
@@ -28,9 +28,9 @@ cpn.add_dataset(
 #
 
 cpn.add_dataset(
-    name="ggHH_kl_1_kt_1_sl_hbbhvv_powheg",
+    name="ggHH_kl_1_kt_1_qqlnu_hbbhvv_powheg",
     id=14870918,
-    processes=[procs.ggHH_kl_1_kt_1_sl_hbbhvv],
+    processes=[procs.ggHH_kl_1_kt_1_qqlnu_hbbhvv],
     keys=[
         "/GluGlutoHHto2B2WtoLNu2Q_kl-1p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v3/NANOAODSIM",  # noqa
     ],
@@ -43,9 +43,9 @@ cpn.add_dataset(
 #
 
 cpn.add_dataset(
-    name="ggHH_kl_1_kt_1_dl_hbbhvv_powheg",
+    name="ggHH_kl_1_kt_1_2l2nu_hbbhvv_powheg",
     id=14857784,
-    processes=[procs.ggHH_kl_1_kt_1_dl_hbbhvv],
+    processes=[procs.ggHH_kl_1_kt_1_2l2nu_hbbhvv],
     keys=[
         "/GluGlutoHHto2B2Vto2L2Nu_kl-1p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
     ],

--- a/cmsdb/campaigns/run3_2022_preEE_nano_v12/hh2bbww.py
+++ b/cmsdb/campaigns/run3_2022_preEE_nano_v12/hh2bbww.py
@@ -27,9 +27,9 @@ cpn.add_dataset(
 #
 
 cpn.add_dataset(
-    name="ggHH_kl_1_kt_1_sl_hbbhvv_powheg",
+    name="ggHH_kl_1_kt_1_qqlnu_hbbhvv_powheg",
     id=14868316,
-    processes=[procs.ggHH_kl_1_kt_1_sl_hbbhvv],
+    processes=[procs.ggHH_kl_1_kt_1_qqlnu_hbbhvv],
     keys=[
         "/GluGlutoHHto2B2WtoLNu2Q_kl-1p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
     ],
@@ -42,9 +42,9 @@ cpn.add_dataset(
 #
 
 cpn.add_dataset(
-    name="ggHH_kl_1_kt_1_dl_hbbhvv_powheg",
+    name="ggHH_kl_1_kt_1_2l2nu_hbbhvv_powheg",
     id=14847284,
-    processes=[procs.ggHH_kl_1_kt_1_dl_hbbhvv],
+    processes=[procs.ggHH_kl_1_kt_1_2l2nu_hbbhvv],
     keys=[
         "/GluGlutoHHto2B2Vto2L2Nu_kl-1p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v1/NANOAODSIM",  # noqa
     ],

--- a/cmsdb/campaigns/run3_2022_preEE_nano_v12/hh2bbww.py
+++ b/cmsdb/campaigns/run3_2022_preEE_nano_v12/hh2bbww.py
@@ -11,26 +11,25 @@ from cmsdb.campaigns.run3_2022_preEE_nano_v12 import campaign_run3_2022_preEE_na
 # ggf, HH -> bbVV inclusive
 #
 
-# commented out since the corresponding process is missing
-# cpn.add_dataset(
-#     name="ggHH_kl_1_kt_1_hbbhww_powheg",
-#     id=14863914,
-#     processes=[procs.ggHH_kl_1_kt_1_hbbhww],
-#     keys=[
-#         "/GluGlutoHHto2B2V_kl-1p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v3/NANOAODSIM",  # noqa
-#     ],
-#     n_files=48,
-#     n_events=229178,
-# )
+cpn.add_dataset(
+    name="ggHH_kl_1_kt_1_hbbhvv_powheg",
+    id=14863914,
+    processes=[procs.ggHH_kl_1_kt_1_hbbhvv],
+    keys=[
+        "/GluGlutoHHto2B2V_kl-1p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v3/NANOAODSIM",  # noqa
+    ],
+    n_files=48,
+    n_events=229178,
+)
 
 #
 # ggf, HH -> bbVV single lepton
 #
 
 cpn.add_dataset(
-    name="ggHH_kl_1_kt_1_sl_hbbhww_powheg",
+    name="ggHH_kl_1_kt_1_sl_hbbhvv_powheg",
     id=14868316,
-    processes=[procs.ggHH_kl_1_kt_1_sl_hbbhww],
+    processes=[procs.ggHH_kl_1_kt_1_sl_hbbhvv],
     keys=[
         "/GluGlutoHHto2B2WtoLNu2Q_kl-1p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
     ],
@@ -43,9 +42,9 @@ cpn.add_dataset(
 #
 
 cpn.add_dataset(
-    name="ggHH_kl_1_kt_1_dl_hbbhww_powheg",
+    name="ggHH_kl_1_kt_1_dl_hbbhvv_powheg",
     id=14847284,
-    processes=[procs.ggHH_kl_1_kt_1_dl_hbbhww],
+    processes=[procs.ggHH_kl_1_kt_1_dl_hbbhvv],
     keys=[
         "/GluGlutoHHto2B2Vto2L2Nu_kl-1p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v1/NANOAODSIM",  # noqa
     ],

--- a/cmsdb/constants/__init__.py
+++ b/cmsdb/constants/__init__.py
@@ -33,10 +33,15 @@ br_z = DotDict(
     qq=Number(0.69911, {"br_z_qq": 0.00056}),
     clep=Number(0.033658, {"br_z_clep": 0.000023}) * n_leps,
 )
+br_z.nunu = 1 - br_z.qq - br_z.clep
 
 br_zz = DotDict(
-    fh=br_z.qq ** 2,
-    dl=2 * br_z.qq * br_z.clep,
+    qqqq=br_z.qq ** 2,
+    llll=br_z.clep ** 2,
+    nunununu=br_z.nunu ** 2,
+    llnunu=2 * br_z.nunu * br_z.clep,
+    llqq=2 * br_z.clep * br_z.qq,
+    qqnunu=2 * br_z.qq * br_z.nunu,
 )
 
 # higgs branching ratios from lhchwg, taken for mH = 125GeV

--- a/cmsdb/constants/__init__.py
+++ b/cmsdb/constants/__init__.py
@@ -34,6 +34,11 @@ br_z = DotDict(
     clep=Number(0.033658, {"br_z_clep": 0.000023}) * n_leps,
 )
 
+br_zz = DotDict(
+    fh=br_z.qq ** 2,
+    dl=2 * br_z.qq * br_z.clep,
+)
+
 # higgs branching ratios from lhchwg, taken for mH = 125GeV
 # https://twiki.cern.ch/twiki/bin/view/LHCPhysics/CERNYellowReportPageBR?rev=23
 

--- a/cmsdb/processes/hh2bbww.py
+++ b/cmsdb/processes/hh2bbww.py
@@ -20,6 +20,13 @@ __all__ = [
     "qqHH_CV_0p5_C2V_1_kl_1_hbbhvv", "qqHH_CV_1p5_C2V_1_kl_1_hbbhvv",
     "qqHH_CV_1_C2V_0_kl_1_hbbhvv", "qqHH_CV_1_C2V_1_kl_0_hbbhvv", "qqHH_CV_1_C2V_1_kl_1_hbbhvv",
     "qqHH_CV_1_C2V_1_kl_2_hbbhvv", "qqHH_CV_1_C2V_2_kl_1_hbbhvv",
+    # HH -> bbVV(2l2v), ggf
+    "ggHH_dl_hbbhvv", "ggHH_kl_0_kt_1_dl_hbbhvv", "ggHH_kl_1_kt_1_dl_hbbhvv",
+    "ggHH_kl_2p45_kt_1_dl_hbbhvv", "ggHH_kl_5_kt_1_dl_hbbhvv",
+    # HH -> bbVV(2l2v), vbf
+    "qqHH_dl_hbbhvv", "qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhvv", "qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhvv",
+    "qqHH_CV_1_C2V_0_kl_1_dl_hbbhvv", "qqHH_CV_1_C2V_1_kl_0_dl_hbbhvv", "qqHH_CV_1_C2V_1_kl_1_dl_hbbhvv",
+    "qqHH_CV_1_C2V_1_kl_2_dl_hbbhvv", "qqHH_CV_1_C2V_2_kl_1_dl_hbbhvv",
     # HH -> bbWW(qqlv), ggf
     "ggHH_sl_hbbhww", "ggHH_kl_0_kt_1_sl_hbbhww", "ggHH_kl_1_kt_1_sl_hbbhww",
     "ggHH_kl_2p45_kt_1_sl_hbbhww", "ggHH_kl_5_kt_1_sl_hbbhww",
@@ -229,6 +236,121 @@ qqHH_hbbhvv.add_process(qqHH_CV_1_C2V_0_kl_1_hbbhvv)
 qqHH_hbbhvv.add_process(qqHH_CV_1_C2V_2_kl_1_hbbhvv)
 qqHH_hbbhvv.add_process(qqHH_CV_0p5_C2V_1_kl_1_hbbhvv)
 qqHH_hbbhvv.add_process(qqHH_CV_1p5_C2V_1_kl_1_hbbhvv)
+
+#
+# HH -> bbVV(2l2v), ggf
+#
+
+ggHH_dl_hbbhvv = ggHH_hbbhvv.add_process(
+    name="ggHH_dl_hbbhvv",
+    id=21320,
+    label=r"$HH_{ggf} \rightarrow bbVV(2l2\nu)$",
+)
+
+ggHH_kl_0_kt_1_dl_hbbhvv = ggHH_kl_0_kt_1.add_process(
+    name="ggHH_kl_0_kt_1_dl_hbbhvv",
+    id=21321,
+    label=r"$HH_{ggf}^{\kappa\lambda=0} \rightarrow bbVV(2l2\nu)$",
+    xsecs=multiply_xsecs(ggHH_kl_0_kt_1, br_bbvv_dl),
+)
+
+ggHH_kl_1_kt_1_dl_hbbhvv = ggHH_kl_1_kt_1.add_process(
+    name="ggHH_kl_1_kt_1_dl_hbbhvv",
+    label=r"$HH_{ggf}^{\kappa\lambda=1} \rightarrow bbVV(2l2\nu)$",
+    id=21322,
+    xsecs=multiply_xsecs(ggHH_kl_1_kt_1, br_bbvv_dl),
+)
+
+ggHH_kl_2p45_kt_1_dl_hbbhvv = ggHH_kl_2p45_kt_1.add_process(
+    name="ggHH_kl_2p45_kt_1_dl_hbbhvv",
+    label=r"$HH_{ggf}^{\kappa\lambda=2.45} \rightarrow bbVV(2l2\nu)$",
+    id=21323,
+    xsecs=multiply_xsecs(ggHH_kl_2p45_kt_1, br_bbvv_dl),
+)
+
+ggHH_kl_5_kt_1_dl_hbbhvv = ggHH_kl_5_kt_1.add_process(
+    name="ggHH_kl_5_kt_1_dl_hbbhvv",
+    label=r"$HH_{ggf}^{\kappa\lambda=5} \rightarrow bbVV(2l2\nu)$",
+    id=21324,
+    xsecs=multiply_xsecs(ggHH_kl_5_kt_1, br_bbvv_dl),
+)
+
+
+# add process dependencies
+ggHH_dl_hbbhvv.add_process(ggHH_kl_0_kt_1_dl_hbbhvv)
+ggHH_dl_hbbhvv.add_process(ggHH_kl_1_kt_1_dl_hbbhvv)
+ggHH_dl_hbbhvv.add_process(ggHH_kl_2p45_kt_1_dl_hbbhvv)
+ggHH_dl_hbbhvv.add_process(ggHH_kl_5_kt_1_dl_hbbhvv)
+
+
+#
+# HH -> bbVV(2l2v), vbf
+#
+
+qqHH_dl_hbbhvv = qqHH_hbbhvv.add_process(
+    name="qqHH_dl_hbbhvv",
+    label=r"$HH_{vbf} \rightarrow bbVV(2l2\nu)$",
+    id=22420,
+)
+
+qqHH_CV_1_C2V_1_kl_1_dl_hbbhvv = qqHH_CV_1_C2V_1_kl_1.add_process(
+    name="qqHH_CV_1_C2V_1_kl_1_dl_hbbhvv",
+    label=r"$HH_{vbf}^{1,1,1} \rightarrow bbVV(2l2\nu)$",
+    id=22421,
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_1, br_bbvv_dl),
+)
+
+qqHH_CV_1_C2V_1_kl_0_dl_hbbhvv = qqHH_CV_1_C2V_1_kl_0.add_process(
+    name="qqHH_CV_1_C2V_1_kl_0_dl_hbbhvv",
+    label=r"$HH_{vbf}^{1,1,0} \rightarrow bbVV(2l2\nu)$",
+    id=22422,
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_0, br_bbvv_dl),
+)
+
+qqHH_CV_1_C2V_1_kl_2_dl_hbbhvv = qqHH_CV_1_C2V_1_kl_2.add_process(
+    name="qqHH_CV_1_C2V_1_kl_2_dl_hbbhvv",
+    label=r"$HH_{vbf}^{1,1,2} \rightarrow bbVV(2l2\nu)$",
+    id=22423,
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_2, br_bbvv_dl),
+)
+
+qqHH_CV_1_C2V_0_kl_1_dl_hbbhvv = qqHH_CV_1_C2V_0_kl_1.add_process(
+    name="qqHH_CV_1_C2V_0_kl_1_dl_hbbhvv",
+    label=r"$HH_{vbf}^{1,0,1} \rightarrow bbVV(2l2\nu)$",
+    id=22424,
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_0_kl_1, br_bbvv_dl),
+)
+
+qqHH_CV_1_C2V_2_kl_1_dl_hbbhvv = qqHH_CV_1_C2V_2_kl_1.add_process(
+    name="qqHH_CV_1_C2V_2_kl_1_dl_hbbhvv",
+    label=r"$HH_{vbf}^{1,2,1} \rightarrow bbVV(2l2\nu)$",
+    id=22425,
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_2_kl_1, br_bbvv_dl),
+)
+
+qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhvv = qqHH_CV_0p5_C2V_1_kl_1.add_process(
+    name="qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhvv",
+    label=r"$HH_{vbf}^{0.5,1,1} \rightarrow bbVV(2l2\nu)$",
+    id=22426,
+    xsecs=multiply_xsecs(qqHH_CV_0p5_C2V_1_kl_1, br_bbvv_dl),
+)
+
+qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhvv = qqHH_CV_1p5_C2V_1_kl_1.add_process(
+    name="qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhvv",
+    label=r"$HH_{vbf}^{1.5,1,1} \rightarrow bbVV(2l2\nu)$",
+    id=22427,
+    xsecs=multiply_xsecs(qqHH_CV_1p5_C2V_1_kl_1, br_bbvv_dl),
+)
+
+# add process dependencies
+qqHH_dl_hbbhvv.add_process(qqHH_CV_1_C2V_1_kl_1_dl_hbbhvv)
+qqHH_dl_hbbhvv.add_process(qqHH_CV_1_C2V_1_kl_0_dl_hbbhvv)
+qqHH_dl_hbbhvv.add_process(qqHH_CV_1_C2V_1_kl_2_dl_hbbhvv)
+qqHH_dl_hbbhvv.add_process(qqHH_CV_1_C2V_0_kl_1_dl_hbbhvv)
+qqHH_dl_hbbhvv.add_process(qqHH_CV_1_C2V_2_kl_1_dl_hbbhvv)
+qqHH_dl_hbbhvv.add_process(qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhvv)
+qqHH_dl_hbbhvv.add_process(qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhvv)
+
 
 #
 # HH -> bbWW(qqlv), ggf

--- a/cmsdb/processes/hh2bbww.py
+++ b/cmsdb/processes/hh2bbww.py
@@ -1,7 +1,14 @@
 # coding: utf-8
 
 """
-HH -> bbWW process definitions.
+HH -> bbVV process definitions.
+
+IDs are assigned in the range 21200-21499 for ggHH and 22200-22499 for qqHH.
+bbWW processes are assigned IDs in the range 21200-21299 and 22200-22299.
+bbZZ processes are assigned IDs in the range 21300-21399 and 22300-22399.
+bbVV processes are assigned IDs in the range 21400-21499 and 22400-22499.
+SL processes are assigned the ranges from 10-19 and DL processes from 20-29 (FH still missing)
+The merged processes are assigned the ranges from 1-9.
 """
 
 __all__ = [
@@ -78,6 +85,7 @@ from cmsdb.processes.higgs import (
 #
 
 br_bbvv = const.br_hh.bbww + const.br_hh.bbzz
+br_bbvv_dl = const.br_hh.bbww * const.br_ww.dl + const.br_hh.bbzz * const.br_z.clep ** 2
 br_bbww_sl = const.br_hh.bbww * const.br_ww.sl
 br_bbww_dl = const.br_hh.bbww * const.br_ww.dl
 br_bbzz_dl = const.br_hh.bbzz * const.br_ww.dl
@@ -88,13 +96,13 @@ br_bbzz_dl = const.br_hh.bbzz * const.br_ww.dl
 
 ggHH_hbbhvv = hh_ggf.add_process(
     name="ggHH_hbbhvv",
-    id=-1,
+    id=21400,
     label=r"$HH_{ggf} \rightarrow bbVV$",
 )
 
 qqHH_hbbhvv = hh_vbf.add_process(
     name="qqHH_hbbhvv",
-    id=-1,
+    id=22400,
     label=r"$HH_{vbf} \rightarrow bbVV$",
 )
 
@@ -106,19 +114,19 @@ ggHH_hbbhww = ggHH_hbbhvv.add_process(
 
 qqHH_hbbhww = qqHH_hbbhvv.add_process(
     name="qqHH_hbbhww",
-    id=21201,
+    id=22200,
     label=r"$HH_{vbf} \rightarrow bbWW$",
 )
 
 ggHH_hbbhzz = ggHH_hbbhvv.add_process(
     name="ggHH_hbbhzz",
-    id=-1,
+    id=21300,
     label=r"$HH_{ggf} \rightarrow bbZZ$",
 )
 
 qqHH_hbbhzz = qqHH_hbbhvv.add_process(
     name="qqHH_hbbhzz",
-    id=-1,
+    id=22300,
     label=r"$HH_{vbf} \rightarrow bbZZ$",
 
 )
@@ -128,7 +136,7 @@ qqHH_hbbhzz = qqHH_hbbhvv.add_process(
 
 ggHH_kl_0_kt_1_hbbhvv = ggHH_kl_0_kt_1.add_process(
     name="ggHH_kl_0_kt_1_hbbhvv",
-    id=-1,
+    id=21401,
     label=r"$HH_{ggf}^{\kappa\lambda=0} \rightarrow bbVV$",
     xsecs=multiply_xsecs(ggHH_kl_0_kt_1, br_bbvv),
 )
@@ -136,21 +144,21 @@ ggHH_kl_0_kt_1_hbbhvv = ggHH_kl_0_kt_1.add_process(
 ggHH_kl_1_kt_1_hbbhvv = ggHH_kl_1_kt_1.add_process(
     name="ggHH_kl_1_kt_1_hbbhvv",
     label=r"$HH_{ggf}^{\kappa\lambda=1} \rightarrow bbVV$",
-    id=-1,
+    id=21402,
     xsecs=multiply_xsecs(ggHH_kl_1_kt_1, br_bbvv),
 )
 
 ggHH_kl_2p45_kt_1_hbbhvv = ggHH_kl_2p45_kt_1.add_process(
     name="ggHH_kl_2p45_kt_1_hbbhvv",
     label=r"$HH_{ggf}^{\kappa\lambda=2.45} \rightarrow bbVV$",
-    id=-1,
+    id=21403,
     xsecs=multiply_xsecs(ggHH_kl_2p45_kt_1, br_bbvv),
 )
 
 ggHH_kl_5_kt_1_hbbhvv = ggHH_kl_5_kt_1.add_process(
     name="ggHH_kl_5_kt_1_hbbhvv",
     label=r"$HH_{ggf}^{\kappa\lambda=5} \rightarrow bbVV$",
-    id=-1,
+    id=21404,
     xsecs=multiply_xsecs(ggHH_kl_5_kt_1, br_bbvv),
 )
 
@@ -167,49 +175,49 @@ ggHH_hbbhvv.add_process(ggHH_kl_5_kt_1_hbbhvv)
 qqHH_CV_1_C2V_1_kl_1_hbbhvv = qqHH_CV_1_C2V_1_kl_1.add_process(
     name="qqHH_CV_1_C2V_1_kl_1_hbbhvv",
     label=r"$HH_{vbf}^{1,1,1} \rightarrow bbVV$",
-    id=-1,
+    id=22401,
     xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_1, br_bbvv),
 )
 
 qqHH_CV_1_C2V_1_kl_0_hbbhvv = qqHH_CV_1_C2V_1_kl_0.add_process(
     name="qqHH_CV_1_C2V_1_kl_0_hbbhvv",
     label=r"$HH_{vbf}^{1,1,0} \rightarrow bbVV$",
-    id=-1,
+    id=22402,
     xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_0, br_bbvv),
 )
 
 qqHH_CV_1_C2V_1_kl_2_hbbhvv = qqHH_CV_1_C2V_1_kl_2.add_process(
     name="qqHH_CV_1_C2V_1_kl_2_hbbhvv",
     label=r"$HH_{vbf}^{1,1,2} \rightarrow bbVV$",
-    id=-1,
+    id=22403,
     xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_2, br_bbvv),
 )
 
 qqHH_CV_1_C2V_0_kl_1_hbbhvv = qqHH_CV_1_C2V_0_kl_1.add_process(
     name="qqHH_CV_1_C2V_0_kl_1_hbbhvv",
     label=r"$HH_{vbf}^{1,0,1} \rightarrow bbVV$",
-    id=-1,
+    id=22404,
     xsecs=multiply_xsecs(qqHH_CV_1_C2V_0_kl_1, br_bbvv),
 )
 
 qqHH_CV_1_C2V_2_kl_1_hbbhvv = qqHH_CV_1_C2V_2_kl_1.add_process(
     name="qqHH_CV_1_C2V_2_kl_1_hbbhvv",
     label=r"$HH_{vbf}^{1,2,1} \rightarrow bbVV$",
-    id=-1,
+    id=22405,
     xsecs=multiply_xsecs(qqHH_CV_1_C2V_2_kl_1, br_bbvv),
 )
 
 qqHH_CV_0p5_C2V_1_kl_1_hbbhvv = qqHH_CV_0p5_C2V_1_kl_1.add_process(
     name="qqHH_CV_0p5_C2V_1_kl_1_hbbhvv",
     label=r"$HH_{vbf}^{0.5,1,1} \rightarrow bbVV$",
-    id=-1,
+    id=22406,
     xsecs=multiply_xsecs(qqHH_CV_0p5_C2V_1_kl_1, br_bbvv),
 )
 
 qqHH_CV_1p5_C2V_1_kl_1_hbbhvv = qqHH_CV_1p5_C2V_1_kl_1.add_process(
     name="qqHH_CV_1p5_C2V_1_kl_1_hbbhvv",
     label=r"$HH_{vbf}^{1.5,1,1} \rightarrow bbVV$",
-    id=-1,
+    id=22407,
     xsecs=multiply_xsecs(qqHH_CV_1p5_C2V_1_kl_1, br_bbvv),
 )
 
@@ -453,13 +461,13 @@ qqHH_dl_hbbhww.add_process(qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhww)
 
 ggHH_dl_hbbhzz = ggHH_hbbhzz.add_process(
     name="ggHH_dl_hbbhzz",
-    id=-1,
+    id=21320,
     label=r"$HH_{ggf} \rightarrow bbZZ(ll \nu \nu)$",
 )
 
 ggHH_kl_0_kt_1_dl_hbbhzz = ggHH_kl_0_kt_1.add_process(
     name="ggHH_kl_0_kt_1_dl_hbbhzz",
-    id=-1,
+    id=21321,
     label=r"$HH_{ggf}^{\kappa\lambda=0} \rightarrow bbZZ(ll \nu \nu)$",
     xsecs=multiply_xsecs(ggHH_kl_0_kt_1, br_bbzz_dl),
 )
@@ -467,21 +475,21 @@ ggHH_kl_0_kt_1_dl_hbbhzz = ggHH_kl_0_kt_1.add_process(
 ggHH_kl_1_kt_1_dl_hbbhzz = ggHH_kl_1_kt_1.add_process(
     name="ggHH_kl_1_kt_1_dl_hbbhzz",
     label=r"$HH_{ggf}^{\kappa\lambda=1} \rightarrow bbZZ(ll \nu \nu)$",
-    id=-1,
+    id=21322,
     xsecs=multiply_xsecs(ggHH_kl_1_kt_1, br_bbzz_dl),
 )
 
 ggHH_kl_2p45_kt_1_dl_hbbhzz = ggHH_kl_2p45_kt_1.add_process(
     name="ggHH_kl_2p45_kt_1_dl_hbbhzz",
     label=r"$HH_{ggf}^{\kappa\lambda=2.45} \rightarrow bbZZ(ll \nu \nu)$",
-    id=-1,
+    id=21323,
     xsecs=multiply_xsecs(ggHH_kl_2p45_kt_1, br_bbzz_dl),
 )
 
 ggHH_kl_5_kt_1_dl_hbbhzz = ggHH_kl_5_kt_1.add_process(
     name="ggHH_kl_5_kt_1_dl_hbbhzz",
     label=r"$HH_{ggf}^{\kappa\lambda=5} \rightarrow bbZZ(ll \nu \nu)$",
-    id=-1,
+    id=21324,
     xsecs=multiply_xsecs(ggHH_kl_5_kt_1, br_bbzz_dl),
 )
 
@@ -500,55 +508,55 @@ ggHH_dl_hbbhzz.add_process(ggHH_kl_5_kt_1_dl_hbbhzz)
 qqHH_dl_hbbhzz = qqHH_hbbhzz.add_process(
     name="qqHH_dl_hbbhzz",
     label=r"$HH_{vbf} \rightarrow bbZZ(ll \nu \nu)$",
-    id=-1,
+    id=22320,
 )
 
 qqHH_CV_1_C2V_1_kl_1_dl_hbbhzz = qqHH_CV_1_C2V_1_kl_1.add_process(
     name="qqHH_CV_1_C2V_1_kl_1_dl_hbbhzz",
     label=r"$HH_{vbf}^{1,1,1} \rightarrow bbZZ(ll \nu \nu)$",
-    id=-1,
+    id=22321,
     xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_1, br_bbzz_dl),
 )
 
 qqHH_CV_1_C2V_1_kl_0_dl_hbbhzz = qqHH_CV_1_C2V_1_kl_0.add_process(
     name="qqHH_CV_1_C2V_1_kl_0_dl_hbbhzz",
     label=r"$HH_{vbf}^{1,1,0} \rightarrow bbZZ(ll \nu \nu)$",
-    id=-1,
+    id=22322,
     xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_0, br_bbzz_dl),
 )
 
 qqHH_CV_1_C2V_1_kl_2_dl_hbbhzz = qqHH_CV_1_C2V_1_kl_2.add_process(
     name="qqHH_CV_1_C2V_1_kl_2_dl_hbbhzz",
     label=r"$HH_{vbf}^{1,1,2} \rightarrow bbZZ(ll \nu \nu)$",
-    id=-1,
+    id=22323,
     xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_2, br_bbzz_dl),
 )
 
 qqHH_CV_1_C2V_0_kl_1_dl_hbbhzz = qqHH_CV_1_C2V_0_kl_1.add_process(
     name="qqHH_CV_1_C2V_0_kl_1_dl_hbbhzz",
     label=r"$HH_{vbf}^{1,0,1} \rightarrow bbZZ(ll \nu \nu)$",
-    id=-1,
+    id=22324,
     xsecs=multiply_xsecs(qqHH_CV_1_C2V_0_kl_1, br_bbzz_dl),
 )
 
 qqHH_CV_1_C2V_2_kl_1_dl_hbbhzz = qqHH_CV_1_C2V_2_kl_1.add_process(
     name="qqHH_CV_1_C2V_2_kl_1_dl_hbbhzz",
     label=r"$HH_{vbf}^{1,2,1} \rightarrow bbZZ(ll \nu \nu)$",
-    id=-1,
+    id=22325,
     xsecs=multiply_xsecs(qqHH_CV_1_C2V_2_kl_1, br_bbzz_dl),
 )
 
 qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhzz = qqHH_CV_0p5_C2V_1_kl_1.add_process(
     name="qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhzz",
     label=r"$HH_{vbf}^{0.5,1,1} \rightarrow bbZZ(ll \nu \nu)$",
-    id=-1,
+    id=22326,
     xsecs=multiply_xsecs(qqHH_CV_0p5_C2V_1_kl_1, br_bbzz_dl),
 )
 
 qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhzz = qqHH_CV_1p5_C2V_1_kl_1.add_process(
     name="qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhzz",
     label=r"$HH_{vbf}^{1.5,1,1} \rightarrow bbZZ(ll \nu \nu)$",
-    id=-1,
+    id=22327,
     xsecs=multiply_xsecs(qqHH_CV_1p5_C2V_1_kl_1, br_bbzz_dl),
 )
 
@@ -560,6 +568,7 @@ qqHH_dl_hbbhzz.add_process(qqHH_CV_1_C2V_0_kl_1_dl_hbbhzz)
 qqHH_dl_hbbhzz.add_process(qqHH_CV_1_C2V_2_kl_1_dl_hbbhzz)
 qqHH_dl_hbbhzz.add_process(qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhzz)
 qqHH_dl_hbbhzz.add_process(qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhzz)
+
 #
 # ggF -> radion -> HH
 #

--- a/cmsdb/processes/hh2bbww.py
+++ b/cmsdb/processes/hh2bbww.py
@@ -20,19 +20,19 @@ __all__ = [
     "qqHH_CV_1_C2V_0_kl_1_hbbhvv", "qqHH_CV_1_C2V_1_kl_0_hbbhvv", "qqHH_CV_1_C2V_1_kl_1_hbbhvv",
     "qqHH_CV_1_C2V_1_kl_2_hbbhvv", "qqHH_CV_1_C2V_2_kl_1_hbbhvv",
     # HH -> bbVV(2qlv), ggf
-    "ggHH_sl_hbbhvv", "ggHH_kl_0_kt_1_sl_hbbhvv", "ggHH_kl_1_kt_1_sl_hbbhvv",
-    "ggHH_kl_2p45_kt_1_sl_hbbhvv", "ggHH_kl_5_kt_1_sl_hbbhvv",
+    "ggHH_qqlnu_hbbhvv", "ggHH_kl_0_kt_1_qqlnu_hbbhvv", "ggHH_kl_1_kt_1_qqlnu_hbbhvv",
+    "ggHH_kl_2p45_kt_1_qqlnu_hbbhvv", "ggHH_kl_5_kt_1_qqlnu_hbbhvv",
     # HH -> bbVV(2qlv), vbf
-    "qqHH_sl_hbbhvv", "qqHH_CV_0p5_C2V_1_kl_1_sl_hbbhvv", "qqHH_CV_1p5_C2V_1_kl_1_sl_hbbhvv",
-    "qqHH_CV_1_C2V_0_kl_1_sl_hbbhvv", "qqHH_CV_1_C2V_1_kl_0_sl_hbbhvv", "qqHH_CV_1_C2V_1_kl_1_sl_hbbhvv",
-    "qqHH_CV_1_C2V_1_kl_2_sl_hbbhvv", "qqHH_CV_1_C2V_2_kl_1_sl_hbbhvv",
+    "qqHH_qqlnu_hbbhvv", "qqHH_CV_0p5_C2V_1_kl_1_qqlnu_hbbhvv", "qqHH_CV_1p5_C2V_1_kl_1_qqlnu_hbbhvv",
+    "qqHH_CV_1_C2V_0_kl_1_qqlnu_hbbhvv", "qqHH_CV_1_C2V_1_kl_0_qqlnu_hbbhvv", "qqHH_CV_1_C2V_1_kl_1_qqlnu_hbbhvv",
+    "qqHH_CV_1_C2V_1_kl_2_qqlnu_hbbhvv", "qqHH_CV_1_C2V_2_kl_1_qqlnu_hbbhvv",
     # HH -> bbVV(2l2v), ggf
-    "ggHH_dl_hbbhvv", "ggHH_kl_0_kt_1_dl_hbbhvv", "ggHH_kl_1_kt_1_dl_hbbhvv",
-    "ggHH_kl_2p45_kt_1_dl_hbbhvv", "ggHH_kl_5_kt_1_dl_hbbhvv",
+    "ggHH_2l2nu_hbbhvv", "ggHH_kl_0_kt_1_2l2nu_hbbhvv", "ggHH_kl_1_kt_1_2l2nu_hbbhvv",
+    "ggHH_kl_2p45_kt_1_2l2nu_hbbhvv", "ggHH_kl_5_kt_1_2l2nu_hbbhvv",
     # HH -> bbVV(2l2v), vbf
-    "qqHH_dl_hbbhvv", "qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhvv", "qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhvv",
-    "qqHH_CV_1_C2V_0_kl_1_dl_hbbhvv", "qqHH_CV_1_C2V_1_kl_0_dl_hbbhvv", "qqHH_CV_1_C2V_1_kl_1_dl_hbbhvv",
-    "qqHH_CV_1_C2V_1_kl_2_dl_hbbhvv", "qqHH_CV_1_C2V_2_kl_1_dl_hbbhvv",
+    "qqHH_2l2nu_hbbhvv", "qqHH_CV_0p5_C2V_1_kl_1_2l2nu_hbbhvv", "qqHH_CV_1p5_C2V_1_kl_1_2l2nu_hbbhvv",
+    "qqHH_CV_1_C2V_0_kl_1_2l2nu_hbbhvv", "qqHH_CV_1_C2V_1_kl_0_2l2nu_hbbhvv", "qqHH_CV_1_C2V_1_kl_1_2l2nu_hbbhvv",
+    "qqHH_CV_1_C2V_1_kl_2_2l2nu_hbbhvv", "qqHH_CV_1_C2V_2_kl_1_2l2nu_hbbhvv",
     # HH -> bbWW, ggf
     "ggHH_hbbhww", "ggHH_kl_0_kt_1_hbbhww", "ggHH_kl_1_kt_1_hbbhww",
     "ggHH_kl_2p45_kt_1_hbbhww", "ggHH_kl_5_kt_1_hbbhww",
@@ -41,19 +41,19 @@ __all__ = [
     "qqHH_CV_1_C2V_0_kl_1_hbbhww", "qqHH_CV_1_C2V_1_kl_0_hbbhww", "qqHH_CV_1_C2V_1_kl_1_hbbhww",
     "qqHH_CV_1_C2V_1_kl_2_hbbhww", "qqHH_CV_1_C2V_2_kl_1_hbbhww",
     # HH -> bbWW(qqlv), ggf
-    "ggHH_sl_hbbhww", "ggHH_kl_0_kt_1_sl_hbbhww", "ggHH_kl_1_kt_1_sl_hbbhww",
-    "ggHH_kl_2p45_kt_1_sl_hbbhww", "ggHH_kl_5_kt_1_sl_hbbhww",
+    "ggHH_qqlnu_hbbhww", "ggHH_kl_0_kt_1_qqlnu_hbbhww", "ggHH_kl_1_kt_1_qqlnu_hbbhww",
+    "ggHH_kl_2p45_kt_1_qqlnu_hbbhww", "ggHH_kl_5_kt_1_qqlnu_hbbhww",
     # HH -> bbWW(lvlv), ggf
-    "ggHH_dl_hbbhww", "ggHH_kl_0_kt_1_dl_hbbhww", "ggHH_kl_1_kt_1_dl_hbbhww",
-    "ggHH_kl_2p45_kt_1_dl_hbbhww", "ggHH_kl_5_kt_1_dl_hbbhww",
+    "ggHH_2l2nu_hbbhww", "ggHH_kl_0_kt_1_2l2nu_hbbhww", "ggHH_kl_1_kt_1_2l2nu_hbbhww",
+    "ggHH_kl_2p45_kt_1_2l2nu_hbbhww", "ggHH_kl_5_kt_1_2l2nu_hbbhww",
     # HH -> bbWW(qqlv), vbf
-    "qqHH_sl_hbbhww", "qqHH_CV_0p5_C2V_1_kl_1_sl_hbbhww", "qqHH_CV_1p5_C2V_1_kl_1_sl_hbbhww",
-    "qqHH_CV_1_C2V_0_kl_1_sl_hbbhww", "qqHH_CV_1_C2V_1_kl_0_sl_hbbhww", "qqHH_CV_1_C2V_1_kl_1_sl_hbbhww",
-    "qqHH_CV_1_C2V_1_kl_2_sl_hbbhww", "qqHH_CV_1_C2V_2_kl_1_sl_hbbhww",
+    "qqHH_qqlnu_hbbhww", "qqHH_CV_0p5_C2V_1_kl_1_qqlnu_hbbhww", "qqHH_CV_1p5_C2V_1_kl_1_qqlnu_hbbhww",
+    "qqHH_CV_1_C2V_0_kl_1_qqlnu_hbbhww", "qqHH_CV_1_C2V_1_kl_0_qqlnu_hbbhww", "qqHH_CV_1_C2V_1_kl_1_qqlnu_hbbhww",
+    "qqHH_CV_1_C2V_1_kl_2_qqlnu_hbbhww", "qqHH_CV_1_C2V_2_kl_1_qqlnu_hbbhww",
     # HH -> bbWW(lvlv), vbf
-    "qqHH_dl_hbbhww", "qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhww", "qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhww",
-    "qqHH_CV_1_C2V_0_kl_1_dl_hbbhww", "qqHH_CV_1_C2V_1_kl_0_dl_hbbhww", "qqHH_CV_1_C2V_1_kl_1_dl_hbbhww",
-    "qqHH_CV_1_C2V_1_kl_2_dl_hbbhww", "qqHH_CV_1_C2V_2_kl_1_dl_hbbhww",
+    "qqHH_2l2nu_hbbhww", "qqHH_CV_0p5_C2V_1_kl_1_2l2nu_hbbhww", "qqHH_CV_1p5_C2V_1_kl_1_2l2nu_hbbhww",
+    "qqHH_CV_1_C2V_0_kl_1_2l2nu_hbbhww", "qqHH_CV_1_C2V_1_kl_0_2l2nu_hbbhww", "qqHH_CV_1_C2V_1_kl_1_2l2nu_hbbhww",
+    "qqHH_CV_1_C2V_1_kl_2_2l2nu_hbbhww", "qqHH_CV_1_C2V_2_kl_1_2l2nu_hbbhww",
     "ggHH_hbbhzz",
     # HH -> bbZZ, ggf
     "ggHH_hbbhzz", "ggHH_kl_0_kt_1_hbbhzz", "ggHH_kl_1_kt_1_hbbhzz",
@@ -63,12 +63,12 @@ __all__ = [
     "qqHH_CV_1_C2V_0_kl_1_hbbhzz", "qqHH_CV_1_C2V_1_kl_0_hbbhzz", "qqHH_CV_1_C2V_1_kl_1_hbbhzz",
     "qqHH_CV_1_C2V_1_kl_2_hbbhzz", "qqHH_CV_1_C2V_2_kl_1_hbbhzz",
     # HH -> bbZZ(lvlv), ggf
-    "ggHH_dl_hbbhzz", "ggHH_kl_0_kt_1_dl_hbbhzz", "ggHH_kl_1_kt_1_dl_hbbhzz",
-    "ggHH_kl_2p45_kt_1_dl_hbbhzz", "ggHH_kl_5_kt_1_dl_hbbhzz",
+    "ggHH_2l2nu_hbbhzz", "ggHH_kl_0_kt_1_2l2nu_hbbhzz", "ggHH_kl_1_kt_1_2l2nu_hbbhzz",
+    "ggHH_kl_2p45_kt_1_2l2nu_hbbhzz", "ggHH_kl_5_kt_1_2l2nu_hbbhzz",
     # HH -> bbZZ(lvlv), vbf
-    "qqHH_dl_hbbhzz", "qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhzz", "qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhzz",
-    "qqHH_CV_1_C2V_0_kl_1_dl_hbbhzz", "qqHH_CV_1_C2V_1_kl_0_dl_hbbhzz", "qqHH_CV_1_C2V_1_kl_1_dl_hbbhzz",
-    "qqHH_CV_1_C2V_1_kl_2_dl_hbbhzz", "qqHH_CV_1_C2V_2_kl_1_dl_hbbhzz",
+    "qqHH_2l2nu_hbbhzz", "qqHH_CV_0p5_C2V_1_kl_1_2l2nu_hbbhzz", "qqHH_CV_1p5_C2V_1_kl_1_2l2nu_hbbhzz",
+    "qqHH_CV_1_C2V_0_kl_1_2l2nu_hbbhzz", "qqHH_CV_1_C2V_1_kl_0_2l2nu_hbbhzz", "qqHH_CV_1_C2V_1_kl_1_2l2nu_hbbhzz",
+    "qqHH_CV_1_C2V_1_kl_2_2l2nu_hbbhzz", "qqHH_CV_1_C2V_2_kl_1_2l2nu_hbbhzz",
     # Resonant HH -> bbWW: radion
     "radion_hh_ggf_bbww",
     "radion_hh_ggf_bbww_m250", "radion_hh_ggf_bbww_m260", "radion_hh_ggf_bbww_m270",
@@ -112,13 +112,12 @@ from cmsdb.processes.higgs import (
 # Helper
 #
 
-# NOTE: bbzz_dl is not descriptive enough, should probably be updated to bbzz_2l2nu or similar (same for bbvv)
-br_bbww_sl = const.br_hh.bbww * const.br_ww.sl
-br_bbww_dl = const.br_hh.bbww * const.br_ww.dl
-br_bbzz_dl = const.br_hh.bbzz * const.br_zz.llnunu
+br_bbww_qqlnu = const.br_hh.bbww * const.br_ww.sl
+br_bbww_2l2nu = const.br_hh.bbww * const.br_ww.dl
+br_bbzz_2l2nu = const.br_hh.bbzz * const.br_zz.llnunu
 br_bbvv = const.br_hh.bbww + const.br_hh.bbzz
-br_bbvv_sl = br_bbww_sl
-br_bbvv_dl = br_bbww_dl + br_bbzz_dl
+br_bbvv_qqlnu = br_bbww_qqlnu
+br_bbvv_2l2nu = br_bbww_2l2nu + br_bbzz_2l2nu
 
 
 #############################################################
@@ -243,229 +242,229 @@ qqHH_hbbhvv.add_process(qqHH_CV_1p5_C2V_1_kl_1_hbbhvv)
 # HH -> bbVV(qqlv), ggf
 #
 
-ggHH_sl_hbbhvv = ggHH_hbbhvv.add_process(
-    name="ggHH_sl_hbbhvv",
+ggHH_qqlnu_hbbhvv = ggHH_hbbhvv.add_process(
+    name="ggHH_qqlnu_hbbhvv",
     id=21310,
     label=r"$HH_{ggf} \rightarrow bbVV(qql\nu)$",
 )
 
-ggHH_kl_0_kt_1_sl_hbbhvv = ggHH_kl_0_kt_1_hbbhvv.add_process(
-    name="ggHH_kl_0_kt_1_sl_hbbhvv",
+ggHH_kl_0_kt_1_qqlnu_hbbhvv = ggHH_kl_0_kt_1_hbbhvv.add_process(
+    name="ggHH_kl_0_kt_1_qqlnu_hbbhvv",
     id=21311,
     label=r"$HH_{ggf}^{\kappa\lambda=0} \rightarrow bbVV(qql\nu)$",
-    xsecs=multiply_xsecs(ggHH_kl_0_kt_1, br_bbvv_sl),
+    xsecs=multiply_xsecs(ggHH_kl_0_kt_1, br_bbvv_qqlnu),
 )
 
-ggHH_kl_1_kt_1_sl_hbbhvv = ggHH_kl_1_kt_1_hbbhvv.add_process(
-    name="ggHH_kl_1_kt_1_sl_hbbhvv",
+ggHH_kl_1_kt_1_qqlnu_hbbhvv = ggHH_kl_1_kt_1_hbbhvv.add_process(
+    name="ggHH_kl_1_kt_1_qqlnu_hbbhvv",
     label=r"$HH_{ggf}^{\kappa\lambda=1} \rightarrow bbVV(qql\nu)$",
     id=21312,
-    xsecs=multiply_xsecs(ggHH_kl_1_kt_1, br_bbvv_sl),
+    xsecs=multiply_xsecs(ggHH_kl_1_kt_1, br_bbvv_qqlnu),
 )
 
-ggHH_kl_2p45_kt_1_sl_hbbhvv = ggHH_kl_2p45_kt_1_hbbhvv.add_process(
-    name="ggHH_kl_2p45_kt_1_sl_hbbhvv",
+ggHH_kl_2p45_kt_1_qqlnu_hbbhvv = ggHH_kl_2p45_kt_1_hbbhvv.add_process(
+    name="ggHH_kl_2p45_kt_1_qqlnu_hbbhvv",
     label=r"$HH_{ggf}^{\kappa\lambda=2.45} \rightarrow bbVV(qql\nu)$",
     id=21313,
-    xsecs=multiply_xsecs(ggHH_kl_2p45_kt_1, br_bbvv_sl),
+    xsecs=multiply_xsecs(ggHH_kl_2p45_kt_1, br_bbvv_qqlnu),
 )
 
-ggHH_kl_5_kt_1_sl_hbbhvv = ggHH_kl_5_kt_1_hbbhvv.add_process(
-    name="ggHH_kl_5_kt_1_sl_hbbhvv",
+ggHH_kl_5_kt_1_qqlnu_hbbhvv = ggHH_kl_5_kt_1_hbbhvv.add_process(
+    name="ggHH_kl_5_kt_1_qqlnu_hbbhvv",
     label=r"$HH_{ggf}^{\kappa\lambda=5} \rightarrow bbVV(qql\nu)$",
     id=21314,
-    xsecs=multiply_xsecs(ggHH_kl_5_kt_1, br_bbvv_sl),
+    xsecs=multiply_xsecs(ggHH_kl_5_kt_1, br_bbvv_qqlnu),
 )
 
 
 # add process dependencies
-ggHH_sl_hbbhvv.add_process(ggHH_kl_0_kt_1_sl_hbbhvv)
-ggHH_sl_hbbhvv.add_process(ggHH_kl_1_kt_1_sl_hbbhvv)
-ggHH_sl_hbbhvv.add_process(ggHH_kl_2p45_kt_1_sl_hbbhvv)
-ggHH_sl_hbbhvv.add_process(ggHH_kl_5_kt_1_sl_hbbhvv)
+ggHH_qqlnu_hbbhvv.add_process(ggHH_kl_0_kt_1_qqlnu_hbbhvv)
+ggHH_qqlnu_hbbhvv.add_process(ggHH_kl_1_kt_1_qqlnu_hbbhvv)
+ggHH_qqlnu_hbbhvv.add_process(ggHH_kl_2p45_kt_1_qqlnu_hbbhvv)
+ggHH_qqlnu_hbbhvv.add_process(ggHH_kl_5_kt_1_qqlnu_hbbhvv)
 
 
 #
 # HH -> bbVV(qqlv), vbf
 #
 
-qqHH_sl_hbbhvv = qqHH_hbbhvv.add_process(
-    name="qqHH_sl_hbbhvv",
+qqHH_qqlnu_hbbhvv = qqHH_hbbhvv.add_process(
+    name="qqHH_qqlnu_hbbhvv",
     label=r"$HH_{vbf} \rightarrow bbVV(qql\nu)$",
     id=22410,
 )
 
-qqHH_CV_1_C2V_1_kl_1_sl_hbbhvv = qqHH_CV_1_C2V_1_kl_1_hbbhvv.add_process(
-    name="qqHH_CV_1_C2V_1_kl_1_sl_hbbhvv",
+qqHH_CV_1_C2V_1_kl_1_qqlnu_hbbhvv = qqHH_CV_1_C2V_1_kl_1_hbbhvv.add_process(
+    name="qqHH_CV_1_C2V_1_kl_1_qqlnu_hbbhvv",
     label=r"$HH_{vbf}^{1,1,1} \rightarrow bbVV(qql\nu)$",
     id=22411,
-    xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_1, br_bbvv_sl),
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_1, br_bbvv_qqlnu),
 )
 
-qqHH_CV_1_C2V_1_kl_0_sl_hbbhvv = qqHH_CV_1_C2V_1_kl_0_hbbhvv.add_process(
-    name="qqHH_CV_1_C2V_1_kl_0_sl_hbbhvv",
+qqHH_CV_1_C2V_1_kl_0_qqlnu_hbbhvv = qqHH_CV_1_C2V_1_kl_0_hbbhvv.add_process(
+    name="qqHH_CV_1_C2V_1_kl_0_qqlnu_hbbhvv",
     label=r"$HH_{vbf}^{1,1,0} \rightarrow bbVV(qql\nu)$",
     id=22412,
-    xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_0, br_bbvv_sl),
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_0, br_bbvv_qqlnu),
 )
 
-qqHH_CV_1_C2V_1_kl_2_sl_hbbhvv = qqHH_CV_1_C2V_1_kl_2_hbbhvv.add_process(
-    name="qqHH_CV_1_C2V_1_kl_2_sl_hbbhvv",
+qqHH_CV_1_C2V_1_kl_2_qqlnu_hbbhvv = qqHH_CV_1_C2V_1_kl_2_hbbhvv.add_process(
+    name="qqHH_CV_1_C2V_1_kl_2_qqlnu_hbbhvv",
     label=r"$HH_{vbf}^{1,1,2} \rightarrow bbVV(qql\nu)$",
     id=22413,
-    xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_2, br_bbvv_sl),
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_2, br_bbvv_qqlnu),
 )
 
-qqHH_CV_1_C2V_0_kl_1_sl_hbbhvv = qqHH_CV_1_C2V_0_kl_1_hbbhvv.add_process(
-    name="qqHH_CV_1_C2V_0_kl_1_sl_hbbhvv",
+qqHH_CV_1_C2V_0_kl_1_qqlnu_hbbhvv = qqHH_CV_1_C2V_0_kl_1_hbbhvv.add_process(
+    name="qqHH_CV_1_C2V_0_kl_1_qqlnu_hbbhvv",
     label=r"$HH_{vbf}^{1,0,1} \rightarrow bbVV(qql\nu)$",
     id=22414,
-    xsecs=multiply_xsecs(qqHH_CV_1_C2V_0_kl_1, br_bbvv_sl),
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_0_kl_1, br_bbvv_qqlnu),
 )
 
-qqHH_CV_1_C2V_2_kl_1_sl_hbbhvv = qqHH_CV_1_C2V_2_kl_1_hbbhvv.add_process(
-    name="qqHH_CV_1_C2V_2_kl_1_sl_hbbhvv",
+qqHH_CV_1_C2V_2_kl_1_qqlnu_hbbhvv = qqHH_CV_1_C2V_2_kl_1_hbbhvv.add_process(
+    name="qqHH_CV_1_C2V_2_kl_1_qqlnu_hbbhvv",
     label=r"$HH_{vbf}^{1,2,1} \rightarrow bbVV(qql\nu)$",
     id=22415,
-    xsecs=multiply_xsecs(qqHH_CV_1_C2V_2_kl_1, br_bbvv_sl),
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_2_kl_1, br_bbvv_qqlnu),
 )
 
-qqHH_CV_0p5_C2V_1_kl_1_sl_hbbhvv = qqHH_CV_0p5_C2V_1_kl_1_hbbhvv.add_process(
-    name="qqHH_CV_0p5_C2V_1_kl_1_sl_hbbhvv",
+qqHH_CV_0p5_C2V_1_kl_1_qqlnu_hbbhvv = qqHH_CV_0p5_C2V_1_kl_1_hbbhvv.add_process(
+    name="qqHH_CV_0p5_C2V_1_kl_1_qqlnu_hbbhvv",
     label=r"$HH_{vbf}^{0.5,1,1} \rightarrow bbVV(qql\nu)$",
     id=22416,
-    xsecs=multiply_xsecs(qqHH_CV_0p5_C2V_1_kl_1, br_bbvv_sl),
+    xsecs=multiply_xsecs(qqHH_CV_0p5_C2V_1_kl_1, br_bbvv_qqlnu),
 )
 
-qqHH_CV_1p5_C2V_1_kl_1_sl_hbbhvv = qqHH_CV_1p5_C2V_1_kl_1_hbbhvv.add_process(
-    name="qqHH_CV_1p5_C2V_1_kl_1_sl_hbbhvv",
+qqHH_CV_1p5_C2V_1_kl_1_qqlnu_hbbhvv = qqHH_CV_1p5_C2V_1_kl_1_hbbhvv.add_process(
+    name="qqHH_CV_1p5_C2V_1_kl_1_qqlnu_hbbhvv",
     label=r"$HH_{vbf}^{1.5,1,1} \rightarrow bbVV(qql\nu)$",
     id=22417,
-    xsecs=multiply_xsecs(qqHH_CV_1p5_C2V_1_kl_1, br_bbvv_sl),
+    xsecs=multiply_xsecs(qqHH_CV_1p5_C2V_1_kl_1, br_bbvv_qqlnu),
 )
 
 # add process dependencies
-qqHH_sl_hbbhvv.add_process(qqHH_CV_1_C2V_1_kl_1_sl_hbbhvv)
-qqHH_sl_hbbhvv.add_process(qqHH_CV_1_C2V_1_kl_0_sl_hbbhvv)
-qqHH_sl_hbbhvv.add_process(qqHH_CV_1_C2V_1_kl_2_sl_hbbhvv)
-qqHH_sl_hbbhvv.add_process(qqHH_CV_1_C2V_0_kl_1_sl_hbbhvv)
-qqHH_sl_hbbhvv.add_process(qqHH_CV_1_C2V_2_kl_1_sl_hbbhvv)
-qqHH_sl_hbbhvv.add_process(qqHH_CV_0p5_C2V_1_kl_1_sl_hbbhvv)
-qqHH_sl_hbbhvv.add_process(qqHH_CV_1p5_C2V_1_kl_1_sl_hbbhvv)
+qqHH_qqlnu_hbbhvv.add_process(qqHH_CV_1_C2V_1_kl_1_qqlnu_hbbhvv)
+qqHH_qqlnu_hbbhvv.add_process(qqHH_CV_1_C2V_1_kl_0_qqlnu_hbbhvv)
+qqHH_qqlnu_hbbhvv.add_process(qqHH_CV_1_C2V_1_kl_2_qqlnu_hbbhvv)
+qqHH_qqlnu_hbbhvv.add_process(qqHH_CV_1_C2V_0_kl_1_qqlnu_hbbhvv)
+qqHH_qqlnu_hbbhvv.add_process(qqHH_CV_1_C2V_2_kl_1_qqlnu_hbbhvv)
+qqHH_qqlnu_hbbhvv.add_process(qqHH_CV_0p5_C2V_1_kl_1_qqlnu_hbbhvv)
+qqHH_qqlnu_hbbhvv.add_process(qqHH_CV_1p5_C2V_1_kl_1_qqlnu_hbbhvv)
 
 #
 # HH -> bbVV(2l2v), ggf
 #
 
-ggHH_dl_hbbhvv = ggHH_hbbhvv.add_process(
-    name="ggHH_dl_hbbhvv",
+ggHH_2l2nu_hbbhvv = ggHH_hbbhvv.add_process(
+    name="ggHH_2l2nu_hbbhvv",
     id=21320,
     label=r"$HH_{ggf} \rightarrow bbVV(2l2\nu)$",
 )
 
-ggHH_kl_0_kt_1_dl_hbbhvv = ggHH_kl_0_kt_1_hbbhvv.add_process(
-    name="ggHH_kl_0_kt_1_dl_hbbhvv",
+ggHH_kl_0_kt_1_2l2nu_hbbhvv = ggHH_kl_0_kt_1_hbbhvv.add_process(
+    name="ggHH_kl_0_kt_1_2l2nu_hbbhvv",
     id=21321,
     label=r"$HH_{ggf}^{\kappa\lambda=0} \rightarrow bbVV(2l2\nu)$",
-    xsecs=multiply_xsecs(ggHH_kl_0_kt_1, br_bbvv_dl),
+    xsecs=multiply_xsecs(ggHH_kl_0_kt_1, br_bbvv_2l2nu),
 )
 
-ggHH_kl_1_kt_1_dl_hbbhvv = ggHH_kl_1_kt_1_hbbhvv.add_process(
-    name="ggHH_kl_1_kt_1_dl_hbbhvv",
+ggHH_kl_1_kt_1_2l2nu_hbbhvv = ggHH_kl_1_kt_1_hbbhvv.add_process(
+    name="ggHH_kl_1_kt_1_2l2nu_hbbhvv",
     label=r"$HH_{ggf}^{\kappa\lambda=1} \rightarrow bbVV(2l2\nu)$",
     id=21322,
-    xsecs=multiply_xsecs(ggHH_kl_1_kt_1, br_bbvv_dl),
+    xsecs=multiply_xsecs(ggHH_kl_1_kt_1, br_bbvv_2l2nu),
 )
 
-ggHH_kl_2p45_kt_1_dl_hbbhvv = ggHH_kl_2p45_kt_1_hbbhvv.add_process(
-    name="ggHH_kl_2p45_kt_1_dl_hbbhvv",
+ggHH_kl_2p45_kt_1_2l2nu_hbbhvv = ggHH_kl_2p45_kt_1_hbbhvv.add_process(
+    name="ggHH_kl_2p45_kt_1_2l2nu_hbbhvv",
     label=r"$HH_{ggf}^{\kappa\lambda=2.45} \rightarrow bbVV(2l2\nu)$",
     id=21323,
-    xsecs=multiply_xsecs(ggHH_kl_2p45_kt_1, br_bbvv_dl),
+    xsecs=multiply_xsecs(ggHH_kl_2p45_kt_1, br_bbvv_2l2nu),
 )
 
-ggHH_kl_5_kt_1_dl_hbbhvv = ggHH_kl_5_kt_1_hbbhvv.add_process(
-    name="ggHH_kl_5_kt_1_dl_hbbhvv",
+ggHH_kl_5_kt_1_2l2nu_hbbhvv = ggHH_kl_5_kt_1_hbbhvv.add_process(
+    name="ggHH_kl_5_kt_1_2l2nu_hbbhvv",
     label=r"$HH_{ggf}^{\kappa\lambda=5} \rightarrow bbVV(2l2\nu)$",
     id=21324,
-    xsecs=multiply_xsecs(ggHH_kl_5_kt_1, br_bbvv_dl),
+    xsecs=multiply_xsecs(ggHH_kl_5_kt_1, br_bbvv_2l2nu),
 )
 
 
 # add process dependencies
-ggHH_dl_hbbhvv.add_process(ggHH_kl_0_kt_1_dl_hbbhvv)
-ggHH_dl_hbbhvv.add_process(ggHH_kl_1_kt_1_dl_hbbhvv)
-ggHH_dl_hbbhvv.add_process(ggHH_kl_2p45_kt_1_dl_hbbhvv)
-ggHH_dl_hbbhvv.add_process(ggHH_kl_5_kt_1_dl_hbbhvv)
+ggHH_2l2nu_hbbhvv.add_process(ggHH_kl_0_kt_1_2l2nu_hbbhvv)
+ggHH_2l2nu_hbbhvv.add_process(ggHH_kl_1_kt_1_2l2nu_hbbhvv)
+ggHH_2l2nu_hbbhvv.add_process(ggHH_kl_2p45_kt_1_2l2nu_hbbhvv)
+ggHH_2l2nu_hbbhvv.add_process(ggHH_kl_5_kt_1_2l2nu_hbbhvv)
 
 
 #
 # HH -> bbVV(2l2v), vbf
 #
 
-qqHH_dl_hbbhvv = qqHH_hbbhvv.add_process(
-    name="qqHH_dl_hbbhvv",
+qqHH_2l2nu_hbbhvv = qqHH_hbbhvv.add_process(
+    name="qqHH_2l2nu_hbbhvv",
     label=r"$HH_{vbf} \rightarrow bbVV(2l2\nu)$",
     id=22420,
 )
 
-qqHH_CV_1_C2V_1_kl_1_dl_hbbhvv = qqHH_CV_1_C2V_1_kl_1_hbbhvv.add_process(
-    name="qqHH_CV_1_C2V_1_kl_1_dl_hbbhvv",
+qqHH_CV_1_C2V_1_kl_1_2l2nu_hbbhvv = qqHH_CV_1_C2V_1_kl_1_hbbhvv.add_process(
+    name="qqHH_CV_1_C2V_1_kl_1_2l2nu_hbbhvv",
     label=r"$HH_{vbf}^{1,1,1} \rightarrow bbVV(2l2\nu)$",
     id=22421,
-    xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_1, br_bbvv_dl),
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_1, br_bbvv_2l2nu),
 )
 
-qqHH_CV_1_C2V_1_kl_0_dl_hbbhvv = qqHH_CV_1_C2V_1_kl_0_hbbhvv.add_process(
-    name="qqHH_CV_1_C2V_1_kl_0_dl_hbbhvv",
+qqHH_CV_1_C2V_1_kl_0_2l2nu_hbbhvv = qqHH_CV_1_C2V_1_kl_0_hbbhvv.add_process(
+    name="qqHH_CV_1_C2V_1_kl_0_2l2nu_hbbhvv",
     label=r"$HH_{vbf}^{1,1,0} \rightarrow bbVV(2l2\nu)$",
     id=22422,
-    xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_0, br_bbvv_dl),
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_0, br_bbvv_2l2nu),
 )
 
-qqHH_CV_1_C2V_1_kl_2_dl_hbbhvv = qqHH_CV_1_C2V_1_kl_2_hbbhvv.add_process(
-    name="qqHH_CV_1_C2V_1_kl_2_dl_hbbhvv",
+qqHH_CV_1_C2V_1_kl_2_2l2nu_hbbhvv = qqHH_CV_1_C2V_1_kl_2_hbbhvv.add_process(
+    name="qqHH_CV_1_C2V_1_kl_2_2l2nu_hbbhvv",
     label=r"$HH_{vbf}^{1,1,2} \rightarrow bbVV(2l2\nu)$",
     id=22423,
-    xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_2, br_bbvv_dl),
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_2, br_bbvv_2l2nu),
 )
 
-qqHH_CV_1_C2V_0_kl_1_dl_hbbhvv = qqHH_CV_1_C2V_0_kl_1_hbbhvv.add_process(
-    name="qqHH_CV_1_C2V_0_kl_1_dl_hbbhvv",
+qqHH_CV_1_C2V_0_kl_1_2l2nu_hbbhvv = qqHH_CV_1_C2V_0_kl_1_hbbhvv.add_process(
+    name="qqHH_CV_1_C2V_0_kl_1_2l2nu_hbbhvv",
     label=r"$HH_{vbf}^{1,0,1} \rightarrow bbVV(2l2\nu)$",
     id=22424,
-    xsecs=multiply_xsecs(qqHH_CV_1_C2V_0_kl_1, br_bbvv_dl),
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_0_kl_1, br_bbvv_2l2nu),
 )
 
-qqHH_CV_1_C2V_2_kl_1_dl_hbbhvv = qqHH_CV_1_C2V_2_kl_1_hbbhvv.add_process(
-    name="qqHH_CV_1_C2V_2_kl_1_dl_hbbhvv",
+qqHH_CV_1_C2V_2_kl_1_2l2nu_hbbhvv = qqHH_CV_1_C2V_2_kl_1_hbbhvv.add_process(
+    name="qqHH_CV_1_C2V_2_kl_1_2l2nu_hbbhvv",
     label=r"$HH_{vbf}^{1,2,1} \rightarrow bbVV(2l2\nu)$",
     id=22425,
-    xsecs=multiply_xsecs(qqHH_CV_1_C2V_2_kl_1, br_bbvv_dl),
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_2_kl_1, br_bbvv_2l2nu),
 )
 
-qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhvv = qqHH_CV_0p5_C2V_1_kl_1_hbbhvv.add_process(
-    name="qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhvv",
+qqHH_CV_0p5_C2V_1_kl_1_2l2nu_hbbhvv = qqHH_CV_0p5_C2V_1_kl_1_hbbhvv.add_process(
+    name="qqHH_CV_0p5_C2V_1_kl_1_2l2nu_hbbhvv",
     label=r"$HH_{vbf}^{0.5,1,1} \rightarrow bbVV(2l2\nu)$",
     id=22426,
-    xsecs=multiply_xsecs(qqHH_CV_0p5_C2V_1_kl_1, br_bbvv_dl),
+    xsecs=multiply_xsecs(qqHH_CV_0p5_C2V_1_kl_1, br_bbvv_2l2nu),
 )
 
-qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhvv = qqHH_CV_1p5_C2V_1_kl_1_hbbhvv.add_process(
-    name="qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhvv",
+qqHH_CV_1p5_C2V_1_kl_1_2l2nu_hbbhvv = qqHH_CV_1p5_C2V_1_kl_1_hbbhvv.add_process(
+    name="qqHH_CV_1p5_C2V_1_kl_1_2l2nu_hbbhvv",
     label=r"$HH_{vbf}^{1.5,1,1} \rightarrow bbVV(2l2\nu)$",
     id=22427,
-    xsecs=multiply_xsecs(qqHH_CV_1p5_C2V_1_kl_1, br_bbvv_dl),
+    xsecs=multiply_xsecs(qqHH_CV_1p5_C2V_1_kl_1, br_bbvv_2l2nu),
 )
 
 # add process dependencies
-qqHH_dl_hbbhvv.add_process(qqHH_CV_1_C2V_1_kl_1_dl_hbbhvv)
-qqHH_dl_hbbhvv.add_process(qqHH_CV_1_C2V_1_kl_0_dl_hbbhvv)
-qqHH_dl_hbbhvv.add_process(qqHH_CV_1_C2V_1_kl_2_dl_hbbhvv)
-qqHH_dl_hbbhvv.add_process(qqHH_CV_1_C2V_0_kl_1_dl_hbbhvv)
-qqHH_dl_hbbhvv.add_process(qqHH_CV_1_C2V_2_kl_1_dl_hbbhvv)
-qqHH_dl_hbbhvv.add_process(qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhvv)
-qqHH_dl_hbbhvv.add_process(qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhvv)
+qqHH_2l2nu_hbbhvv.add_process(qqHH_CV_1_C2V_1_kl_1_2l2nu_hbbhvv)
+qqHH_2l2nu_hbbhvv.add_process(qqHH_CV_1_C2V_1_kl_0_2l2nu_hbbhvv)
+qqHH_2l2nu_hbbhvv.add_process(qqHH_CV_1_C2V_1_kl_2_2l2nu_hbbhvv)
+qqHH_2l2nu_hbbhvv.add_process(qqHH_CV_1_C2V_0_kl_1_2l2nu_hbbhvv)
+qqHH_2l2nu_hbbhvv.add_process(qqHH_CV_1_C2V_2_kl_1_2l2nu_hbbhvv)
+qqHH_2l2nu_hbbhvv.add_process(qqHH_CV_0p5_C2V_1_kl_1_2l2nu_hbbhvv)
+qqHH_2l2nu_hbbhvv.add_process(qqHH_CV_1p5_C2V_1_kl_1_2l2nu_hbbhvv)
 
 ###############################################################
 #
@@ -589,252 +588,252 @@ qqHH_hbbhww.add_process(qqHH_CV_1p5_C2V_1_kl_1_hbbhww)
 # HH -> bbWW(qqlv), ggf
 #
 
-ggHH_sl_hbbhww = ggHH_hbbhww.add_process(
-    name="ggHH_sl_hbbhww",
+ggHH_qqlnu_hbbhww = ggHH_hbbhww.add_process(
+    name="ggHH_qqlnu_hbbhww",
     id=21210,
     label=r"$HH_{ggf} \rightarrow bbWW(qql\nu)$",
 )
 
-ggHH_kl_0_kt_1_sl_hbbhww = ggHH_kl_0_kt_1_sl_hbbhvv.add_process(
-    name="ggHH_kl_0_kt_1_sl_hbbhww",
+ggHH_kl_0_kt_1_qqlnu_hbbhww = ggHH_kl_0_kt_1_qqlnu_hbbhvv.add_process(
+    name="ggHH_kl_0_kt_1_qqlnu_hbbhww",
     id=21211,
     label=r"$HH_{ggf}^{\kappa\lambda=0} \rightarrow bbWW(qql\nu)$",
-    xsecs=multiply_xsecs(ggHH_kl_0_kt_1, br_bbww_sl),
+    xsecs=multiply_xsecs(ggHH_kl_0_kt_1, br_bbww_qqlnu),
 )
 
-ggHH_kl_1_kt_1_sl_hbbhww = ggHH_kl_1_kt_1_sl_hbbhvv.add_process(
-    name="ggHH_kl_1_kt_1_sl_hbbhww",
+ggHH_kl_1_kt_1_qqlnu_hbbhww = ggHH_kl_1_kt_1_qqlnu_hbbhvv.add_process(
+    name="ggHH_kl_1_kt_1_qqlnu_hbbhww",
     label=r"$HH_{ggf}^{\kappa\lambda=1} \rightarrow bbWW(qql\nu)$",
     id=21212,
-    xsecs=multiply_xsecs(ggHH_kl_1_kt_1, br_bbww_sl),
+    xsecs=multiply_xsecs(ggHH_kl_1_kt_1, br_bbww_qqlnu),
 )
 
-ggHH_kl_2p45_kt_1_sl_hbbhww = ggHH_kl_2p45_kt_1_sl_hbbhvv.add_process(
-    name="ggHH_kl_2p45_kt_1_sl_hbbhww",
+ggHH_kl_2p45_kt_1_qqlnu_hbbhww = ggHH_kl_2p45_kt_1_qqlnu_hbbhvv.add_process(
+    name="ggHH_kl_2p45_kt_1_qqlnu_hbbhww",
     label=r"$HH_{ggf}^{\kappa\lambda=2.45} \rightarrow bbWW(qql\nu)$",
     id=21213,
-    xsecs=multiply_xsecs(ggHH_kl_2p45_kt_1, br_bbww_sl),
+    xsecs=multiply_xsecs(ggHH_kl_2p45_kt_1, br_bbww_qqlnu),
 )
 
-ggHH_kl_5_kt_1_sl_hbbhww = ggHH_kl_5_kt_1_sl_hbbhvv.add_process(
-    name="ggHH_kl_5_kt_1_sl_hbbhww",
+ggHH_kl_5_kt_1_qqlnu_hbbhww = ggHH_kl_5_kt_1_qqlnu_hbbhvv.add_process(
+    name="ggHH_kl_5_kt_1_qqlnu_hbbhww",
     label=r"$HH_{ggf}^{\kappa\lambda=5} \rightarrow bbWW(qql\nu)$",
     id=21214,
-    xsecs=multiply_xsecs(ggHH_kl_5_kt_1, br_bbww_sl),
+    xsecs=multiply_xsecs(ggHH_kl_5_kt_1, br_bbww_qqlnu),
 )
 
 # add process dependencies
-ggHH_sl_hbbhww.add_process(ggHH_kl_0_kt_1_sl_hbbhww)
-ggHH_sl_hbbhww.add_process(ggHH_kl_1_kt_1_sl_hbbhww)
-ggHH_sl_hbbhww.add_process(ggHH_kl_2p45_kt_1_sl_hbbhww)
-ggHH_sl_hbbhww.add_process(ggHH_kl_5_kt_1_sl_hbbhww)
+ggHH_qqlnu_hbbhww.add_process(ggHH_kl_0_kt_1_qqlnu_hbbhww)
+ggHH_qqlnu_hbbhww.add_process(ggHH_kl_1_kt_1_qqlnu_hbbhww)
+ggHH_qqlnu_hbbhww.add_process(ggHH_kl_2p45_kt_1_qqlnu_hbbhww)
+ggHH_qqlnu_hbbhww.add_process(ggHH_kl_5_kt_1_qqlnu_hbbhww)
 
-ggHH_kl_0_kt_1_hbbhww.add_process(ggHH_kl_0_kt_1_sl_hbbhww)
-ggHH_kl_1_kt_1_hbbhww.add_process(ggHH_kl_1_kt_1_sl_hbbhww)
-ggHH_kl_2p45_kt_1_hbbhww.add_process(ggHH_kl_2p45_kt_1_sl_hbbhww)
-ggHH_kl_5_kt_1_hbbhww.add_process(ggHH_kl_5_kt_1_sl_hbbhww)
+ggHH_kl_0_kt_1_hbbhww.add_process(ggHH_kl_0_kt_1_qqlnu_hbbhww)
+ggHH_kl_1_kt_1_hbbhww.add_process(ggHH_kl_1_kt_1_qqlnu_hbbhww)
+ggHH_kl_2p45_kt_1_hbbhww.add_process(ggHH_kl_2p45_kt_1_qqlnu_hbbhww)
+ggHH_kl_5_kt_1_hbbhww.add_process(ggHH_kl_5_kt_1_qqlnu_hbbhww)
 
 
 #
 # HH -> bbWW(lvlv), ggf
 #
 
-ggHH_dl_hbbhww = ggHH_hbbhww.add_process(
-    name="ggHH_dl_hbbhww",
+ggHH_2l2nu_hbbhww = ggHH_hbbhww.add_process(
+    name="ggHH_2l2nu_hbbhww",
     id=21220,
     label=r"$HH_{ggf} \rightarrow bbWW(l\nu l\nu)$",
 )
 
-ggHH_kl_0_kt_1_dl_hbbhww = ggHH_kl_0_kt_1_dl_hbbhvv.add_process(
-    name="ggHH_kl_0_kt_1_dl_hbbhww",
+ggHH_kl_0_kt_1_2l2nu_hbbhww = ggHH_kl_0_kt_1_2l2nu_hbbhvv.add_process(
+    name="ggHH_kl_0_kt_1_2l2nu_hbbhww",
     id=21221,
     label=r"$HH_{ggf}^{\kappa\lambda=0} \rightarrow bbWW(l\nu l\nu)$",
-    xsecs=multiply_xsecs(ggHH_kl_0_kt_1, br_bbww_dl),
+    xsecs=multiply_xsecs(ggHH_kl_0_kt_1, br_bbww_2l2nu),
 )
 
-ggHH_kl_1_kt_1_dl_hbbhww = ggHH_kl_1_kt_1_dl_hbbhvv.add_process(
-    name="ggHH_kl_1_kt_1_dl_hbbhww",
+ggHH_kl_1_kt_1_2l2nu_hbbhww = ggHH_kl_1_kt_1_2l2nu_hbbhvv.add_process(
+    name="ggHH_kl_1_kt_1_2l2nu_hbbhww",
     label=r"$HH_{ggf}^{\kappa\lambda=1} \rightarrow bbWW(l\nu l\nu)$",
     id=21222,
-    xsecs=multiply_xsecs(ggHH_kl_1_kt_1, br_bbww_dl),
+    xsecs=multiply_xsecs(ggHH_kl_1_kt_1, br_bbww_2l2nu),
 )
 
-ggHH_kl_2p45_kt_1_dl_hbbhww = ggHH_kl_2p45_kt_1_dl_hbbhvv.add_process(
-    name="ggHH_kl_2p45_kt_1_dl_hbbhww",
+ggHH_kl_2p45_kt_1_2l2nu_hbbhww = ggHH_kl_2p45_kt_1_2l2nu_hbbhvv.add_process(
+    name="ggHH_kl_2p45_kt_1_2l2nu_hbbhww",
     label=r"$HH_{ggf}^{\kappa\lambda=2.45} \rightarrow bbWW(l\nu l\nu)$",
     id=21223,
-    xsecs=multiply_xsecs(ggHH_kl_2p45_kt_1, br_bbww_dl),
+    xsecs=multiply_xsecs(ggHH_kl_2p45_kt_1, br_bbww_2l2nu),
 )
 
-ggHH_kl_5_kt_1_dl_hbbhww = ggHH_kl_5_kt_1_dl_hbbhvv.add_process(
-    name="ggHH_kl_5_kt_1_dl_hbbhww",
+ggHH_kl_5_kt_1_2l2nu_hbbhww = ggHH_kl_5_kt_1_2l2nu_hbbhvv.add_process(
+    name="ggHH_kl_5_kt_1_2l2nu_hbbhww",
     label=r"$HH_{ggf}^{\kappa\lambda=5} \rightarrow bbWW(l\nu l\nu)$",
     id=21224,
-    xsecs=multiply_xsecs(ggHH_kl_5_kt_1, br_bbww_dl),
+    xsecs=multiply_xsecs(ggHH_kl_5_kt_1, br_bbww_2l2nu),
 )
 
 # add process dependencies
-ggHH_dl_hbbhww.add_process(ggHH_kl_0_kt_1_dl_hbbhww)
-ggHH_dl_hbbhww.add_process(ggHH_kl_1_kt_1_dl_hbbhww)
-ggHH_dl_hbbhww.add_process(ggHH_kl_2p45_kt_1_dl_hbbhww)
-ggHH_dl_hbbhww.add_process(ggHH_kl_5_kt_1_dl_hbbhww)
+ggHH_2l2nu_hbbhww.add_process(ggHH_kl_0_kt_1_2l2nu_hbbhww)
+ggHH_2l2nu_hbbhww.add_process(ggHH_kl_1_kt_1_2l2nu_hbbhww)
+ggHH_2l2nu_hbbhww.add_process(ggHH_kl_2p45_kt_1_2l2nu_hbbhww)
+ggHH_2l2nu_hbbhww.add_process(ggHH_kl_5_kt_1_2l2nu_hbbhww)
 
-ggHH_kl_0_kt_1_hbbhww.add_process(ggHH_kl_0_kt_1_dl_hbbhww)
-ggHH_kl_1_kt_1_hbbhww.add_process(ggHH_kl_1_kt_1_dl_hbbhww)
-ggHH_kl_2p45_kt_1_hbbhww.add_process(ggHH_kl_2p45_kt_1_dl_hbbhww)
-ggHH_kl_5_kt_1_hbbhww.add_process(ggHH_kl_5_kt_1_dl_hbbhww)
+ggHH_kl_0_kt_1_hbbhww.add_process(ggHH_kl_0_kt_1_2l2nu_hbbhww)
+ggHH_kl_1_kt_1_hbbhww.add_process(ggHH_kl_1_kt_1_2l2nu_hbbhww)
+ggHH_kl_2p45_kt_1_hbbhww.add_process(ggHH_kl_2p45_kt_1_2l2nu_hbbhww)
+ggHH_kl_5_kt_1_hbbhww.add_process(ggHH_kl_5_kt_1_2l2nu_hbbhww)
 
 #
 # HH -> bbWW(qqlv), vbf
 #
 
-qqHH_sl_hbbhww = qqHH_hbbhww.add_process(
-    name="qqHH_sl_hbbhww",
+qqHH_qqlnu_hbbhww = qqHH_hbbhww.add_process(
+    name="qqHH_qqlnu_hbbhww",
     label=r"$HH_{vbf} \rightarrow bbWW(qql\nu)$",
     id=22210,
 )
 
-qqHH_CV_1_C2V_1_kl_1_sl_hbbhww = qqHH_CV_1_C2V_1_kl_1_sl_hbbhvv.add_process(
-    name="qqHH_CV_1_C2V_1_kl_1_sl_hbbhww",
+qqHH_CV_1_C2V_1_kl_1_qqlnu_hbbhww = qqHH_CV_1_C2V_1_kl_1_qqlnu_hbbhvv.add_process(
+    name="qqHH_CV_1_C2V_1_kl_1_qqlnu_hbbhww",
     label=r"$HH_{vbf}^{1,1,1} \rightarrow bbWW(qql\nu)$",
     id=22211,
-    xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_1, br_bbww_sl),
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_1, br_bbww_qqlnu),
 )
 
-qqHH_CV_1_C2V_1_kl_0_sl_hbbhww = qqHH_CV_1_C2V_1_kl_0_sl_hbbhvv.add_process(
-    name="qqHH_CV_1_C2V_1_kl_0_sl_hbbhww",
+qqHH_CV_1_C2V_1_kl_0_qqlnu_hbbhww = qqHH_CV_1_C2V_1_kl_0_qqlnu_hbbhvv.add_process(
+    name="qqHH_CV_1_C2V_1_kl_0_qqlnu_hbbhww",
     label=r"$HH_{vbf}^{1,1,0} \rightarrow bbWW(qql\nu)$",
     id=22212,
-    xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_0, br_bbww_sl),
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_0, br_bbww_qqlnu),
 )
 
-qqHH_CV_1_C2V_1_kl_2_sl_hbbhww = qqHH_CV_1_C2V_1_kl_2_sl_hbbhvv.add_process(
-    name="qqHH_CV_1_C2V_1_kl_2_sl_hbbhww",
+qqHH_CV_1_C2V_1_kl_2_qqlnu_hbbhww = qqHH_CV_1_C2V_1_kl_2_qqlnu_hbbhvv.add_process(
+    name="qqHH_CV_1_C2V_1_kl_2_qqlnu_hbbhww",
     label=r"$HH_{vbf}^{1,1,2} \rightarrow bbWW(qql\nu)$",
     id=22213,
-    xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_2, br_bbww_sl),
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_2, br_bbww_qqlnu),
 )
 
-qqHH_CV_1_C2V_0_kl_1_sl_hbbhww = qqHH_CV_1_C2V_0_kl_1_sl_hbbhvv.add_process(
-    name="qqHH_CV_1_C2V_0_kl_1_sl_hbbhww",
+qqHH_CV_1_C2V_0_kl_1_qqlnu_hbbhww = qqHH_CV_1_C2V_0_kl_1_qqlnu_hbbhvv.add_process(
+    name="qqHH_CV_1_C2V_0_kl_1_qqlnu_hbbhww",
     label=r"$HH_{vbf}^{1,0,1} \rightarrow bbWW(qql\nu)$",
     id=22214,
-    xsecs=multiply_xsecs(qqHH_CV_1_C2V_0_kl_1, br_bbww_sl),
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_0_kl_1, br_bbww_qqlnu),
 )
 
-qqHH_CV_1_C2V_2_kl_1_sl_hbbhww = qqHH_CV_1_C2V_2_kl_1_sl_hbbhvv.add_process(
-    name="qqHH_CV_1_C2V_2_kl_1_sl_hbbhww",
+qqHH_CV_1_C2V_2_kl_1_qqlnu_hbbhww = qqHH_CV_1_C2V_2_kl_1_qqlnu_hbbhvv.add_process(
+    name="qqHH_CV_1_C2V_2_kl_1_qqlnu_hbbhww",
     label=r"$HH_{vbf}^{1,2,1} \rightarrow bbWW(qql\nu)$",
     id=22215,
-    xsecs=multiply_xsecs(qqHH_CV_1_C2V_2_kl_1, br_bbww_sl),
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_2_kl_1, br_bbww_qqlnu),
 )
 
-qqHH_CV_0p5_C2V_1_kl_1_sl_hbbhww = qqHH_CV_0p5_C2V_1_kl_1_sl_hbbhvv.add_process(
-    name="qqHH_CV_0p5_C2V_1_kl_1_sl_hbbhww",
+qqHH_CV_0p5_C2V_1_kl_1_qqlnu_hbbhww = qqHH_CV_0p5_C2V_1_kl_1_qqlnu_hbbhvv.add_process(
+    name="qqHH_CV_0p5_C2V_1_kl_1_qqlnu_hbbhww",
     label=r"$HH_{vbf}^{0.5,1,1} \rightarrow bbWW(qql\nu)$",
     id=22216,
-    xsecs=multiply_xsecs(qqHH_CV_0p5_C2V_1_kl_1, br_bbww_sl),
+    xsecs=multiply_xsecs(qqHH_CV_0p5_C2V_1_kl_1, br_bbww_qqlnu),
 )
 
-qqHH_CV_1p5_C2V_1_kl_1_sl_hbbhww = qqHH_CV_1p5_C2V_1_kl_1_sl_hbbhvv.add_process(
-    name="qqHH_CV_1p5_C2V_1_kl_1_sl_hbbhww",
+qqHH_CV_1p5_C2V_1_kl_1_qqlnu_hbbhww = qqHH_CV_1p5_C2V_1_kl_1_qqlnu_hbbhvv.add_process(
+    name="qqHH_CV_1p5_C2V_1_kl_1_qqlnu_hbbhww",
     label=r"$HH_{vbf}^{1.5,1,1} \rightarrow bbWW(qql\nu)$",
     id=22217,
-    xsecs=multiply_xsecs(qqHH_CV_1p5_C2V_1_kl_1, br_bbww_sl),
+    xsecs=multiply_xsecs(qqHH_CV_1p5_C2V_1_kl_1, br_bbww_qqlnu),
 )
 
 # add process dependencies
-qqHH_sl_hbbhww.add_process(qqHH_CV_1_C2V_1_kl_1_sl_hbbhww)
-qqHH_sl_hbbhww.add_process(qqHH_CV_1_C2V_1_kl_0_sl_hbbhww)
-qqHH_sl_hbbhww.add_process(qqHH_CV_1_C2V_1_kl_2_sl_hbbhww)
-qqHH_sl_hbbhww.add_process(qqHH_CV_1_C2V_0_kl_1_sl_hbbhww)
-qqHH_sl_hbbhww.add_process(qqHH_CV_1_C2V_2_kl_1_sl_hbbhww)
-qqHH_sl_hbbhww.add_process(qqHH_CV_0p5_C2V_1_kl_1_sl_hbbhww)
-qqHH_sl_hbbhww.add_process(qqHH_CV_1p5_C2V_1_kl_1_sl_hbbhww)
+qqHH_qqlnu_hbbhww.add_process(qqHH_CV_1_C2V_1_kl_1_qqlnu_hbbhww)
+qqHH_qqlnu_hbbhww.add_process(qqHH_CV_1_C2V_1_kl_0_qqlnu_hbbhww)
+qqHH_qqlnu_hbbhww.add_process(qqHH_CV_1_C2V_1_kl_2_qqlnu_hbbhww)
+qqHH_qqlnu_hbbhww.add_process(qqHH_CV_1_C2V_0_kl_1_qqlnu_hbbhww)
+qqHH_qqlnu_hbbhww.add_process(qqHH_CV_1_C2V_2_kl_1_qqlnu_hbbhww)
+qqHH_qqlnu_hbbhww.add_process(qqHH_CV_0p5_C2V_1_kl_1_qqlnu_hbbhww)
+qqHH_qqlnu_hbbhww.add_process(qqHH_CV_1p5_C2V_1_kl_1_qqlnu_hbbhww)
 
-qqHH_CV_1_C2V_1_kl_1_hbbhww.add_process(qqHH_CV_1_C2V_1_kl_1_sl_hbbhww)
-qqHH_CV_1_C2V_1_kl_0_hbbhww.add_process(qqHH_CV_1_C2V_1_kl_0_sl_hbbhww)
-qqHH_CV_1_C2V_1_kl_2_hbbhww.add_process(qqHH_CV_1_C2V_1_kl_2_sl_hbbhww)
-qqHH_CV_1_C2V_0_kl_1_hbbhww.add_process(qqHH_CV_1_C2V_0_kl_1_sl_hbbhww)
-qqHH_CV_1_C2V_2_kl_1_hbbhww.add_process(qqHH_CV_1_C2V_2_kl_1_sl_hbbhww)
-qqHH_CV_0p5_C2V_1_kl_1_hbbhww.add_process(qqHH_CV_0p5_C2V_1_kl_1_sl_hbbhww)
-qqHH_CV_1p5_C2V_1_kl_1_hbbhww.add_process(qqHH_CV_1p5_C2V_1_kl_1_sl_hbbhww)
+qqHH_CV_1_C2V_1_kl_1_hbbhww.add_process(qqHH_CV_1_C2V_1_kl_1_qqlnu_hbbhww)
+qqHH_CV_1_C2V_1_kl_0_hbbhww.add_process(qqHH_CV_1_C2V_1_kl_0_qqlnu_hbbhww)
+qqHH_CV_1_C2V_1_kl_2_hbbhww.add_process(qqHH_CV_1_C2V_1_kl_2_qqlnu_hbbhww)
+qqHH_CV_1_C2V_0_kl_1_hbbhww.add_process(qqHH_CV_1_C2V_0_kl_1_qqlnu_hbbhww)
+qqHH_CV_1_C2V_2_kl_1_hbbhww.add_process(qqHH_CV_1_C2V_2_kl_1_qqlnu_hbbhww)
+qqHH_CV_0p5_C2V_1_kl_1_hbbhww.add_process(qqHH_CV_0p5_C2V_1_kl_1_qqlnu_hbbhww)
+qqHH_CV_1p5_C2V_1_kl_1_hbbhww.add_process(qqHH_CV_1p5_C2V_1_kl_1_qqlnu_hbbhww)
 
 #
 # HH -> bbWW(lvlv), vbf
 #
 
-qqHH_dl_hbbhww = qqHH_hbbhww.add_process(
-    name="qqHH_dl_hbbhww",
+qqHH_2l2nu_hbbhww = qqHH_hbbhww.add_process(
+    name="qqHH_2l2nu_hbbhww",
     label=r"$HH_{vbf} \rightarrow bbWW(l\nu l\nu)$",
     id=22220,
 )
 
-qqHH_CV_1_C2V_1_kl_1_dl_hbbhww = qqHH_CV_1_C2V_1_kl_1_dl_hbbhvv.add_process(
-    name="qqHH_CV_1_C2V_1_kl_1_dl_hbbhww",
+qqHH_CV_1_C2V_1_kl_1_2l2nu_hbbhww = qqHH_CV_1_C2V_1_kl_1_2l2nu_hbbhvv.add_process(
+    name="qqHH_CV_1_C2V_1_kl_1_2l2nu_hbbhww",
     label=r"$HH_{vbf}^{1,1,1} \rightarrow bbWW(l\nu l\nu)$",
     id=22221,
-    xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_1, br_bbww_dl),
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_1, br_bbww_2l2nu),
 )
 
-qqHH_CV_1_C2V_1_kl_0_dl_hbbhww = qqHH_CV_1_C2V_1_kl_0_dl_hbbhvv.add_process(
-    name="qqHH_CV_1_C2V_1_kl_0_dl_hbbhww",
+qqHH_CV_1_C2V_1_kl_0_2l2nu_hbbhww = qqHH_CV_1_C2V_1_kl_0_2l2nu_hbbhvv.add_process(
+    name="qqHH_CV_1_C2V_1_kl_0_2l2nu_hbbhww",
     label=r"$HH_{vbf}^{1,1,0} \rightarrow bbWW(l\nu l\nu)$",
     id=22222,
-    xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_0, br_bbww_dl),
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_0, br_bbww_2l2nu),
 )
 
-qqHH_CV_1_C2V_1_kl_2_dl_hbbhww = qqHH_CV_1_C2V_1_kl_2_dl_hbbhvv.add_process(
-    name="qqHH_CV_1_C2V_1_kl_2_dl_hbbhww",
+qqHH_CV_1_C2V_1_kl_2_2l2nu_hbbhww = qqHH_CV_1_C2V_1_kl_2_2l2nu_hbbhvv.add_process(
+    name="qqHH_CV_1_C2V_1_kl_2_2l2nu_hbbhww",
     label=r"$HH_{vbf}^{1,1,2} \rightarrow bbWW(l\nu l\nu)$",
     id=22223,
-    xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_2, br_bbww_dl),
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_2, br_bbww_2l2nu),
 )
 
-qqHH_CV_1_C2V_0_kl_1_dl_hbbhww = qqHH_CV_1_C2V_0_kl_1_dl_hbbhvv.add_process(
-    name="qqHH_CV_1_C2V_0_kl_1_dl_hbbhww",
+qqHH_CV_1_C2V_0_kl_1_2l2nu_hbbhww = qqHH_CV_1_C2V_0_kl_1_2l2nu_hbbhvv.add_process(
+    name="qqHH_CV_1_C2V_0_kl_1_2l2nu_hbbhww",
     label=r"$HH_{vbf}^{1,0,1} \rightarrow bbWW(l\nu l\nu)$",
     id=22224,
-    xsecs=multiply_xsecs(qqHH_CV_1_C2V_0_kl_1, br_bbww_dl),
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_0_kl_1, br_bbww_2l2nu),
 )
 
-qqHH_CV_1_C2V_2_kl_1_dl_hbbhww = qqHH_CV_1_C2V_2_kl_1_dl_hbbhvv.add_process(
-    name="qqHH_CV_1_C2V_2_kl_1_dl_hbbhww",
+qqHH_CV_1_C2V_2_kl_1_2l2nu_hbbhww = qqHH_CV_1_C2V_2_kl_1_2l2nu_hbbhvv.add_process(
+    name="qqHH_CV_1_C2V_2_kl_1_2l2nu_hbbhww",
     label=r"$HH_{vbf}^{1,2,1} \rightarrow bbWW(l\nu l\nu)$",
     id=22225,
-    xsecs=multiply_xsecs(qqHH_CV_1_C2V_2_kl_1, br_bbww_dl),
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_2_kl_1, br_bbww_2l2nu),
 )
 
-qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhww = qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhvv.add_process(
-    name="qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhww",
+qqHH_CV_0p5_C2V_1_kl_1_2l2nu_hbbhww = qqHH_CV_0p5_C2V_1_kl_1_2l2nu_hbbhvv.add_process(
+    name="qqHH_CV_0p5_C2V_1_kl_1_2l2nu_hbbhww",
     label=r"$HH_{vbf}^{0.5,1,1} \rightarrow bbWW(l\nu l\nu)$",
     id=22226,
-    xsecs=multiply_xsecs(qqHH_CV_0p5_C2V_1_kl_1, br_bbww_dl),
+    xsecs=multiply_xsecs(qqHH_CV_0p5_C2V_1_kl_1, br_bbww_2l2nu),
 )
 
-qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhww = qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhvv.add_process(
-    name="qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhww",
+qqHH_CV_1p5_C2V_1_kl_1_2l2nu_hbbhww = qqHH_CV_1p5_C2V_1_kl_1_2l2nu_hbbhvv.add_process(
+    name="qqHH_CV_1p5_C2V_1_kl_1_2l2nu_hbbhww",
     label=r"$HH_{vbf}^{1.5,1,1} \rightarrow bbWW(l\nu l\nu)$",
     id=22227,
-    xsecs=multiply_xsecs(qqHH_CV_1p5_C2V_1_kl_1, br_bbww_dl),
+    xsecs=multiply_xsecs(qqHH_CV_1p5_C2V_1_kl_1, br_bbww_2l2nu),
 )
 
 # add process dependencies
-qqHH_dl_hbbhww.add_process(qqHH_CV_1_C2V_1_kl_1_dl_hbbhww)
-qqHH_dl_hbbhww.add_process(qqHH_CV_1_C2V_1_kl_0_dl_hbbhww)
-qqHH_dl_hbbhww.add_process(qqHH_CV_1_C2V_1_kl_2_dl_hbbhww)
-qqHH_dl_hbbhww.add_process(qqHH_CV_1_C2V_0_kl_1_dl_hbbhww)
-qqHH_dl_hbbhww.add_process(qqHH_CV_1_C2V_2_kl_1_dl_hbbhww)
-qqHH_dl_hbbhww.add_process(qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhww)
-qqHH_dl_hbbhww.add_process(qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhww)
+qqHH_2l2nu_hbbhww.add_process(qqHH_CV_1_C2V_1_kl_1_2l2nu_hbbhww)
+qqHH_2l2nu_hbbhww.add_process(qqHH_CV_1_C2V_1_kl_0_2l2nu_hbbhww)
+qqHH_2l2nu_hbbhww.add_process(qqHH_CV_1_C2V_1_kl_2_2l2nu_hbbhww)
+qqHH_2l2nu_hbbhww.add_process(qqHH_CV_1_C2V_0_kl_1_2l2nu_hbbhww)
+qqHH_2l2nu_hbbhww.add_process(qqHH_CV_1_C2V_2_kl_1_2l2nu_hbbhww)
+qqHH_2l2nu_hbbhww.add_process(qqHH_CV_0p5_C2V_1_kl_1_2l2nu_hbbhww)
+qqHH_2l2nu_hbbhww.add_process(qqHH_CV_1p5_C2V_1_kl_1_2l2nu_hbbhww)
 
-qqHH_CV_1_C2V_1_kl_1_hbbhww.add_process(qqHH_CV_1_C2V_1_kl_1_dl_hbbhww)
-qqHH_CV_1_C2V_1_kl_0_hbbhww.add_process(qqHH_CV_1_C2V_1_kl_0_dl_hbbhww)
-qqHH_CV_1_C2V_1_kl_2_hbbhww.add_process(qqHH_CV_1_C2V_1_kl_2_dl_hbbhww)
-qqHH_CV_1_C2V_0_kl_1_hbbhww.add_process(qqHH_CV_1_C2V_0_kl_1_dl_hbbhww)
-qqHH_CV_1_C2V_2_kl_1_hbbhww.add_process(qqHH_CV_1_C2V_2_kl_1_dl_hbbhww)
-qqHH_CV_0p5_C2V_1_kl_1_hbbhww.add_process(qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhww)
-qqHH_CV_1p5_C2V_1_kl_1_hbbhww.add_process(qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhww)
+qqHH_CV_1_C2V_1_kl_1_hbbhww.add_process(qqHH_CV_1_C2V_1_kl_1_2l2nu_hbbhww)
+qqHH_CV_1_C2V_1_kl_0_hbbhww.add_process(qqHH_CV_1_C2V_1_kl_0_2l2nu_hbbhww)
+qqHH_CV_1_C2V_1_kl_2_hbbhww.add_process(qqHH_CV_1_C2V_1_kl_2_2l2nu_hbbhww)
+qqHH_CV_1_C2V_0_kl_1_hbbhww.add_process(qqHH_CV_1_C2V_0_kl_1_2l2nu_hbbhww)
+qqHH_CV_1_C2V_2_kl_1_hbbhww.add_process(qqHH_CV_1_C2V_2_kl_1_2l2nu_hbbhww)
+qqHH_CV_0p5_C2V_1_kl_1_hbbhww.add_process(qqHH_CV_0p5_C2V_1_kl_1_2l2nu_hbbhww)
+qqHH_CV_1p5_C2V_1_kl_1_hbbhww.add_process(qqHH_CV_1p5_C2V_1_kl_1_2l2nu_hbbhww)
 
 ##############################################################
 #
@@ -846,7 +845,7 @@ qqHH_CV_1p5_C2V_1_kl_1_hbbhww.add_process(qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhww)
 # HH -> bbZZ (incl), ggf
 #
 
-ggHH_hbbhzz = ggHH_dl_hbbhvv.add_process(
+ggHH_hbbhzz = ggHH_2l2nu_hbbhvv.add_process(
     name="ggHH_hbbhzz",
     id=21300,
     label=r"$HH_{ggf} \rightarrow bbZZ$",
@@ -958,128 +957,128 @@ qqHH_hbbhzz.add_process(qqHH_CV_1p5_C2V_1_kl_1_hbbhzz)
 # HH -> bbZZ, ggf
 #
 
-ggHH_dl_hbbhzz = ggHH_hbbhzz.add_process(
-    name="ggHH_dl_hbbhzz",
+ggHH_2l2nu_hbbhzz = ggHH_hbbhzz.add_process(
+    name="ggHH_2l2nu_hbbhzz",
     id=21320,
     label=r"$HH_{ggf} \rightarrow bbZZ(ll \nu \nu)$",
 )
 
-ggHH_kl_0_kt_1_dl_hbbhzz = ggHH_kl_0_kt_1_dl_hbbhvv.add_process(
-    name="ggHH_kl_0_kt_1_dl_hbbhzz",
+ggHH_kl_0_kt_1_2l2nu_hbbhzz = ggHH_kl_0_kt_1_2l2nu_hbbhvv.add_process(
+    name="ggHH_kl_0_kt_1_2l2nu_hbbhzz",
     id=21321,
     label=r"$HH_{ggf}^{\kappa\lambda=0} \rightarrow bbZZ(ll \nu \nu)$",
-    xsecs=multiply_xsecs(ggHH_kl_0_kt_1, br_bbzz_dl),
+    xsecs=multiply_xsecs(ggHH_kl_0_kt_1, br_bbzz_2l2nu),
 )
 
-ggHH_kl_1_kt_1_dl_hbbhzz = ggHH_kl_1_kt_1_dl_hbbhvv.add_process(
-    name="ggHH_kl_1_kt_1_dl_hbbhzz",
+ggHH_kl_1_kt_1_2l2nu_hbbhzz = ggHH_kl_1_kt_1_2l2nu_hbbhvv.add_process(
+    name="ggHH_kl_1_kt_1_2l2nu_hbbhzz",
     label=r"$HH_{ggf}^{\kappa\lambda=1} \rightarrow bbZZ(ll \nu \nu)$",
     id=21322,
-    xsecs=multiply_xsecs(ggHH_kl_1_kt_1, br_bbzz_dl),
+    xsecs=multiply_xsecs(ggHH_kl_1_kt_1, br_bbzz_2l2nu),
 )
 
-ggHH_kl_2p45_kt_1_dl_hbbhzz = ggHH_kl_2p45_kt_1_dl_hbbhvv.add_process(
-    name="ggHH_kl_2p45_kt_1_dl_hbbhzz",
+ggHH_kl_2p45_kt_1_2l2nu_hbbhzz = ggHH_kl_2p45_kt_1_2l2nu_hbbhvv.add_process(
+    name="ggHH_kl_2p45_kt_1_2l2nu_hbbhzz",
     label=r"$HH_{ggf}^{\kappa\lambda=2.45} \rightarrow bbZZ(ll \nu \nu)$",
     id=21323,
-    xsecs=multiply_xsecs(ggHH_kl_2p45_kt_1, br_bbzz_dl),
+    xsecs=multiply_xsecs(ggHH_kl_2p45_kt_1, br_bbzz_2l2nu),
 )
 
-ggHH_kl_5_kt_1_dl_hbbhzz = ggHH_kl_5_kt_1_dl_hbbhvv.add_process(
-    name="ggHH_kl_5_kt_1_dl_hbbhzz",
+ggHH_kl_5_kt_1_2l2nu_hbbhzz = ggHH_kl_5_kt_1_2l2nu_hbbhvv.add_process(
+    name="ggHH_kl_5_kt_1_2l2nu_hbbhzz",
     label=r"$HH_{ggf}^{\kappa\lambda=5} \rightarrow bbZZ(ll \nu \nu)$",
     id=21324,
-    xsecs=multiply_xsecs(ggHH_kl_5_kt_1, br_bbzz_dl),
+    xsecs=multiply_xsecs(ggHH_kl_5_kt_1, br_bbzz_2l2nu),
 )
 
 
 # add process dependencies
-ggHH_dl_hbbhzz.add_process(ggHH_kl_0_kt_1_dl_hbbhzz)
-ggHH_dl_hbbhzz.add_process(ggHH_kl_1_kt_1_dl_hbbhzz)
-ggHH_dl_hbbhzz.add_process(ggHH_kl_2p45_kt_1_dl_hbbhzz)
-ggHH_dl_hbbhzz.add_process(ggHH_kl_5_kt_1_dl_hbbhzz)
+ggHH_2l2nu_hbbhzz.add_process(ggHH_kl_0_kt_1_2l2nu_hbbhzz)
+ggHH_2l2nu_hbbhzz.add_process(ggHH_kl_1_kt_1_2l2nu_hbbhzz)
+ggHH_2l2nu_hbbhzz.add_process(ggHH_kl_2p45_kt_1_2l2nu_hbbhzz)
+ggHH_2l2nu_hbbhzz.add_process(ggHH_kl_5_kt_1_2l2nu_hbbhzz)
 
-ggHH_kl_0_kt_1_hbbhzz.add_process(ggHH_kl_0_kt_1_dl_hbbhzz)
-ggHH_kl_1_kt_1_hbbhzz.add_process(ggHH_kl_1_kt_1_dl_hbbhzz)
-ggHH_kl_2p45_kt_1_hbbhzz.add_process(ggHH_kl_2p45_kt_1_dl_hbbhzz)
-ggHH_kl_5_kt_1_hbbhzz.add_process(ggHH_kl_5_kt_1_dl_hbbhzz)
+ggHH_kl_0_kt_1_hbbhzz.add_process(ggHH_kl_0_kt_1_2l2nu_hbbhzz)
+ggHH_kl_1_kt_1_hbbhzz.add_process(ggHH_kl_1_kt_1_2l2nu_hbbhzz)
+ggHH_kl_2p45_kt_1_hbbhzz.add_process(ggHH_kl_2p45_kt_1_2l2nu_hbbhzz)
+ggHH_kl_5_kt_1_hbbhzz.add_process(ggHH_kl_5_kt_1_2l2nu_hbbhzz)
 
 
 #
 # HH -> bbZZ(lvlv), vbf
 #
 
-qqHH_dl_hbbhzz = qqHH_hbbhzz.add_process(
-    name="qqHH_dl_hbbhzz",
+qqHH_2l2nu_hbbhzz = qqHH_hbbhzz.add_process(
+    name="qqHH_2l2nu_hbbhzz",
     label=r"$HH_{vbf} \rightarrow bbZZ(ll \nu \nu)$",
     id=22320,
 )
 
-qqHH_CV_1_C2V_1_kl_1_dl_hbbhzz = qqHH_CV_1_C2V_1_kl_1_dl_hbbhvv.add_process(
-    name="qqHH_CV_1_C2V_1_kl_1_dl_hbbhzz",
+qqHH_CV_1_C2V_1_kl_1_2l2nu_hbbhzz = qqHH_CV_1_C2V_1_kl_1_2l2nu_hbbhvv.add_process(
+    name="qqHH_CV_1_C2V_1_kl_1_2l2nu_hbbhzz",
     label=r"$HH_{vbf}^{1,1,1} \rightarrow bbZZ(ll \nu \nu)$",
     id=22321,
-    xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_1, br_bbzz_dl),
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_1, br_bbzz_2l2nu),
 )
 
-qqHH_CV_1_C2V_1_kl_0_dl_hbbhzz = qqHH_CV_1_C2V_1_kl_0_dl_hbbhvv.add_process(
-    name="qqHH_CV_1_C2V_1_kl_0_dl_hbbhzz",
+qqHH_CV_1_C2V_1_kl_0_2l2nu_hbbhzz = qqHH_CV_1_C2V_1_kl_0_2l2nu_hbbhvv.add_process(
+    name="qqHH_CV_1_C2V_1_kl_0_2l2nu_hbbhzz",
     label=r"$HH_{vbf}^{1,1,0} \rightarrow bbZZ(ll \nu \nu)$",
     id=22322,
-    xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_0, br_bbzz_dl),
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_0, br_bbzz_2l2nu),
 )
 
-qqHH_CV_1_C2V_1_kl_2_dl_hbbhzz = qqHH_CV_1_C2V_1_kl_2_dl_hbbhvv.add_process(
-    name="qqHH_CV_1_C2V_1_kl_2_dl_hbbhzz",
+qqHH_CV_1_C2V_1_kl_2_2l2nu_hbbhzz = qqHH_CV_1_C2V_1_kl_2_2l2nu_hbbhvv.add_process(
+    name="qqHH_CV_1_C2V_1_kl_2_2l2nu_hbbhzz",
     label=r"$HH_{vbf}^{1,1,2} \rightarrow bbZZ(ll \nu \nu)$",
     id=22323,
-    xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_2, br_bbzz_dl),
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_2, br_bbzz_2l2nu),
 )
 
-qqHH_CV_1_C2V_0_kl_1_dl_hbbhzz = qqHH_CV_1_C2V_0_kl_1_dl_hbbhvv.add_process(
-    name="qqHH_CV_1_C2V_0_kl_1_dl_hbbhzz",
+qqHH_CV_1_C2V_0_kl_1_2l2nu_hbbhzz = qqHH_CV_1_C2V_0_kl_1_2l2nu_hbbhvv.add_process(
+    name="qqHH_CV_1_C2V_0_kl_1_2l2nu_hbbhzz",
     label=r"$HH_{vbf}^{1,0,1} \rightarrow bbZZ(ll \nu \nu)$",
     id=22324,
-    xsecs=multiply_xsecs(qqHH_CV_1_C2V_0_kl_1, br_bbzz_dl),
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_0_kl_1, br_bbzz_2l2nu),
 )
 
-qqHH_CV_1_C2V_2_kl_1_dl_hbbhzz = qqHH_CV_1_C2V_2_kl_1_dl_hbbhvv.add_process(
-    name="qqHH_CV_1_C2V_2_kl_1_dl_hbbhzz",
+qqHH_CV_1_C2V_2_kl_1_2l2nu_hbbhzz = qqHH_CV_1_C2V_2_kl_1_2l2nu_hbbhvv.add_process(
+    name="qqHH_CV_1_C2V_2_kl_1_2l2nu_hbbhzz",
     label=r"$HH_{vbf}^{1,2,1} \rightarrow bbZZ(ll \nu \nu)$",
     id=22325,
-    xsecs=multiply_xsecs(qqHH_CV_1_C2V_2_kl_1, br_bbzz_dl),
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_2_kl_1, br_bbzz_2l2nu),
 )
 
-qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhzz = qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhvv.add_process(
-    name="qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhzz",
+qqHH_CV_0p5_C2V_1_kl_1_2l2nu_hbbhzz = qqHH_CV_0p5_C2V_1_kl_1_2l2nu_hbbhvv.add_process(
+    name="qqHH_CV_0p5_C2V_1_kl_1_2l2nu_hbbhzz",
     label=r"$HH_{vbf}^{0.5,1,1} \rightarrow bbZZ(ll \nu \nu)$",
     id=22326,
-    xsecs=multiply_xsecs(qqHH_CV_0p5_C2V_1_kl_1, br_bbzz_dl),
+    xsecs=multiply_xsecs(qqHH_CV_0p5_C2V_1_kl_1, br_bbzz_2l2nu),
 )
 
-qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhzz = qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhvv.add_process(
-    name="qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhzz",
+qqHH_CV_1p5_C2V_1_kl_1_2l2nu_hbbhzz = qqHH_CV_1p5_C2V_1_kl_1_2l2nu_hbbhvv.add_process(
+    name="qqHH_CV_1p5_C2V_1_kl_1_2l2nu_hbbhzz",
     label=r"$HH_{vbf}^{1.5,1,1} \rightarrow bbZZ(ll \nu \nu)$",
     id=22327,
-    xsecs=multiply_xsecs(qqHH_CV_1p5_C2V_1_kl_1, br_bbzz_dl),
+    xsecs=multiply_xsecs(qqHH_CV_1p5_C2V_1_kl_1, br_bbzz_2l2nu),
 )
 
 # add process dependencies
-qqHH_dl_hbbhzz.add_process(qqHH_CV_1_C2V_1_kl_1_dl_hbbhzz)
-qqHH_dl_hbbhzz.add_process(qqHH_CV_1_C2V_1_kl_0_dl_hbbhzz)
-qqHH_dl_hbbhzz.add_process(qqHH_CV_1_C2V_1_kl_2_dl_hbbhzz)
-qqHH_dl_hbbhzz.add_process(qqHH_CV_1_C2V_0_kl_1_dl_hbbhzz)
-qqHH_dl_hbbhzz.add_process(qqHH_CV_1_C2V_2_kl_1_dl_hbbhzz)
-qqHH_dl_hbbhzz.add_process(qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhzz)
-qqHH_dl_hbbhzz.add_process(qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhzz)
+qqHH_2l2nu_hbbhzz.add_process(qqHH_CV_1_C2V_1_kl_1_2l2nu_hbbhzz)
+qqHH_2l2nu_hbbhzz.add_process(qqHH_CV_1_C2V_1_kl_0_2l2nu_hbbhzz)
+qqHH_2l2nu_hbbhzz.add_process(qqHH_CV_1_C2V_1_kl_2_2l2nu_hbbhzz)
+qqHH_2l2nu_hbbhzz.add_process(qqHH_CV_1_C2V_0_kl_1_2l2nu_hbbhzz)
+qqHH_2l2nu_hbbhzz.add_process(qqHH_CV_1_C2V_2_kl_1_2l2nu_hbbhzz)
+qqHH_2l2nu_hbbhzz.add_process(qqHH_CV_0p5_C2V_1_kl_1_2l2nu_hbbhzz)
+qqHH_2l2nu_hbbhzz.add_process(qqHH_CV_1p5_C2V_1_kl_1_2l2nu_hbbhzz)
 
-qqHH_CV_1_C2V_1_kl_1_hbbhzz.add_process(qqHH_CV_1_C2V_1_kl_1_dl_hbbhzz)
-qqHH_CV_1_C2V_1_kl_0_hbbhzz.add_process(qqHH_CV_1_C2V_1_kl_0_dl_hbbhzz)
-qqHH_CV_1_C2V_1_kl_2_hbbhzz.add_process(qqHH_CV_1_C2V_1_kl_2_dl_hbbhzz)
-qqHH_CV_1_C2V_0_kl_1_hbbhzz.add_process(qqHH_CV_1_C2V_0_kl_1_dl_hbbhzz)
-qqHH_CV_1_C2V_2_kl_1_hbbhzz.add_process(qqHH_CV_1_C2V_2_kl_1_dl_hbbhzz)
-qqHH_CV_0p5_C2V_1_kl_1_hbbhzz.add_process(qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhzz)
-qqHH_CV_1p5_C2V_1_kl_1_hbbhzz.add_process(qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhzz)
+qqHH_CV_1_C2V_1_kl_1_hbbhzz.add_process(qqHH_CV_1_C2V_1_kl_1_2l2nu_hbbhzz)
+qqHH_CV_1_C2V_1_kl_0_hbbhzz.add_process(qqHH_CV_1_C2V_1_kl_0_2l2nu_hbbhzz)
+qqHH_CV_1_C2V_1_kl_2_hbbhzz.add_process(qqHH_CV_1_C2V_1_kl_2_2l2nu_hbbhzz)
+qqHH_CV_1_C2V_0_kl_1_hbbhzz.add_process(qqHH_CV_1_C2V_0_kl_1_2l2nu_hbbhzz)
+qqHH_CV_1_C2V_2_kl_1_hbbhzz.add_process(qqHH_CV_1_C2V_2_kl_1_2l2nu_hbbhzz)
+qqHH_CV_0p5_C2V_1_kl_1_hbbhzz.add_process(qqHH_CV_0p5_C2V_1_kl_1_2l2nu_hbbhzz)
+qqHH_CV_1p5_C2V_1_kl_1_hbbhzz.add_process(qqHH_CV_1p5_C2V_1_kl_1_2l2nu_hbbhzz)
 
 
 #############################################################

--- a/cmsdb/processes/hh2bbww.py
+++ b/cmsdb/processes/hh2bbww.py
@@ -247,28 +247,28 @@ ggHH_dl_hbbhvv = ggHH_hbbhvv.add_process(
     label=r"$HH_{ggf} \rightarrow bbVV(2l2\nu)$",
 )
 
-ggHH_kl_0_kt_1_dl_hbbhvv = ggHH_kl_0_kt_1.add_process(
+ggHH_kl_0_kt_1_dl_hbbhvv = ggHH_kl_0_kt_1_hbbhvv.add_process(
     name="ggHH_kl_0_kt_1_dl_hbbhvv",
     id=21321,
     label=r"$HH_{ggf}^{\kappa\lambda=0} \rightarrow bbVV(2l2\nu)$",
     xsecs=multiply_xsecs(ggHH_kl_0_kt_1, br_bbvv_dl),
 )
 
-ggHH_kl_1_kt_1_dl_hbbhvv = ggHH_kl_1_kt_1.add_process(
+ggHH_kl_1_kt_1_dl_hbbhvv = ggHH_kl_1_kt_1_hbbhvv.add_process(
     name="ggHH_kl_1_kt_1_dl_hbbhvv",
     label=r"$HH_{ggf}^{\kappa\lambda=1} \rightarrow bbVV(2l2\nu)$",
     id=21322,
     xsecs=multiply_xsecs(ggHH_kl_1_kt_1, br_bbvv_dl),
 )
 
-ggHH_kl_2p45_kt_1_dl_hbbhvv = ggHH_kl_2p45_kt_1.add_process(
+ggHH_kl_2p45_kt_1_dl_hbbhvv = ggHH_kl_2p45_kt_1_hbbhvv.add_process(
     name="ggHH_kl_2p45_kt_1_dl_hbbhvv",
     label=r"$HH_{ggf}^{\kappa\lambda=2.45} \rightarrow bbVV(2l2\nu)$",
     id=21323,
     xsecs=multiply_xsecs(ggHH_kl_2p45_kt_1, br_bbvv_dl),
 )
 
-ggHH_kl_5_kt_1_dl_hbbhvv = ggHH_kl_5_kt_1.add_process(
+ggHH_kl_5_kt_1_dl_hbbhvv = ggHH_kl_5_kt_1_hbbhvv.add_process(
     name="ggHH_kl_5_kt_1_dl_hbbhvv",
     label=r"$HH_{ggf}^{\kappa\lambda=5} \rightarrow bbVV(2l2\nu)$",
     id=21324,
@@ -293,49 +293,49 @@ qqHH_dl_hbbhvv = qqHH_hbbhvv.add_process(
     id=22420,
 )
 
-qqHH_CV_1_C2V_1_kl_1_dl_hbbhvv = qqHH_CV_1_C2V_1_kl_1.add_process(
+qqHH_CV_1_C2V_1_kl_1_dl_hbbhvv = qqHH_CV_1_C2V_1_kl_1_hbbhvv.add_process(
     name="qqHH_CV_1_C2V_1_kl_1_dl_hbbhvv",
     label=r"$HH_{vbf}^{1,1,1} \rightarrow bbVV(2l2\nu)$",
     id=22421,
     xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_1, br_bbvv_dl),
 )
 
-qqHH_CV_1_C2V_1_kl_0_dl_hbbhvv = qqHH_CV_1_C2V_1_kl_0.add_process(
+qqHH_CV_1_C2V_1_kl_0_dl_hbbhvv = qqHH_CV_1_C2V_1_kl_0_hbbhvv.add_process(
     name="qqHH_CV_1_C2V_1_kl_0_dl_hbbhvv",
     label=r"$HH_{vbf}^{1,1,0} \rightarrow bbVV(2l2\nu)$",
     id=22422,
     xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_0, br_bbvv_dl),
 )
 
-qqHH_CV_1_C2V_1_kl_2_dl_hbbhvv = qqHH_CV_1_C2V_1_kl_2.add_process(
+qqHH_CV_1_C2V_1_kl_2_dl_hbbhvv = qqHH_CV_1_C2V_1_kl_2_hbbhvv.add_process(
     name="qqHH_CV_1_C2V_1_kl_2_dl_hbbhvv",
     label=r"$HH_{vbf}^{1,1,2} \rightarrow bbVV(2l2\nu)$",
     id=22423,
     xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_2, br_bbvv_dl),
 )
 
-qqHH_CV_1_C2V_0_kl_1_dl_hbbhvv = qqHH_CV_1_C2V_0_kl_1.add_process(
+qqHH_CV_1_C2V_0_kl_1_dl_hbbhvv = qqHH_CV_1_C2V_0_kl_1_hbbhvv.add_process(
     name="qqHH_CV_1_C2V_0_kl_1_dl_hbbhvv",
     label=r"$HH_{vbf}^{1,0,1} \rightarrow bbVV(2l2\nu)$",
     id=22424,
     xsecs=multiply_xsecs(qqHH_CV_1_C2V_0_kl_1, br_bbvv_dl),
 )
 
-qqHH_CV_1_C2V_2_kl_1_dl_hbbhvv = qqHH_CV_1_C2V_2_kl_1.add_process(
+qqHH_CV_1_C2V_2_kl_1_dl_hbbhvv = qqHH_CV_1_C2V_2_kl_1_hbbhvv.add_process(
     name="qqHH_CV_1_C2V_2_kl_1_dl_hbbhvv",
     label=r"$HH_{vbf}^{1,2,1} \rightarrow bbVV(2l2\nu)$",
     id=22425,
     xsecs=multiply_xsecs(qqHH_CV_1_C2V_2_kl_1, br_bbvv_dl),
 )
 
-qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhvv = qqHH_CV_0p5_C2V_1_kl_1.add_process(
+qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhvv = qqHH_CV_0p5_C2V_1_kl_1_hbbhvv.add_process(
     name="qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhvv",
     label=r"$HH_{vbf}^{0.5,1,1} \rightarrow bbVV(2l2\nu)$",
     id=22426,
     xsecs=multiply_xsecs(qqHH_CV_0p5_C2V_1_kl_1, br_bbvv_dl),
 )
 
-qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhvv = qqHH_CV_1p5_C2V_1_kl_1.add_process(
+qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhvv = qqHH_CV_1p5_C2V_1_kl_1_hbbhvv.add_process(
     name="qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhvv",
     label=r"$HH_{vbf}^{1.5,1,1} \rightarrow bbVV(2l2\nu)$",
     id=22427,
@@ -351,6 +351,9 @@ qqHH_dl_hbbhvv.add_process(qqHH_CV_1_C2V_2_kl_1_dl_hbbhvv)
 qqHH_dl_hbbhvv.add_process(qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhvv)
 qqHH_dl_hbbhvv.add_process(qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhvv)
 
+#
+# NOTE: HH -> bbWW(incl) not yet included
+#
 
 #
 # HH -> bbWW(qqlv), ggf
@@ -362,28 +365,28 @@ ggHH_sl_hbbhww = ggHH_hbbhww.add_process(
     label=r"$HH_{ggf} \rightarrow bbWW(qql\nu)$",
 )
 
-ggHH_kl_0_kt_1_sl_hbbhww = ggHH_kl_0_kt_1.add_process(
+ggHH_kl_0_kt_1_sl_hbbhww = ggHH_kl_0_kt_1_hbbhvv.add_process(
     name="ggHH_kl_0_kt_1_sl_hbbhww",
     id=21211,
     label=r"$HH_{ggf}^{\kappa\lambda=0} \rightarrow bbWW(qql\nu)$",
     xsecs=multiply_xsecs(ggHH_kl_0_kt_1, br_bbww_sl),
 )
 
-ggHH_kl_1_kt_1_sl_hbbhww = ggHH_kl_1_kt_1.add_process(
+ggHH_kl_1_kt_1_sl_hbbhww = ggHH_kl_1_kt_1_hbbhvv.add_process(
     name="ggHH_kl_1_kt_1_sl_hbbhww",
     label=r"$HH_{ggf}^{\kappa\lambda=1} \rightarrow bbWW(qql\nu)$",
     id=21212,
     xsecs=multiply_xsecs(ggHH_kl_1_kt_1, br_bbww_sl),
 )
 
-ggHH_kl_2p45_kt_1_sl_hbbhww = ggHH_kl_2p45_kt_1.add_process(
+ggHH_kl_2p45_kt_1_sl_hbbhww = ggHH_kl_2p45_kt_1_hbbhvv.add_process(
     name="ggHH_kl_2p45_kt_1_sl_hbbhww",
     label=r"$HH_{ggf}^{\kappa\lambda=2.45} \rightarrow bbWW(qql\nu)$",
     id=21213,
     xsecs=multiply_xsecs(ggHH_kl_2p45_kt_1, br_bbww_sl),
 )
 
-ggHH_kl_5_kt_1_sl_hbbhww = ggHH_kl_5_kt_1.add_process(
+ggHH_kl_5_kt_1_sl_hbbhww = ggHH_kl_5_kt_1_hbbhvv.add_process(
     name="ggHH_kl_5_kt_1_sl_hbbhww",
     label=r"$HH_{ggf}^{\kappa\lambda=5} \rightarrow bbWW(qql\nu)$",
     id=21214,
@@ -406,28 +409,28 @@ ggHH_dl_hbbhww = ggHH_hbbhww.add_process(
     label=r"$HH_{ggf} \rightarrow bbWW(l\nu l\nu)$",
 )
 
-ggHH_kl_0_kt_1_dl_hbbhww = ggHH_kl_0_kt_1.add_process(
+ggHH_kl_0_kt_1_dl_hbbhww = ggHH_kl_0_kt_1_dl_hbbhvv.add_process(
     name="ggHH_kl_0_kt_1_dl_hbbhww",
     id=21221,
     label=r"$HH_{ggf}^{\kappa\lambda=0} \rightarrow bbWW(l\nu l\nu)$",
     xsecs=multiply_xsecs(ggHH_kl_0_kt_1, br_bbww_dl),
 )
 
-ggHH_kl_1_kt_1_dl_hbbhww = ggHH_kl_1_kt_1.add_process(
+ggHH_kl_1_kt_1_dl_hbbhww = ggHH_kl_1_kt_1_dl_hbbhvv.add_process(
     name="ggHH_kl_1_kt_1_dl_hbbhww",
     label=r"$HH_{ggf}^{\kappa\lambda=1} \rightarrow bbWW(l\nu l\nu)$",
     id=21222,
     xsecs=multiply_xsecs(ggHH_kl_1_kt_1, br_bbww_dl),
 )
 
-ggHH_kl_2p45_kt_1_dl_hbbhww = ggHH_kl_2p45_kt_1.add_process(
+ggHH_kl_2p45_kt_1_dl_hbbhww = ggHH_kl_2p45_kt_1_dl_hbbhvv.add_process(
     name="ggHH_kl_2p45_kt_1_dl_hbbhww",
     label=r"$HH_{ggf}^{\kappa\lambda=2.45} \rightarrow bbWW(l\nu l\nu)$",
     id=21223,
     xsecs=multiply_xsecs(ggHH_kl_2p45_kt_1, br_bbww_dl),
 )
 
-ggHH_kl_5_kt_1_dl_hbbhww = ggHH_kl_5_kt_1.add_process(
+ggHH_kl_5_kt_1_dl_hbbhww = ggHH_kl_5_kt_1_dl_hbbhvv.add_process(
     name="ggHH_kl_5_kt_1_dl_hbbhww",
     label=r"$HH_{ggf}^{\kappa\lambda=5} \rightarrow bbWW(l\nu l\nu)$",
     id=21224,
@@ -451,49 +454,49 @@ qqHH_sl_hbbhww = qqHH_hbbhww.add_process(
     id=22210,
 )
 
-qqHH_CV_1_C2V_1_kl_1_sl_hbbhww = qqHH_CV_1_C2V_1_kl_1.add_process(
+qqHH_CV_1_C2V_1_kl_1_sl_hbbhww = qqHH_CV_1_C2V_1_kl_1_hbbhvv.add_process(
     name="qqHH_CV_1_C2V_1_kl_1_sl_hbbhww",
     label=r"$HH_{vbf}^{1,1,1} \rightarrow bbWW(qql\nu)$",
     id=22211,
     xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_1, br_bbww_sl),
 )
 
-qqHH_CV_1_C2V_1_kl_0_sl_hbbhww = qqHH_CV_1_C2V_1_kl_0.add_process(
+qqHH_CV_1_C2V_1_kl_0_sl_hbbhww = qqHH_CV_1_C2V_1_kl_0_hbbhvv.add_process(
     name="qqHH_CV_1_C2V_1_kl_0_sl_hbbhww",
     label=r"$HH_{vbf}^{1,1,0} \rightarrow bbWW(qql\nu)$",
     id=22212,
     xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_0, br_bbww_sl),
 )
 
-qqHH_CV_1_C2V_1_kl_2_sl_hbbhww = qqHH_CV_1_C2V_1_kl_2.add_process(
+qqHH_CV_1_C2V_1_kl_2_sl_hbbhww = qqHH_CV_1_C2V_1_kl_2_hbbhvv.add_process(
     name="qqHH_CV_1_C2V_1_kl_2_sl_hbbhww",
     label=r"$HH_{vbf}^{1,1,2} \rightarrow bbWW(qql\nu)$",
     id=22213,
     xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_2, br_bbww_sl),
 )
 
-qqHH_CV_1_C2V_0_kl_1_sl_hbbhww = qqHH_CV_1_C2V_0_kl_1.add_process(
+qqHH_CV_1_C2V_0_kl_1_sl_hbbhww = qqHH_CV_1_C2V_0_kl_1_hbbhvv.add_process(
     name="qqHH_CV_1_C2V_0_kl_1_sl_hbbhww",
     label=r"$HH_{vbf}^{1,0,1} \rightarrow bbWW(qql\nu)$",
     id=22214,
     xsecs=multiply_xsecs(qqHH_CV_1_C2V_0_kl_1, br_bbww_sl),
 )
 
-qqHH_CV_1_C2V_2_kl_1_sl_hbbhww = qqHH_CV_1_C2V_2_kl_1.add_process(
+qqHH_CV_1_C2V_2_kl_1_sl_hbbhww = qqHH_CV_1_C2V_2_kl_1_hbbhvv.add_process(
     name="qqHH_CV_1_C2V_2_kl_1_sl_hbbhww",
     label=r"$HH_{vbf}^{1,2,1} \rightarrow bbWW(qql\nu)$",
     id=22215,
     xsecs=multiply_xsecs(qqHH_CV_1_C2V_2_kl_1, br_bbww_sl),
 )
 
-qqHH_CV_0p5_C2V_1_kl_1_sl_hbbhww = qqHH_CV_0p5_C2V_1_kl_1.add_process(
+qqHH_CV_0p5_C2V_1_kl_1_sl_hbbhww = qqHH_CV_0p5_C2V_1_kl_1_hbbhvv.add_process(
     name="qqHH_CV_0p5_C2V_1_kl_1_sl_hbbhww",
     label=r"$HH_{vbf}^{0.5,1,1} \rightarrow bbWW(qql\nu)$",
     id=22216,
     xsecs=multiply_xsecs(qqHH_CV_0p5_C2V_1_kl_1, br_bbww_sl),
 )
 
-qqHH_CV_1p5_C2V_1_kl_1_sl_hbbhww = qqHH_CV_1p5_C2V_1_kl_1.add_process(
+qqHH_CV_1p5_C2V_1_kl_1_sl_hbbhww = qqHH_CV_1p5_C2V_1_kl_1_hbbhvv.add_process(
     name="qqHH_CV_1p5_C2V_1_kl_1_sl_hbbhww",
     label=r"$HH_{vbf}^{1.5,1,1} \rightarrow bbWW(qql\nu)$",
     id=22217,
@@ -519,49 +522,49 @@ qqHH_dl_hbbhww = qqHH_hbbhww.add_process(
     id=22220,
 )
 
-qqHH_CV_1_C2V_1_kl_1_dl_hbbhww = qqHH_CV_1_C2V_1_kl_1.add_process(
+qqHH_CV_1_C2V_1_kl_1_dl_hbbhww = qqHH_CV_1_C2V_1_kl_1_dl_hbbhvv.add_process(
     name="qqHH_CV_1_C2V_1_kl_1_dl_hbbhww",
     label=r"$HH_{vbf}^{1,1,1} \rightarrow bbWW(l\nu l\nu)$",
     id=22221,
     xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_1, br_bbww_dl),
 )
 
-qqHH_CV_1_C2V_1_kl_0_dl_hbbhww = qqHH_CV_1_C2V_1_kl_0.add_process(
+qqHH_CV_1_C2V_1_kl_0_dl_hbbhww = qqHH_CV_1_C2V_1_kl_0_dl_hbbhvv.add_process(
     name="qqHH_CV_1_C2V_1_kl_0_dl_hbbhww",
     label=r"$HH_{vbf}^{1,1,0} \rightarrow bbWW(l\nu l\nu)$",
     id=22222,
     xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_0, br_bbww_dl),
 )
 
-qqHH_CV_1_C2V_1_kl_2_dl_hbbhww = qqHH_CV_1_C2V_1_kl_2.add_process(
+qqHH_CV_1_C2V_1_kl_2_dl_hbbhww = qqHH_CV_1_C2V_1_kl_2_dl_hbbhvv.add_process(
     name="qqHH_CV_1_C2V_1_kl_2_dl_hbbhww",
     label=r"$HH_{vbf}^{1,1,2} \rightarrow bbWW(l\nu l\nu)$",
     id=22223,
     xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_2, br_bbww_dl),
 )
 
-qqHH_CV_1_C2V_0_kl_1_dl_hbbhww = qqHH_CV_1_C2V_0_kl_1.add_process(
+qqHH_CV_1_C2V_0_kl_1_dl_hbbhww = qqHH_CV_1_C2V_0_kl_1_dl_hbbhvv.add_process(
     name="qqHH_CV_1_C2V_0_kl_1_dl_hbbhww",
     label=r"$HH_{vbf}^{1,0,1} \rightarrow bbWW(l\nu l\nu)$",
     id=22224,
     xsecs=multiply_xsecs(qqHH_CV_1_C2V_0_kl_1, br_bbww_dl),
 )
 
-qqHH_CV_1_C2V_2_kl_1_dl_hbbhww = qqHH_CV_1_C2V_2_kl_1.add_process(
+qqHH_CV_1_C2V_2_kl_1_dl_hbbhww = qqHH_CV_1_C2V_2_kl_1_dl_hbbhvv.add_process(
     name="qqHH_CV_1_C2V_2_kl_1_dl_hbbhww",
     label=r"$HH_{vbf}^{1,2,1} \rightarrow bbWW(l\nu l\nu)$",
     id=22225,
     xsecs=multiply_xsecs(qqHH_CV_1_C2V_2_kl_1, br_bbww_dl),
 )
 
-qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhww = qqHH_CV_0p5_C2V_1_kl_1.add_process(
+qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhww = qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhvv.add_process(
     name="qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhww",
     label=r"$HH_{vbf}^{0.5,1,1} \rightarrow bbWW(l\nu l\nu)$",
     id=22226,
     xsecs=multiply_xsecs(qqHH_CV_0p5_C2V_1_kl_1, br_bbww_dl),
 )
 
-qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhww = qqHH_CV_1p5_C2V_1_kl_1.add_process(
+qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhww = qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhvv.add_process(
     name="qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhww",
     label=r"$HH_{vbf}^{1.5,1,1} \rightarrow bbWW(l\nu l\nu)$",
     id=22227,
@@ -587,28 +590,28 @@ ggHH_dl_hbbhzz = ggHH_hbbhzz.add_process(
     label=r"$HH_{ggf} \rightarrow bbZZ(ll \nu \nu)$",
 )
 
-ggHH_kl_0_kt_1_dl_hbbhzz = ggHH_kl_0_kt_1.add_process(
+ggHH_kl_0_kt_1_dl_hbbhzz = ggHH_kl_0_kt_1_dl_hbbhvv.add_process(
     name="ggHH_kl_0_kt_1_dl_hbbhzz",
     id=21321,
     label=r"$HH_{ggf}^{\kappa\lambda=0} \rightarrow bbZZ(ll \nu \nu)$",
     xsecs=multiply_xsecs(ggHH_kl_0_kt_1, br_bbzz_dl),
 )
 
-ggHH_kl_1_kt_1_dl_hbbhzz = ggHH_kl_1_kt_1.add_process(
+ggHH_kl_1_kt_1_dl_hbbhzz = ggHH_kl_1_kt_1_dl_hbbhvv.add_process(
     name="ggHH_kl_1_kt_1_dl_hbbhzz",
     label=r"$HH_{ggf}^{\kappa\lambda=1} \rightarrow bbZZ(ll \nu \nu)$",
     id=21322,
     xsecs=multiply_xsecs(ggHH_kl_1_kt_1, br_bbzz_dl),
 )
 
-ggHH_kl_2p45_kt_1_dl_hbbhzz = ggHH_kl_2p45_kt_1.add_process(
+ggHH_kl_2p45_kt_1_dl_hbbhzz = ggHH_kl_2p45_kt_1_dl_hbbhvv.add_process(
     name="ggHH_kl_2p45_kt_1_dl_hbbhzz",
     label=r"$HH_{ggf}^{\kappa\lambda=2.45} \rightarrow bbZZ(ll \nu \nu)$",
     id=21323,
     xsecs=multiply_xsecs(ggHH_kl_2p45_kt_1, br_bbzz_dl),
 )
 
-ggHH_kl_5_kt_1_dl_hbbhzz = ggHH_kl_5_kt_1.add_process(
+ggHH_kl_5_kt_1_dl_hbbhzz = ggHH_kl_5_kt_1_dl_hbbhvv.add_process(
     name="ggHH_kl_5_kt_1_dl_hbbhzz",
     label=r"$HH_{ggf}^{\kappa\lambda=5} \rightarrow bbZZ(ll \nu \nu)$",
     id=21324,
@@ -633,49 +636,49 @@ qqHH_dl_hbbhzz = qqHH_hbbhzz.add_process(
     id=22320,
 )
 
-qqHH_CV_1_C2V_1_kl_1_dl_hbbhzz = qqHH_CV_1_C2V_1_kl_1.add_process(
+qqHH_CV_1_C2V_1_kl_1_dl_hbbhzz = qqHH_CV_1_C2V_1_kl_1_dl_hbbhvv.add_process(
     name="qqHH_CV_1_C2V_1_kl_1_dl_hbbhzz",
     label=r"$HH_{vbf}^{1,1,1} \rightarrow bbZZ(ll \nu \nu)$",
     id=22321,
     xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_1, br_bbzz_dl),
 )
 
-qqHH_CV_1_C2V_1_kl_0_dl_hbbhzz = qqHH_CV_1_C2V_1_kl_0.add_process(
+qqHH_CV_1_C2V_1_kl_0_dl_hbbhzz = qqHH_CV_1_C2V_1_kl_0_dl_hbbhvv.add_process(
     name="qqHH_CV_1_C2V_1_kl_0_dl_hbbhzz",
     label=r"$HH_{vbf}^{1,1,0} \rightarrow bbZZ(ll \nu \nu)$",
     id=22322,
     xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_0, br_bbzz_dl),
 )
 
-qqHH_CV_1_C2V_1_kl_2_dl_hbbhzz = qqHH_CV_1_C2V_1_kl_2.add_process(
+qqHH_CV_1_C2V_1_kl_2_dl_hbbhzz = qqHH_CV_1_C2V_1_kl_2_dl_hbbhvv.add_process(
     name="qqHH_CV_1_C2V_1_kl_2_dl_hbbhzz",
     label=r"$HH_{vbf}^{1,1,2} \rightarrow bbZZ(ll \nu \nu)$",
     id=22323,
     xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_2, br_bbzz_dl),
 )
 
-qqHH_CV_1_C2V_0_kl_1_dl_hbbhzz = qqHH_CV_1_C2V_0_kl_1.add_process(
+qqHH_CV_1_C2V_0_kl_1_dl_hbbhzz = qqHH_CV_1_C2V_0_kl_1_dl_hbbhvv.add_process(
     name="qqHH_CV_1_C2V_0_kl_1_dl_hbbhzz",
     label=r"$HH_{vbf}^{1,0,1} \rightarrow bbZZ(ll \nu \nu)$",
     id=22324,
     xsecs=multiply_xsecs(qqHH_CV_1_C2V_0_kl_1, br_bbzz_dl),
 )
 
-qqHH_CV_1_C2V_2_kl_1_dl_hbbhzz = qqHH_CV_1_C2V_2_kl_1.add_process(
+qqHH_CV_1_C2V_2_kl_1_dl_hbbhzz = qqHH_CV_1_C2V_2_kl_1_dl_hbbhvv.add_process(
     name="qqHH_CV_1_C2V_2_kl_1_dl_hbbhzz",
     label=r"$HH_{vbf}^{1,2,1} \rightarrow bbZZ(ll \nu \nu)$",
     id=22325,
     xsecs=multiply_xsecs(qqHH_CV_1_C2V_2_kl_1, br_bbzz_dl),
 )
 
-qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhzz = qqHH_CV_0p5_C2V_1_kl_1.add_process(
+qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhzz = qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhvv.add_process(
     name="qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhzz",
     label=r"$HH_{vbf}^{0.5,1,1} \rightarrow bbZZ(ll \nu \nu)$",
     id=22326,
     xsecs=multiply_xsecs(qqHH_CV_0p5_C2V_1_kl_1, br_bbzz_dl),
 )
 
-qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhzz = qqHH_CV_1p5_C2V_1_kl_1.add_process(
+qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhzz = qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhvv.add_process(
     name="qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhzz",
     label=r"$HH_{vbf}^{1.5,1,1} \rightarrow bbZZ(ll \nu \nu)$",
     id=22327,

--- a/cmsdb/processes/hh2bbww.py
+++ b/cmsdb/processes/hh2bbww.py
@@ -5,21 +5,36 @@ HH -> bbWW process definitions.
 """
 
 __all__ = [
-    # Single Lepton HHbbWW, ggH
+    "ggHH_hbbhvv", "qqHH_hbbhvv", "ggHH_hbbhww", "qqHH_hbbhww", "ggHH_hbbhzz", "qqHH_hbbhzz",
+    # HH -> bbVV, ggf
+    "ggHH_kl_0_kt_1_hbbhvv", "ggHH_kl_1_kt_1_hbbhvv",
+    "ggHH_kl_2p45_kt_1_hbbhvv", "ggHH_kl_5_kt_1_hbbhvv",
+    # HH -> bbVV, vbf
+    "qqHH_CV_0p5_C2V_1_kl_1_hbbhvv", "qqHH_CV_1p5_C2V_1_kl_1_hbbhvv",
+    "qqHH_CV_1_C2V_0_kl_1_hbbhvv", "qqHH_CV_1_C2V_1_kl_0_hbbhvv", "qqHH_CV_1_C2V_1_kl_1_hbbhvv",
+    "qqHH_CV_1_C2V_1_kl_2_hbbhvv", "qqHH_CV_1_C2V_2_kl_1_hbbhvv",
+    # HH -> bbWW(qqlv), ggf
     "ggHH_sl_hbbhww", "ggHH_kl_0_kt_1_sl_hbbhww", "ggHH_kl_1_kt_1_sl_hbbhww",
     "ggHH_kl_2p45_kt_1_sl_hbbhww", "ggHH_kl_5_kt_1_sl_hbbhww",
-    # Dilepton HHbbWW, ggH
+    # HH -> bbWW(lvlv), ggf
     "ggHH_dl_hbbhww", "ggHH_kl_0_kt_1_dl_hbbhww", "ggHH_kl_1_kt_1_dl_hbbhww",
     "ggHH_kl_2p45_kt_1_dl_hbbhww", "ggHH_kl_5_kt_1_dl_hbbhww",
-    # Single Lepton HHbbWW, qqH
+    # HH -> bbZZ(lvlv), ggf
+    "ggHH_dl_hbbhzz", "ggHH_kl_0_kt_1_dl_hbbhzz", "ggHH_kl_1_kt_1_dl_hbbhzz",
+    "ggHH_kl_2p45_kt_1_dl_hbbhzz", "ggHH_kl_5_kt_1_dl_hbbhzz",
+    # HH -> bbWW(qqlv), vbf
     "qqHH_sl_hbbhww", "qqHH_CV_0p5_C2V_1_kl_1_sl_hbbhww", "qqHH_CV_1p5_C2V_1_kl_1_sl_hbbhww",
     "qqHH_CV_1_C2V_0_kl_1_sl_hbbhww", "qqHH_CV_1_C2V_1_kl_0_sl_hbbhww", "qqHH_CV_1_C2V_1_kl_1_sl_hbbhww",
     "qqHH_CV_1_C2V_1_kl_2_sl_hbbhww", "qqHH_CV_1_C2V_2_kl_1_sl_hbbhww",
-    # Dilepton HHbbWW, qqH
+    # HH -> bbWW(lvlv), vbf
     "qqHH_dl_hbbhww", "qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhww", "qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhww",
     "qqHH_CV_1_C2V_0_kl_1_dl_hbbhww", "qqHH_CV_1_C2V_1_kl_0_dl_hbbhww", "qqHH_CV_1_C2V_1_kl_1_dl_hbbhww",
     "qqHH_CV_1_C2V_1_kl_2_dl_hbbhww", "qqHH_CV_1_C2V_2_kl_1_dl_hbbhww",
-    # Resonant HHbbWW: radion
+    # HH -> bbZZ(lvlv), vbf
+    "qqHH_dl_hbbhzz", "qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhzz", "qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhzz",
+    "qqHH_CV_1_C2V_0_kl_1_dl_hbbhzz", "qqHH_CV_1_C2V_1_kl_0_dl_hbbhzz", "qqHH_CV_1_C2V_1_kl_1_dl_hbbhzz",
+    "qqHH_CV_1_C2V_1_kl_2_dl_hbbhzz", "qqHH_CV_1_C2V_2_kl_1_dl_hbbhzz",
+    # Resonant HH -> bbWW: radion
     "radion_hh_ggf_bbww",
     "radion_hh_ggf_bbww_m250", "radion_hh_ggf_bbww_m260", "radion_hh_ggf_bbww_m270",
     "radion_hh_ggf_bbww_m280", "radion_hh_ggf_bbww_m300", "radion_hh_ggf_bbww_m320",
@@ -30,7 +45,7 @@ __all__ = [
     "radion_hh_ggf_bbww_m1000", "radion_hh_ggf_bbww_m1250", "radion_hh_ggf_bbww_m1500",
     "radion_hh_ggf_bbww_m1750", "radion_hh_ggf_bbww_m2000", "radion_hh_ggf_bbww_m2500",
     "radion_hh_ggf_bbww_m3000",
-    # Resonant HHbbWW: graviton
+    # Resonant HH -> bbWW: graviton
     "graviton_hh_ggf_bbww",
     "graviton_hh_ggf_bbww_m250", "graviton_hh_ggf_bbww_m260",
     "graviton_hh_ggf_bbww_m270", "graviton_hh_ggf_bbww_m280",
@@ -62,28 +77,153 @@ from cmsdb.processes.higgs import (
 # Helper
 #
 
+br_bbvv = const.br_hh.bbww + const.br_hh.bbzz
 br_bbww_sl = const.br_hh.bbww * const.br_ww.sl
 br_bbww_dl = const.br_hh.bbww * const.br_ww.dl
-
+br_bbzz_dl = const.br_hh.bbzz * const.br_ww.dl
 
 #
-# HH -> bbWW -> bbWWqqlnu
+# HH -> bbVV
 #
 
-ggHH_hbbhww = hh_ggf.add_process(
+ggHH_hbbhvv = hh_ggf.add_process(
+    name="ggHH_hbbhvv",
+    id=-1,
+    label=r"$HH_{ggf} \rightarrow bbVV$",
+)
+
+qqHH_hbbhvv = hh_vbf.add_process(
+    name="qqHH_hbbhvv",
+    id=-1,
+    label=r"$HH_{vbf} \rightarrow bbVV$",
+)
+
+ggHH_hbbhww = ggHH_hbbhvv.add_process(
     name="ggHH_hbbhww",
     id=21200,
     label=r"$HH_{ggf} \rightarrow bbWW$",
 )
 
-qqHH_hbbhww = hh_vbf.add_process(
+qqHH_hbbhww = qqHH_hbbhvv.add_process(
     name="qqHH_hbbhww",
     id=21201,
     label=r"$HH_{vbf} \rightarrow bbWW$",
 )
 
+ggHH_hbbhzz = ggHH_hbbhvv.add_process(
+    name="ggHH_hbbhzz",
+    id=-1,
+    label=r"$HH_{ggf} \rightarrow bbZZ$",
+)
+
+qqHH_hbbhzz = qqHH_hbbhvv.add_process(
+    name="qqHH_hbbhzz",
+    id=-1,
+    label=r"$HH_{vbf} \rightarrow bbZZ$",
+
+)
 #
-# ggf, single lepton
+# HH -> bbVV, ggf
+#
+
+ggHH_kl_0_kt_1_hbbhvv = ggHH_kl_0_kt_1.add_process(
+    name="ggHH_kl_0_kt_1_hbbhvv",
+    id=-1,
+    label=r"$HH_{ggf}^{\kappa\lambda=0} \rightarrow bbVV$",
+    xsecs=multiply_xsecs(ggHH_kl_0_kt_1, br_bbvv),
+)
+
+ggHH_kl_1_kt_1_hbbhvv = ggHH_kl_1_kt_1.add_process(
+    name="ggHH_kl_1_kt_1_hbbhvv",
+    label=r"$HH_{ggf}^{\kappa\lambda=1} \rightarrow bbVV$",
+    id=-1,
+    xsecs=multiply_xsecs(ggHH_kl_1_kt_1, br_bbvv),
+)
+
+ggHH_kl_2p45_kt_1_hbbhvv = ggHH_kl_2p45_kt_1.add_process(
+    name="ggHH_kl_2p45_kt_1_hbbhvv",
+    label=r"$HH_{ggf}^{\kappa\lambda=2.45} \rightarrow bbVV$",
+    id=-1,
+    xsecs=multiply_xsecs(ggHH_kl_2p45_kt_1, br_bbvv),
+)
+
+ggHH_kl_5_kt_1_hbbhvv = ggHH_kl_5_kt_1.add_process(
+    name="ggHH_kl_5_kt_1_hbbhvv",
+    label=r"$HH_{ggf}^{\kappa\lambda=5} \rightarrow bbVV$",
+    id=-1,
+    xsecs=multiply_xsecs(ggHH_kl_5_kt_1, br_bbvv),
+)
+
+# add process dependencies
+ggHH_hbbhvv.add_process(ggHH_kl_0_kt_1_hbbhvv)
+ggHH_hbbhvv.add_process(ggHH_kl_1_kt_1_hbbhvv)
+ggHH_hbbhvv.add_process(ggHH_kl_2p45_kt_1_hbbhvv)
+ggHH_hbbhvv.add_process(ggHH_kl_5_kt_1_hbbhvv)
+
+#
+# HH -> bbVV, vbf
+#
+
+qqHH_CV_1_C2V_1_kl_1_hbbhvv = qqHH_CV_1_C2V_1_kl_1.add_process(
+    name="qqHH_CV_1_C2V_1_kl_1_hbbhvv",
+    label=r"$HH_{vbf}^{1,1,1} \rightarrow bbVV$",
+    id=-1,
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_1, br_bbvv),
+)
+
+qqHH_CV_1_C2V_1_kl_0_hbbhvv = qqHH_CV_1_C2V_1_kl_0.add_process(
+    name="qqHH_CV_1_C2V_1_kl_0_hbbhvv",
+    label=r"$HH_{vbf}^{1,1,0} \rightarrow bbVV$",
+    id=-1,
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_0, br_bbvv),
+)
+
+qqHH_CV_1_C2V_1_kl_2_hbbhvv = qqHH_CV_1_C2V_1_kl_2.add_process(
+    name="qqHH_CV_1_C2V_1_kl_2_hbbhvv",
+    label=r"$HH_{vbf}^{1,1,2} \rightarrow bbVV$",
+    id=-1,
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_2, br_bbvv),
+)
+
+qqHH_CV_1_C2V_0_kl_1_hbbhvv = qqHH_CV_1_C2V_0_kl_1.add_process(
+    name="qqHH_CV_1_C2V_0_kl_1_hbbhvv",
+    label=r"$HH_{vbf}^{1,0,1} \rightarrow bbVV$",
+    id=-1,
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_0_kl_1, br_bbvv),
+)
+
+qqHH_CV_1_C2V_2_kl_1_hbbhvv = qqHH_CV_1_C2V_2_kl_1.add_process(
+    name="qqHH_CV_1_C2V_2_kl_1_hbbhvv",
+    label=r"$HH_{vbf}^{1,2,1} \rightarrow bbVV$",
+    id=-1,
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_2_kl_1, br_bbvv),
+)
+
+qqHH_CV_0p5_C2V_1_kl_1_hbbhvv = qqHH_CV_0p5_C2V_1_kl_1.add_process(
+    name="qqHH_CV_0p5_C2V_1_kl_1_hbbhvv",
+    label=r"$HH_{vbf}^{0.5,1,1} \rightarrow bbVV$",
+    id=-1,
+    xsecs=multiply_xsecs(qqHH_CV_0p5_C2V_1_kl_1, br_bbvv),
+)
+
+qqHH_CV_1p5_C2V_1_kl_1_hbbhvv = qqHH_CV_1p5_C2V_1_kl_1.add_process(
+    name="qqHH_CV_1p5_C2V_1_kl_1_hbbhvv",
+    label=r"$HH_{vbf}^{1.5,1,1} \rightarrow bbVV$",
+    id=-1,
+    xsecs=multiply_xsecs(qqHH_CV_1p5_C2V_1_kl_1, br_bbvv),
+)
+
+# add process dependencies
+qqHH_hbbhvv.add_process(qqHH_CV_1_C2V_1_kl_1_hbbhvv)
+qqHH_hbbhvv.add_process(qqHH_CV_1_C2V_1_kl_0_hbbhvv)
+qqHH_hbbhvv.add_process(qqHH_CV_1_C2V_1_kl_2_hbbhvv)
+qqHH_hbbhvv.add_process(qqHH_CV_1_C2V_0_kl_1_hbbhvv)
+qqHH_hbbhvv.add_process(qqHH_CV_1_C2V_2_kl_1_hbbhvv)
+qqHH_hbbhvv.add_process(qqHH_CV_0p5_C2V_1_kl_1_hbbhvv)
+qqHH_hbbhvv.add_process(qqHH_CV_1p5_C2V_1_kl_1_hbbhvv)
+
+#
+# HH -> bbWW(qqlv), ggf
 #
 
 ggHH_sl_hbbhww = ggHH_hbbhww.add_process(
@@ -127,7 +267,7 @@ ggHH_sl_hbbhww.add_process(ggHH_kl_2p45_kt_1_sl_hbbhww)
 ggHH_sl_hbbhww.add_process(ggHH_kl_5_kt_1_sl_hbbhww)
 
 #
-# ggf, dilepton
+# HH -> bbWW(lvlv), ggf
 #
 
 ggHH_dl_hbbhww = ggHH_hbbhww.add_process(
@@ -172,7 +312,7 @@ ggHH_dl_hbbhww.add_process(ggHH_kl_2p45_kt_1_dl_hbbhww)
 ggHH_dl_hbbhww.add_process(ggHH_kl_5_kt_1_dl_hbbhww)
 
 #
-# VBF, single lepton
+# HH -> bbWW(qqlv), vbf
 #
 
 qqHH_sl_hbbhww = qqHH_hbbhww.add_process(
@@ -240,7 +380,7 @@ qqHH_sl_hbbhww.add_process(qqHH_CV_0p5_C2V_1_kl_1_sl_hbbhww)
 qqHH_sl_hbbhww.add_process(qqHH_CV_1p5_C2V_1_kl_1_sl_hbbhww)
 
 #
-# VBF, dilepton
+# HH -> bbWW(lvlv), vbf
 #
 
 qqHH_dl_hbbhww = qqHH_hbbhww.add_process(
@@ -253,49 +393,49 @@ qqHH_CV_1_C2V_1_kl_1_dl_hbbhww = qqHH_CV_1_C2V_1_kl_1.add_process(
     name="qqHH_CV_1_C2V_1_kl_1_dl_hbbhww",
     label=r"$HH_{vbf}^{1,1,1} \rightarrow bbWW(l\nu l\nu)$",
     id=22221,
-    xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_1, br_bbww_sl),
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_1, br_bbww_dl),
 )
 
 qqHH_CV_1_C2V_1_kl_0_dl_hbbhww = qqHH_CV_1_C2V_1_kl_0.add_process(
     name="qqHH_CV_1_C2V_1_kl_0_dl_hbbhww",
     label=r"$HH_{vbf}^{1,1,0} \rightarrow bbWW(l\nu l\nu)$",
     id=22222,
-    xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_0, br_bbww_sl),
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_0, br_bbww_dl),
 )
 
 qqHH_CV_1_C2V_1_kl_2_dl_hbbhww = qqHH_CV_1_C2V_1_kl_2.add_process(
     name="qqHH_CV_1_C2V_1_kl_2_dl_hbbhww",
     label=r"$HH_{vbf}^{1,1,2} \rightarrow bbWW(l\nu l\nu)$",
     id=22223,
-    xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_2, br_bbww_sl),
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_2, br_bbww_dl),
 )
 
 qqHH_CV_1_C2V_0_kl_1_dl_hbbhww = qqHH_CV_1_C2V_0_kl_1.add_process(
     name="qqHH_CV_1_C2V_0_kl_1_dl_hbbhww",
     label=r"$HH_{vbf}^{1,0,1} \rightarrow bbWW(l\nu l\nu)$",
     id=22224,
-    xsecs=multiply_xsecs(qqHH_CV_1_C2V_0_kl_1, br_bbww_sl),
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_0_kl_1, br_bbww_dl),
 )
 
 qqHH_CV_1_C2V_2_kl_1_dl_hbbhww = qqHH_CV_1_C2V_2_kl_1.add_process(
     name="qqHH_CV_1_C2V_2_kl_1_dl_hbbhww",
     label=r"$HH_{vbf}^{1,2,1} \rightarrow bbWW(l\nu l\nu)$",
     id=22225,
-    xsecs=multiply_xsecs(qqHH_CV_1_C2V_2_kl_1, br_bbww_sl),
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_2_kl_1, br_bbww_dl),
 )
 
 qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhww = qqHH_CV_0p5_C2V_1_kl_1.add_process(
     name="qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhww",
     label=r"$HH_{vbf}^{0.5,1,1} \rightarrow bbWW(l\nu l\nu)$",
     id=22226,
-    xsecs=multiply_xsecs(qqHH_CV_0p5_C2V_1_kl_1, br_bbww_sl),
+    xsecs=multiply_xsecs(qqHH_CV_0p5_C2V_1_kl_1, br_bbww_dl),
 )
 
 qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhww = qqHH_CV_1p5_C2V_1_kl_1.add_process(
     name="qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhww",
     label=r"$HH_{vbf}^{1.5,1,1} \rightarrow bbWW(l\nu l\nu)$",
     id=22227,
-    xsecs=multiply_xsecs(qqHH_CV_1p5_C2V_1_kl_1, br_bbww_sl),
+    xsecs=multiply_xsecs(qqHH_CV_1p5_C2V_1_kl_1, br_bbww_dl),
 )
 
 # add process dependencies
@@ -307,6 +447,119 @@ qqHH_dl_hbbhww.add_process(qqHH_CV_1_C2V_2_kl_1_dl_hbbhww)
 qqHH_dl_hbbhww.add_process(qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhww)
 qqHH_dl_hbbhww.add_process(qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhww)
 
+#
+# HH -> bbZZ, ggf
+#
+
+ggHH_dl_hbbhzz = ggHH_hbbhzz.add_process(
+    name="ggHH_dl_hbbhzz",
+    id=-1,
+    label=r"$HH_{ggf} \rightarrow bbZZ(ll \nu \nu)$",
+)
+
+ggHH_kl_0_kt_1_dl_hbbhzz = ggHH_kl_0_kt_1.add_process(
+    name="ggHH_kl_0_kt_1_dl_hbbhzz",
+    id=-1,
+    label=r"$HH_{ggf}^{\kappa\lambda=0} \rightarrow bbZZ(ll \nu \nu)$",
+    xsecs=multiply_xsecs(ggHH_kl_0_kt_1, br_bbzz_dl),
+)
+
+ggHH_kl_1_kt_1_dl_hbbhzz = ggHH_kl_1_kt_1.add_process(
+    name="ggHH_kl_1_kt_1_dl_hbbhzz",
+    label=r"$HH_{ggf}^{\kappa\lambda=1} \rightarrow bbZZ(ll \nu \nu)$",
+    id=-1,
+    xsecs=multiply_xsecs(ggHH_kl_1_kt_1, br_bbzz_dl),
+)
+
+ggHH_kl_2p45_kt_1_dl_hbbhzz = ggHH_kl_2p45_kt_1.add_process(
+    name="ggHH_kl_2p45_kt_1_dl_hbbhzz",
+    label=r"$HH_{ggf}^{\kappa\lambda=2.45} \rightarrow bbZZ(ll \nu \nu)$",
+    id=-1,
+    xsecs=multiply_xsecs(ggHH_kl_2p45_kt_1, br_bbzz_dl),
+)
+
+ggHH_kl_5_kt_1_dl_hbbhzz = ggHH_kl_5_kt_1.add_process(
+    name="ggHH_kl_5_kt_1_dl_hbbhzz",
+    label=r"$HH_{ggf}^{\kappa\lambda=5} \rightarrow bbZZ(ll \nu \nu)$",
+    id=-1,
+    xsecs=multiply_xsecs(ggHH_kl_5_kt_1, br_bbzz_dl),
+)
+
+
+# add process dependencies
+ggHH_dl_hbbhzz.add_process(ggHH_kl_0_kt_1_dl_hbbhzz)
+ggHH_dl_hbbhzz.add_process(ggHH_kl_1_kt_1_dl_hbbhzz)
+ggHH_dl_hbbhzz.add_process(ggHH_kl_2p45_kt_1_dl_hbbhzz)
+ggHH_dl_hbbhzz.add_process(ggHH_kl_5_kt_1_dl_hbbhzz)
+
+
+#
+# HH -> bbZZ(lvlv), vbf
+#
+
+qqHH_dl_hbbhzz = qqHH_hbbhzz.add_process(
+    name="qqHH_dl_hbbhzz",
+    label=r"$HH_{vbf} \rightarrow bbZZ(ll \nu \nu)$",
+    id=-1,
+)
+
+qqHH_CV_1_C2V_1_kl_1_dl_hbbhzz = qqHH_CV_1_C2V_1_kl_1.add_process(
+    name="qqHH_CV_1_C2V_1_kl_1_dl_hbbhzz",
+    label=r"$HH_{vbf}^{1,1,1} \rightarrow bbZZ(ll \nu \nu)$",
+    id=-1,
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_1, br_bbzz_dl),
+)
+
+qqHH_CV_1_C2V_1_kl_0_dl_hbbhzz = qqHH_CV_1_C2V_1_kl_0.add_process(
+    name="qqHH_CV_1_C2V_1_kl_0_dl_hbbhzz",
+    label=r"$HH_{vbf}^{1,1,0} \rightarrow bbZZ(ll \nu \nu)$",
+    id=-1,
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_0, br_bbzz_dl),
+)
+
+qqHH_CV_1_C2V_1_kl_2_dl_hbbhzz = qqHH_CV_1_C2V_1_kl_2.add_process(
+    name="qqHH_CV_1_C2V_1_kl_2_dl_hbbhzz",
+    label=r"$HH_{vbf}^{1,1,2} \rightarrow bbZZ(ll \nu \nu)$",
+    id=-1,
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_2, br_bbzz_dl),
+)
+
+qqHH_CV_1_C2V_0_kl_1_dl_hbbhzz = qqHH_CV_1_C2V_0_kl_1.add_process(
+    name="qqHH_CV_1_C2V_0_kl_1_dl_hbbhzz",
+    label=r"$HH_{vbf}^{1,0,1} \rightarrow bbZZ(ll \nu \nu)$",
+    id=-1,
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_0_kl_1, br_bbzz_dl),
+)
+
+qqHH_CV_1_C2V_2_kl_1_dl_hbbhzz = qqHH_CV_1_C2V_2_kl_1.add_process(
+    name="qqHH_CV_1_C2V_2_kl_1_dl_hbbhzz",
+    label=r"$HH_{vbf}^{1,2,1} \rightarrow bbZZ(ll \nu \nu)$",
+    id=-1,
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_2_kl_1, br_bbzz_dl),
+)
+
+qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhzz = qqHH_CV_0p5_C2V_1_kl_1.add_process(
+    name="qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhzz",
+    label=r"$HH_{vbf}^{0.5,1,1} \rightarrow bbZZ(ll \nu \nu)$",
+    id=-1,
+    xsecs=multiply_xsecs(qqHH_CV_0p5_C2V_1_kl_1, br_bbzz_dl),
+)
+
+qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhzz = qqHH_CV_1p5_C2V_1_kl_1.add_process(
+    name="qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhzz",
+    label=r"$HH_{vbf}^{1.5,1,1} \rightarrow bbZZ(ll \nu \nu)$",
+    id=-1,
+    xsecs=multiply_xsecs(qqHH_CV_1p5_C2V_1_kl_1, br_bbzz_dl),
+)
+
+# add process dependencies
+qqHH_dl_hbbhzz.add_process(qqHH_CV_1_C2V_1_kl_1_dl_hbbhzz)
+qqHH_dl_hbbhzz.add_process(qqHH_CV_1_C2V_1_kl_0_dl_hbbhzz)
+qqHH_dl_hbbhzz.add_process(qqHH_CV_1_C2V_1_kl_2_dl_hbbhzz)
+qqHH_dl_hbbhzz.add_process(qqHH_CV_1_C2V_0_kl_1_dl_hbbhzz)
+qqHH_dl_hbbhzz.add_process(qqHH_CV_1_C2V_2_kl_1_dl_hbbhzz)
+qqHH_dl_hbbhzz.add_process(qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhzz)
+qqHH_dl_hbbhzz.add_process(qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhzz)
 #
 # ggF -> radion -> HH
 #

--- a/cmsdb/processes/hh2bbww.py
+++ b/cmsdb/processes/hh2bbww.py
@@ -7,7 +7,7 @@ IDs are assigned in the range 21200-21499 for ggHH and 22200-22499 for qqHH.
 bbWW processes are assigned IDs in the range 21200-21299 and 22200-22299.
 bbZZ processes are assigned IDs in the range 21300-21399 and 22300-22399.
 bbVV processes are assigned IDs in the range 21400-21499 and 22400-22499.
-SL processes are assigned the ranges from 10-19 and DL processes from 20-29 (FH still missing)
+qqlnu processes are assigned the ranges from 10-19 and 2l2nu processes from 20-29 (FH still missing)
 The merged processes are assigned the ranges from 1-9.
 """
 
@@ -112,9 +112,10 @@ from cmsdb.processes.higgs import (
 # Helper
 #
 
+# NOTE: bbzz_dl is not descriptive enough, should probably be updated to bbzz_2l2nu or similar (same for bbvv)
 br_bbww_sl = const.br_hh.bbww * const.br_ww.sl
 br_bbww_dl = const.br_hh.bbww * const.br_ww.dl
-br_bbzz_dl = const.br_hh.bbzz * const.br_zz.dl
+br_bbzz_dl = const.br_hh.bbzz * const.br_zz.llnunu
 br_bbvv = const.br_hh.bbww + const.br_hh.bbzz
 br_bbvv_sl = br_bbww_sl
 br_bbvv_dl = br_bbww_dl + br_bbzz_dl

--- a/cmsdb/processes/hh2bbww.py
+++ b/cmsdb/processes/hh2bbww.py
@@ -12,14 +12,20 @@ The merged processes are assigned the ranges from 1-9.
 """
 
 __all__ = [
-    "ggHH_hbbhvv", "qqHH_hbbhvv", "ggHH_hbbhww", "qqHH_hbbhww", "ggHH_hbbhzz", "qqHH_hbbhzz",
     # HH -> bbVV, ggf
-    "ggHH_kl_0_kt_1_hbbhvv", "ggHH_kl_1_kt_1_hbbhvv",
+    "ggHH_hbbhvv", "ggHH_kl_0_kt_1_hbbhvv", "ggHH_kl_1_kt_1_hbbhvv",
     "ggHH_kl_2p45_kt_1_hbbhvv", "ggHH_kl_5_kt_1_hbbhvv",
     # HH -> bbVV, vbf
-    "qqHH_CV_0p5_C2V_1_kl_1_hbbhvv", "qqHH_CV_1p5_C2V_1_kl_1_hbbhvv",
+    "qqHH_hbbhvv", "qqHH_CV_0p5_C2V_1_kl_1_hbbhvv", "qqHH_CV_1p5_C2V_1_kl_1_hbbhvv",
     "qqHH_CV_1_C2V_0_kl_1_hbbhvv", "qqHH_CV_1_C2V_1_kl_0_hbbhvv", "qqHH_CV_1_C2V_1_kl_1_hbbhvv",
     "qqHH_CV_1_C2V_1_kl_2_hbbhvv", "qqHH_CV_1_C2V_2_kl_1_hbbhvv",
+    # HH -> bbVV(2qlv), ggf
+    "ggHH_sl_hbbhvv", "ggHH_kl_0_kt_1_sl_hbbhvv", "ggHH_kl_1_kt_1_sl_hbbhvv",
+    "ggHH_kl_2p45_kt_1_sl_hbbhvv", "ggHH_kl_5_kt_1_sl_hbbhvv",
+    # HH -> bbVV(2qlv), vbf
+    "qqHH_sl_hbbhvv", "qqHH_CV_0p5_C2V_1_kl_1_sl_hbbhvv", "qqHH_CV_1p5_C2V_1_kl_1_sl_hbbhvv",
+    "qqHH_CV_1_C2V_0_kl_1_sl_hbbhvv", "qqHH_CV_1_C2V_1_kl_0_sl_hbbhvv", "qqHH_CV_1_C2V_1_kl_1_sl_hbbhvv",
+    "qqHH_CV_1_C2V_1_kl_2_sl_hbbhvv", "qqHH_CV_1_C2V_2_kl_1_sl_hbbhvv",
     # HH -> bbVV(2l2v), ggf
     "ggHH_dl_hbbhvv", "ggHH_kl_0_kt_1_dl_hbbhvv", "ggHH_kl_1_kt_1_dl_hbbhvv",
     "ggHH_kl_2p45_kt_1_dl_hbbhvv", "ggHH_kl_5_kt_1_dl_hbbhvv",
@@ -27,15 +33,19 @@ __all__ = [
     "qqHH_dl_hbbhvv", "qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhvv", "qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhvv",
     "qqHH_CV_1_C2V_0_kl_1_dl_hbbhvv", "qqHH_CV_1_C2V_1_kl_0_dl_hbbhvv", "qqHH_CV_1_C2V_1_kl_1_dl_hbbhvv",
     "qqHH_CV_1_C2V_1_kl_2_dl_hbbhvv", "qqHH_CV_1_C2V_2_kl_1_dl_hbbhvv",
+    # HH -> bbWW, ggf
+    "ggHH_hbbhww", "ggHH_kl_0_kt_1_hbbhww", "ggHH_kl_1_kt_1_hbbhww",
+    "ggHH_kl_2p45_kt_1_hbbhww", "ggHH_kl_5_kt_1_hbbhww",
+    # HH -> bbWW, vbf
+    "qqHH_hbbhww", "qqHH_CV_0p5_C2V_1_kl_1_hbbhww", "qqHH_CV_1p5_C2V_1_kl_1_hbbhww",
+    "qqHH_CV_1_C2V_0_kl_1_hbbhww", "qqHH_CV_1_C2V_1_kl_0_hbbhww", "qqHH_CV_1_C2V_1_kl_1_hbbhww",
+    "qqHH_CV_1_C2V_1_kl_2_hbbhww", "qqHH_CV_1_C2V_2_kl_1_hbbhww",
     # HH -> bbWW(qqlv), ggf
     "ggHH_sl_hbbhww", "ggHH_kl_0_kt_1_sl_hbbhww", "ggHH_kl_1_kt_1_sl_hbbhww",
     "ggHH_kl_2p45_kt_1_sl_hbbhww", "ggHH_kl_5_kt_1_sl_hbbhww",
     # HH -> bbWW(lvlv), ggf
     "ggHH_dl_hbbhww", "ggHH_kl_0_kt_1_dl_hbbhww", "ggHH_kl_1_kt_1_dl_hbbhww",
     "ggHH_kl_2p45_kt_1_dl_hbbhww", "ggHH_kl_5_kt_1_dl_hbbhww",
-    # HH -> bbZZ(lvlv), ggf
-    "ggHH_dl_hbbhzz", "ggHH_kl_0_kt_1_dl_hbbhzz", "ggHH_kl_1_kt_1_dl_hbbhzz",
-    "ggHH_kl_2p45_kt_1_dl_hbbhzz", "ggHH_kl_5_kt_1_dl_hbbhzz",
     # HH -> bbWW(qqlv), vbf
     "qqHH_sl_hbbhww", "qqHH_CV_0p5_C2V_1_kl_1_sl_hbbhww", "qqHH_CV_1p5_C2V_1_kl_1_sl_hbbhww",
     "qqHH_CV_1_C2V_0_kl_1_sl_hbbhww", "qqHH_CV_1_C2V_1_kl_0_sl_hbbhww", "qqHH_CV_1_C2V_1_kl_1_sl_hbbhww",
@@ -44,6 +54,17 @@ __all__ = [
     "qqHH_dl_hbbhww", "qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhww", "qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhww",
     "qqHH_CV_1_C2V_0_kl_1_dl_hbbhww", "qqHH_CV_1_C2V_1_kl_0_dl_hbbhww", "qqHH_CV_1_C2V_1_kl_1_dl_hbbhww",
     "qqHH_CV_1_C2V_1_kl_2_dl_hbbhww", "qqHH_CV_1_C2V_2_kl_1_dl_hbbhww",
+    "ggHH_hbbhzz",
+    # HH -> bbZZ, ggf
+    "ggHH_hbbhzz", "ggHH_kl_0_kt_1_hbbhzz", "ggHH_kl_1_kt_1_hbbhzz",
+    "ggHH_kl_2p45_kt_1_hbbhzz", "ggHH_kl_5_kt_1_hbbhzz",
+    # HH -> bbZZ, vbf
+    "qqHH_hbbhzz", "qqHH_CV_0p5_C2V_1_kl_1_hbbhzz", "qqHH_CV_1p5_C2V_1_kl_1_hbbhzz",
+    "qqHH_CV_1_C2V_0_kl_1_hbbhzz", "qqHH_CV_1_C2V_1_kl_0_hbbhzz", "qqHH_CV_1_C2V_1_kl_1_hbbhzz",
+    "qqHH_CV_1_C2V_1_kl_2_hbbhzz", "qqHH_CV_1_C2V_2_kl_1_hbbhzz",
+    # HH -> bbZZ(lvlv), ggf
+    "ggHH_dl_hbbhzz", "ggHH_kl_0_kt_1_dl_hbbhzz", "ggHH_kl_1_kt_1_dl_hbbhzz",
+    "ggHH_kl_2p45_kt_1_dl_hbbhzz", "ggHH_kl_5_kt_1_dl_hbbhzz",
     # HH -> bbZZ(lvlv), vbf
     "qqHH_dl_hbbhzz", "qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhzz", "qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhzz",
     "qqHH_CV_1_C2V_0_kl_1_dl_hbbhzz", "qqHH_CV_1_C2V_1_kl_0_dl_hbbhzz", "qqHH_CV_1_C2V_1_kl_1_dl_hbbhzz",
@@ -91,14 +112,22 @@ from cmsdb.processes.higgs import (
 # Helper
 #
 
-br_bbvv = const.br_hh.bbww + const.br_hh.bbzz
-br_bbvv_dl = const.br_hh.bbww * const.br_ww.dl + const.br_hh.bbzz * const.br_zz.dl
 br_bbww_sl = const.br_hh.bbww * const.br_ww.sl
 br_bbww_dl = const.br_hh.bbww * const.br_ww.dl
 br_bbzz_dl = const.br_hh.bbzz * const.br_zz.dl
+br_bbvv = const.br_hh.bbww + const.br_hh.bbzz
+br_bbvv_sl = br_bbww_sl
+br_bbvv_dl = br_bbww_dl + br_bbzz_dl
 
+
+#############################################################
 #
 # HH -> bbVV
+#
+#############################################################
+
+#
+# HH -> bbVV (incl), ggf
 #
 
 ggHH_hbbhvv = hh_ggf.add_process(
@@ -106,40 +135,6 @@ ggHH_hbbhvv = hh_ggf.add_process(
     id=21400,
     label=r"$HH_{ggf} \rightarrow bbVV$",
 )
-
-qqHH_hbbhvv = hh_vbf.add_process(
-    name="qqHH_hbbhvv",
-    id=22400,
-    label=r"$HH_{vbf} \rightarrow bbVV$",
-)
-
-ggHH_hbbhww = ggHH_hbbhvv.add_process(
-    name="ggHH_hbbhww",
-    id=21200,
-    label=r"$HH_{ggf} \rightarrow bbWW$",
-)
-
-qqHH_hbbhww = qqHH_hbbhvv.add_process(
-    name="qqHH_hbbhww",
-    id=22200,
-    label=r"$HH_{vbf} \rightarrow bbWW$",
-)
-
-ggHH_hbbhzz = ggHH_hbbhvv.add_process(
-    name="ggHH_hbbhzz",
-    id=21300,
-    label=r"$HH_{ggf} \rightarrow bbZZ$",
-)
-
-qqHH_hbbhzz = qqHH_hbbhvv.add_process(
-    name="qqHH_hbbhzz",
-    id=22300,
-    label=r"$HH_{vbf} \rightarrow bbZZ$",
-
-)
-#
-# HH -> bbVV, ggf
-#
 
 ggHH_kl_0_kt_1_hbbhvv = ggHH_kl_0_kt_1.add_process(
     name="ggHH_kl_0_kt_1_hbbhvv",
@@ -176,8 +171,14 @@ ggHH_hbbhvv.add_process(ggHH_kl_2p45_kt_1_hbbhvv)
 ggHH_hbbhvv.add_process(ggHH_kl_5_kt_1_hbbhvv)
 
 #
-# HH -> bbVV, vbf
+# HH -> bbVV(incl), vbf
 #
+
+qqHH_hbbhvv = hh_vbf.add_process(
+    name="qqHH_hbbhvv",
+    id=22400,
+    label=r"$HH_{vbf} \rightarrow bbVV$",
+)
 
 qqHH_CV_1_C2V_1_kl_1_hbbhvv = qqHH_CV_1_C2V_1_kl_1.add_process(
     name="qqHH_CV_1_C2V_1_kl_1_hbbhvv",
@@ -236,6 +237,120 @@ qqHH_hbbhvv.add_process(qqHH_CV_1_C2V_0_kl_1_hbbhvv)
 qqHH_hbbhvv.add_process(qqHH_CV_1_C2V_2_kl_1_hbbhvv)
 qqHH_hbbhvv.add_process(qqHH_CV_0p5_C2V_1_kl_1_hbbhvv)
 qqHH_hbbhvv.add_process(qqHH_CV_1p5_C2V_1_kl_1_hbbhvv)
+
+#
+# HH -> bbVV(qqlv), ggf
+#
+
+ggHH_sl_hbbhvv = ggHH_hbbhvv.add_process(
+    name="ggHH_sl_hbbhvv",
+    id=21310,
+    label=r"$HH_{ggf} \rightarrow bbVV(qql\nu)$",
+)
+
+ggHH_kl_0_kt_1_sl_hbbhvv = ggHH_kl_0_kt_1_hbbhvv.add_process(
+    name="ggHH_kl_0_kt_1_sl_hbbhvv",
+    id=21311,
+    label=r"$HH_{ggf}^{\kappa\lambda=0} \rightarrow bbVV(qql\nu)$",
+    xsecs=multiply_xsecs(ggHH_kl_0_kt_1, br_bbvv_sl),
+)
+
+ggHH_kl_1_kt_1_sl_hbbhvv = ggHH_kl_1_kt_1_hbbhvv.add_process(
+    name="ggHH_kl_1_kt_1_sl_hbbhvv",
+    label=r"$HH_{ggf}^{\kappa\lambda=1} \rightarrow bbVV(qql\nu)$",
+    id=21312,
+    xsecs=multiply_xsecs(ggHH_kl_1_kt_1, br_bbvv_sl),
+)
+
+ggHH_kl_2p45_kt_1_sl_hbbhvv = ggHH_kl_2p45_kt_1_hbbhvv.add_process(
+    name="ggHH_kl_2p45_kt_1_sl_hbbhvv",
+    label=r"$HH_{ggf}^{\kappa\lambda=2.45} \rightarrow bbVV(qql\nu)$",
+    id=21313,
+    xsecs=multiply_xsecs(ggHH_kl_2p45_kt_1, br_bbvv_sl),
+)
+
+ggHH_kl_5_kt_1_sl_hbbhvv = ggHH_kl_5_kt_1_hbbhvv.add_process(
+    name="ggHH_kl_5_kt_1_sl_hbbhvv",
+    label=r"$HH_{ggf}^{\kappa\lambda=5} \rightarrow bbVV(qql\nu)$",
+    id=21314,
+    xsecs=multiply_xsecs(ggHH_kl_5_kt_1, br_bbvv_sl),
+)
+
+
+# add process dependencies
+ggHH_sl_hbbhvv.add_process(ggHH_kl_0_kt_1_sl_hbbhvv)
+ggHH_sl_hbbhvv.add_process(ggHH_kl_1_kt_1_sl_hbbhvv)
+ggHH_sl_hbbhvv.add_process(ggHH_kl_2p45_kt_1_sl_hbbhvv)
+ggHH_sl_hbbhvv.add_process(ggHH_kl_5_kt_1_sl_hbbhvv)
+
+
+#
+# HH -> bbVV(qqlv), vbf
+#
+
+qqHH_sl_hbbhvv = qqHH_hbbhvv.add_process(
+    name="qqHH_sl_hbbhvv",
+    label=r"$HH_{vbf} \rightarrow bbVV(qql\nu)$",
+    id=22410,
+)
+
+qqHH_CV_1_C2V_1_kl_1_sl_hbbhvv = qqHH_CV_1_C2V_1_kl_1_hbbhvv.add_process(
+    name="qqHH_CV_1_C2V_1_kl_1_sl_hbbhvv",
+    label=r"$HH_{vbf}^{1,1,1} \rightarrow bbVV(qql\nu)$",
+    id=22411,
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_1, br_bbvv_sl),
+)
+
+qqHH_CV_1_C2V_1_kl_0_sl_hbbhvv = qqHH_CV_1_C2V_1_kl_0_hbbhvv.add_process(
+    name="qqHH_CV_1_C2V_1_kl_0_sl_hbbhvv",
+    label=r"$HH_{vbf}^{1,1,0} \rightarrow bbVV(qql\nu)$",
+    id=22412,
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_0, br_bbvv_sl),
+)
+
+qqHH_CV_1_C2V_1_kl_2_sl_hbbhvv = qqHH_CV_1_C2V_1_kl_2_hbbhvv.add_process(
+    name="qqHH_CV_1_C2V_1_kl_2_sl_hbbhvv",
+    label=r"$HH_{vbf}^{1,1,2} \rightarrow bbVV(qql\nu)$",
+    id=22413,
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_2, br_bbvv_sl),
+)
+
+qqHH_CV_1_C2V_0_kl_1_sl_hbbhvv = qqHH_CV_1_C2V_0_kl_1_hbbhvv.add_process(
+    name="qqHH_CV_1_C2V_0_kl_1_sl_hbbhvv",
+    label=r"$HH_{vbf}^{1,0,1} \rightarrow bbVV(qql\nu)$",
+    id=22414,
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_0_kl_1, br_bbvv_sl),
+)
+
+qqHH_CV_1_C2V_2_kl_1_sl_hbbhvv = qqHH_CV_1_C2V_2_kl_1_hbbhvv.add_process(
+    name="qqHH_CV_1_C2V_2_kl_1_sl_hbbhvv",
+    label=r"$HH_{vbf}^{1,2,1} \rightarrow bbVV(qql\nu)$",
+    id=22415,
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_2_kl_1, br_bbvv_sl),
+)
+
+qqHH_CV_0p5_C2V_1_kl_1_sl_hbbhvv = qqHH_CV_0p5_C2V_1_kl_1_hbbhvv.add_process(
+    name="qqHH_CV_0p5_C2V_1_kl_1_sl_hbbhvv",
+    label=r"$HH_{vbf}^{0.5,1,1} \rightarrow bbVV(qql\nu)$",
+    id=22416,
+    xsecs=multiply_xsecs(qqHH_CV_0p5_C2V_1_kl_1, br_bbvv_sl),
+)
+
+qqHH_CV_1p5_C2V_1_kl_1_sl_hbbhvv = qqHH_CV_1p5_C2V_1_kl_1_hbbhvv.add_process(
+    name="qqHH_CV_1p5_C2V_1_kl_1_sl_hbbhvv",
+    label=r"$HH_{vbf}^{1.5,1,1} \rightarrow bbVV(qql\nu)$",
+    id=22417,
+    xsecs=multiply_xsecs(qqHH_CV_1p5_C2V_1_kl_1, br_bbvv_sl),
+)
+
+# add process dependencies
+qqHH_sl_hbbhvv.add_process(qqHH_CV_1_C2V_1_kl_1_sl_hbbhvv)
+qqHH_sl_hbbhvv.add_process(qqHH_CV_1_C2V_1_kl_0_sl_hbbhvv)
+qqHH_sl_hbbhvv.add_process(qqHH_CV_1_C2V_1_kl_2_sl_hbbhvv)
+qqHH_sl_hbbhvv.add_process(qqHH_CV_1_C2V_0_kl_1_sl_hbbhvv)
+qqHH_sl_hbbhvv.add_process(qqHH_CV_1_C2V_2_kl_1_sl_hbbhvv)
+qqHH_sl_hbbhvv.add_process(qqHH_CV_0p5_C2V_1_kl_1_sl_hbbhvv)
+qqHH_sl_hbbhvv.add_process(qqHH_CV_1p5_C2V_1_kl_1_sl_hbbhvv)
 
 #
 # HH -> bbVV(2l2v), ggf
@@ -351,9 +466,123 @@ qqHH_dl_hbbhvv.add_process(qqHH_CV_1_C2V_2_kl_1_dl_hbbhvv)
 qqHH_dl_hbbhvv.add_process(qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhvv)
 qqHH_dl_hbbhvv.add_process(qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhvv)
 
+###############################################################
 #
-# NOTE: HH -> bbWW(incl) not yet included
+# HH -> bbWW
 #
+###############################################################
+
+#
+# HH -> bbWW (incl), ggf
+#
+
+ggHH_hbbhww = ggHH_hbbhvv.add_process(
+    name="ggHH_hbbhww",
+    id=21200,
+    label=r"$HH_{ggf} \rightarrow bbww$",
+)
+
+ggHH_kl_0_kt_1_hbbhww = ggHH_kl_0_kt_1_hbbhvv.add_process(
+    name="ggHH_kl_0_kt_1_hbbhww",
+    id=21201,
+    label=r"$HH_{ggf}^{\kappa\lambda=0} \rightarrow bbww$",
+    xsecs=multiply_xsecs(ggHH_kl_0_kt_1, const.br_hh.bbww),
+)
+
+ggHH_kl_1_kt_1_hbbhww = ggHH_kl_1_kt_1_hbbhvv.add_process(
+    name="ggHH_kl_1_kt_1_hbbhww",
+    label=r"$HH_{ggf}^{\kappa\lambda=1} \rightarrow bbww$",
+    id=21202,
+    xsecs=multiply_xsecs(ggHH_kl_1_kt_1, const.br_hh.bbww),
+)
+
+ggHH_kl_2p45_kt_1_hbbhww = ggHH_kl_2p45_kt_1_hbbhvv.add_process(
+    name="ggHH_kl_2p45_kt_1_hbbhww",
+    label=r"$HH_{ggf}^{\kappa\lambda=2.45} \rightarrow bbww$",
+    id=21203,
+    xsecs=multiply_xsecs(ggHH_kl_2p45_kt_1, const.br_hh.bbww),
+)
+
+ggHH_kl_5_kt_1_hbbhww = ggHH_kl_5_kt_1_hbbhvv.add_process(
+    name="ggHH_kl_5_kt_1_hbbhww",
+    label=r"$HH_{ggf}^{\kappa\lambda=5} \rightarrow bbww$",
+    id=21204,
+    xsecs=multiply_xsecs(ggHH_kl_5_kt_1, const.br_hh.bbww),
+)
+
+# add process dependencies
+ggHH_hbbhww.add_process(ggHH_kl_0_kt_1_hbbhww)
+ggHH_hbbhww.add_process(ggHH_kl_1_kt_1_hbbhww)
+ggHH_hbbhww.add_process(ggHH_kl_2p45_kt_1_hbbhww)
+ggHH_hbbhww.add_process(ggHH_kl_5_kt_1_hbbhww)
+
+#
+# HH -> bbWW(incl), vbf
+#
+
+qqHH_hbbhww = qqHH_hbbhvv.add_process(
+    name="qqHH_hbbhww",
+    id=22200,
+    label=r"$HH_{vbf} \rightarrow bbWW$",
+)
+
+qqHH_CV_1_C2V_1_kl_1_hbbhww = qqHH_CV_1_C2V_1_kl_1_hbbhvv.add_process(
+    name="qqHH_CV_1_C2V_1_kl_1_hbbhww",
+    label=r"$HH_{vbf}^{1,1,1} \rightarrow bbWW$",
+    id=22201,
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_1, const.br_hh.bbww),
+)
+
+qqHH_CV_1_C2V_1_kl_0_hbbhww = qqHH_CV_1_C2V_1_kl_0_hbbhvv.add_process(
+    name="qqHH_CV_1_C2V_1_kl_0_hbbhww",
+    label=r"$HH_{vbf}^{1,1,0} \rightarrow bbWW$",
+    id=22202,
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_0, const.br_hh.bbww),
+)
+
+qqHH_CV_1_C2V_1_kl_2_hbbhww = qqHH_CV_1_C2V_1_kl_2_hbbhvv.add_process(
+    name="qqHH_CV_1_C2V_1_kl_2_hbbhww",
+    label=r"$HH_{vbf}^{1,1,2} \rightarrow bbWW$",
+    id=22203,
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_2, const.br_hh.bbww),
+)
+
+qqHH_CV_1_C2V_0_kl_1_hbbhww = qqHH_CV_1_C2V_0_kl_1_hbbhvv.add_process(
+    name="qqHH_CV_1_C2V_0_kl_1_hbbhww",
+    label=r"$HH_{vbf}^{1,0,1} \rightarrow bbWW$",
+    id=22204,
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_0_kl_1, const.br_hh.bbww),
+)
+
+qqHH_CV_1_C2V_2_kl_1_hbbhww = qqHH_CV_1_C2V_2_kl_1_hbbhvv.add_process(
+    name="qqHH_CV_1_C2V_2_kl_1_hbbhww",
+    label=r"$HH_{vbf}^{1,2,1} \rightarrow bbWW$",
+    id=22205,
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_2_kl_1, const.br_hh.bbww),
+)
+
+qqHH_CV_0p5_C2V_1_kl_1_hbbhww = qqHH_CV_0p5_C2V_1_kl_1_hbbhvv.add_process(
+    name="qqHH_CV_0p5_C2V_1_kl_1_hbbhww",
+    label=r"$HH_{vbf}^{0.5,1,1} \rightarrow bbWW$",
+    id=22206,
+    xsecs=multiply_xsecs(qqHH_CV_0p5_C2V_1_kl_1, const.br_hh.bbww),
+)
+
+qqHH_CV_1p5_C2V_1_kl_1_hbbhww = qqHH_CV_1p5_C2V_1_kl_1_hbbhvv.add_process(
+    name="qqHH_CV_1p5_C2V_1_kl_1_hbbhww",
+    label=r"$HH_{vbf}^{1.5,1,1} \rightarrow bbWW$",
+    id=22207,
+    xsecs=multiply_xsecs(qqHH_CV_1p5_C2V_1_kl_1, const.br_hh.bbww),
+)
+
+# add process dependencies
+qqHH_hbbhww.add_process(qqHH_CV_1_C2V_1_kl_1_hbbhww)
+qqHH_hbbhww.add_process(qqHH_CV_1_C2V_1_kl_0_hbbhww)
+qqHH_hbbhww.add_process(qqHH_CV_1_C2V_1_kl_2_hbbhww)
+qqHH_hbbhww.add_process(qqHH_CV_1_C2V_0_kl_1_hbbhww)
+qqHH_hbbhww.add_process(qqHH_CV_1_C2V_2_kl_1_hbbhww)
+qqHH_hbbhww.add_process(qqHH_CV_0p5_C2V_1_kl_1_hbbhww)
+qqHH_hbbhww.add_process(qqHH_CV_1p5_C2V_1_kl_1_hbbhww)
 
 #
 # HH -> bbWW(qqlv), ggf
@@ -365,28 +594,28 @@ ggHH_sl_hbbhww = ggHH_hbbhww.add_process(
     label=r"$HH_{ggf} \rightarrow bbWW(qql\nu)$",
 )
 
-ggHH_kl_0_kt_1_sl_hbbhww = ggHH_kl_0_kt_1_hbbhvv.add_process(
+ggHH_kl_0_kt_1_sl_hbbhww = ggHH_kl_0_kt_1_sl_hbbhvv.add_process(
     name="ggHH_kl_0_kt_1_sl_hbbhww",
     id=21211,
     label=r"$HH_{ggf}^{\kappa\lambda=0} \rightarrow bbWW(qql\nu)$",
     xsecs=multiply_xsecs(ggHH_kl_0_kt_1, br_bbww_sl),
 )
 
-ggHH_kl_1_kt_1_sl_hbbhww = ggHH_kl_1_kt_1_hbbhvv.add_process(
+ggHH_kl_1_kt_1_sl_hbbhww = ggHH_kl_1_kt_1_sl_hbbhvv.add_process(
     name="ggHH_kl_1_kt_1_sl_hbbhww",
     label=r"$HH_{ggf}^{\kappa\lambda=1} \rightarrow bbWW(qql\nu)$",
     id=21212,
     xsecs=multiply_xsecs(ggHH_kl_1_kt_1, br_bbww_sl),
 )
 
-ggHH_kl_2p45_kt_1_sl_hbbhww = ggHH_kl_2p45_kt_1_hbbhvv.add_process(
+ggHH_kl_2p45_kt_1_sl_hbbhww = ggHH_kl_2p45_kt_1_sl_hbbhvv.add_process(
     name="ggHH_kl_2p45_kt_1_sl_hbbhww",
     label=r"$HH_{ggf}^{\kappa\lambda=2.45} \rightarrow bbWW(qql\nu)$",
     id=21213,
     xsecs=multiply_xsecs(ggHH_kl_2p45_kt_1, br_bbww_sl),
 )
 
-ggHH_kl_5_kt_1_sl_hbbhww = ggHH_kl_5_kt_1_hbbhvv.add_process(
+ggHH_kl_5_kt_1_sl_hbbhww = ggHH_kl_5_kt_1_sl_hbbhvv.add_process(
     name="ggHH_kl_5_kt_1_sl_hbbhww",
     label=r"$HH_{ggf}^{\kappa\lambda=5} \rightarrow bbWW(qql\nu)$",
     id=21214,
@@ -398,6 +627,12 @@ ggHH_sl_hbbhww.add_process(ggHH_kl_0_kt_1_sl_hbbhww)
 ggHH_sl_hbbhww.add_process(ggHH_kl_1_kt_1_sl_hbbhww)
 ggHH_sl_hbbhww.add_process(ggHH_kl_2p45_kt_1_sl_hbbhww)
 ggHH_sl_hbbhww.add_process(ggHH_kl_5_kt_1_sl_hbbhww)
+
+ggHH_kl_0_kt_1_hbbhww.add_process(ggHH_kl_0_kt_1_sl_hbbhww)
+ggHH_kl_1_kt_1_hbbhww.add_process(ggHH_kl_1_kt_1_sl_hbbhww)
+ggHH_kl_2p45_kt_1_hbbhww.add_process(ggHH_kl_2p45_kt_1_sl_hbbhww)
+ggHH_kl_5_kt_1_hbbhww.add_process(ggHH_kl_5_kt_1_sl_hbbhww)
+
 
 #
 # HH -> bbWW(lvlv), ggf
@@ -437,12 +672,16 @@ ggHH_kl_5_kt_1_dl_hbbhww = ggHH_kl_5_kt_1_dl_hbbhvv.add_process(
     xsecs=multiply_xsecs(ggHH_kl_5_kt_1, br_bbww_dl),
 )
 
-
 # add process dependencies
 ggHH_dl_hbbhww.add_process(ggHH_kl_0_kt_1_dl_hbbhww)
 ggHH_dl_hbbhww.add_process(ggHH_kl_1_kt_1_dl_hbbhww)
 ggHH_dl_hbbhww.add_process(ggHH_kl_2p45_kt_1_dl_hbbhww)
 ggHH_dl_hbbhww.add_process(ggHH_kl_5_kt_1_dl_hbbhww)
+
+ggHH_kl_0_kt_1_hbbhww.add_process(ggHH_kl_0_kt_1_dl_hbbhww)
+ggHH_kl_1_kt_1_hbbhww.add_process(ggHH_kl_1_kt_1_dl_hbbhww)
+ggHH_kl_2p45_kt_1_hbbhww.add_process(ggHH_kl_2p45_kt_1_dl_hbbhww)
+ggHH_kl_5_kt_1_hbbhww.add_process(ggHH_kl_5_kt_1_dl_hbbhww)
 
 #
 # HH -> bbWW(qqlv), vbf
@@ -454,49 +693,49 @@ qqHH_sl_hbbhww = qqHH_hbbhww.add_process(
     id=22210,
 )
 
-qqHH_CV_1_C2V_1_kl_1_sl_hbbhww = qqHH_CV_1_C2V_1_kl_1_hbbhvv.add_process(
+qqHH_CV_1_C2V_1_kl_1_sl_hbbhww = qqHH_CV_1_C2V_1_kl_1_sl_hbbhvv.add_process(
     name="qqHH_CV_1_C2V_1_kl_1_sl_hbbhww",
     label=r"$HH_{vbf}^{1,1,1} \rightarrow bbWW(qql\nu)$",
     id=22211,
     xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_1, br_bbww_sl),
 )
 
-qqHH_CV_1_C2V_1_kl_0_sl_hbbhww = qqHH_CV_1_C2V_1_kl_0_hbbhvv.add_process(
+qqHH_CV_1_C2V_1_kl_0_sl_hbbhww = qqHH_CV_1_C2V_1_kl_0_sl_hbbhvv.add_process(
     name="qqHH_CV_1_C2V_1_kl_0_sl_hbbhww",
     label=r"$HH_{vbf}^{1,1,0} \rightarrow bbWW(qql\nu)$",
     id=22212,
     xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_0, br_bbww_sl),
 )
 
-qqHH_CV_1_C2V_1_kl_2_sl_hbbhww = qqHH_CV_1_C2V_1_kl_2_hbbhvv.add_process(
+qqHH_CV_1_C2V_1_kl_2_sl_hbbhww = qqHH_CV_1_C2V_1_kl_2_sl_hbbhvv.add_process(
     name="qqHH_CV_1_C2V_1_kl_2_sl_hbbhww",
     label=r"$HH_{vbf}^{1,1,2} \rightarrow bbWW(qql\nu)$",
     id=22213,
     xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_2, br_bbww_sl),
 )
 
-qqHH_CV_1_C2V_0_kl_1_sl_hbbhww = qqHH_CV_1_C2V_0_kl_1_hbbhvv.add_process(
+qqHH_CV_1_C2V_0_kl_1_sl_hbbhww = qqHH_CV_1_C2V_0_kl_1_sl_hbbhvv.add_process(
     name="qqHH_CV_1_C2V_0_kl_1_sl_hbbhww",
     label=r"$HH_{vbf}^{1,0,1} \rightarrow bbWW(qql\nu)$",
     id=22214,
     xsecs=multiply_xsecs(qqHH_CV_1_C2V_0_kl_1, br_bbww_sl),
 )
 
-qqHH_CV_1_C2V_2_kl_1_sl_hbbhww = qqHH_CV_1_C2V_2_kl_1_hbbhvv.add_process(
+qqHH_CV_1_C2V_2_kl_1_sl_hbbhww = qqHH_CV_1_C2V_2_kl_1_sl_hbbhvv.add_process(
     name="qqHH_CV_1_C2V_2_kl_1_sl_hbbhww",
     label=r"$HH_{vbf}^{1,2,1} \rightarrow bbWW(qql\nu)$",
     id=22215,
     xsecs=multiply_xsecs(qqHH_CV_1_C2V_2_kl_1, br_bbww_sl),
 )
 
-qqHH_CV_0p5_C2V_1_kl_1_sl_hbbhww = qqHH_CV_0p5_C2V_1_kl_1_hbbhvv.add_process(
+qqHH_CV_0p5_C2V_1_kl_1_sl_hbbhww = qqHH_CV_0p5_C2V_1_kl_1_sl_hbbhvv.add_process(
     name="qqHH_CV_0p5_C2V_1_kl_1_sl_hbbhww",
     label=r"$HH_{vbf}^{0.5,1,1} \rightarrow bbWW(qql\nu)$",
     id=22216,
     xsecs=multiply_xsecs(qqHH_CV_0p5_C2V_1_kl_1, br_bbww_sl),
 )
 
-qqHH_CV_1p5_C2V_1_kl_1_sl_hbbhww = qqHH_CV_1p5_C2V_1_kl_1_hbbhvv.add_process(
+qqHH_CV_1p5_C2V_1_kl_1_sl_hbbhww = qqHH_CV_1p5_C2V_1_kl_1_sl_hbbhvv.add_process(
     name="qqHH_CV_1p5_C2V_1_kl_1_sl_hbbhww",
     label=r"$HH_{vbf}^{1.5,1,1} \rightarrow bbWW(qql\nu)$",
     id=22217,
@@ -511,6 +750,14 @@ qqHH_sl_hbbhww.add_process(qqHH_CV_1_C2V_0_kl_1_sl_hbbhww)
 qqHH_sl_hbbhww.add_process(qqHH_CV_1_C2V_2_kl_1_sl_hbbhww)
 qqHH_sl_hbbhww.add_process(qqHH_CV_0p5_C2V_1_kl_1_sl_hbbhww)
 qqHH_sl_hbbhww.add_process(qqHH_CV_1p5_C2V_1_kl_1_sl_hbbhww)
+
+qqHH_CV_1_C2V_1_kl_1_hbbhww.add_process(qqHH_CV_1_C2V_1_kl_1_sl_hbbhww)
+qqHH_CV_1_C2V_1_kl_0_hbbhww.add_process(qqHH_CV_1_C2V_1_kl_0_sl_hbbhww)
+qqHH_CV_1_C2V_1_kl_2_hbbhww.add_process(qqHH_CV_1_C2V_1_kl_2_sl_hbbhww)
+qqHH_CV_1_C2V_0_kl_1_hbbhww.add_process(qqHH_CV_1_C2V_0_kl_1_sl_hbbhww)
+qqHH_CV_1_C2V_2_kl_1_hbbhww.add_process(qqHH_CV_1_C2V_2_kl_1_sl_hbbhww)
+qqHH_CV_0p5_C2V_1_kl_1_hbbhww.add_process(qqHH_CV_0p5_C2V_1_kl_1_sl_hbbhww)
+qqHH_CV_1p5_C2V_1_kl_1_hbbhww.add_process(qqHH_CV_1p5_C2V_1_kl_1_sl_hbbhww)
 
 #
 # HH -> bbWW(lvlv), vbf
@@ -580,6 +827,132 @@ qqHH_dl_hbbhww.add_process(qqHH_CV_1_C2V_2_kl_1_dl_hbbhww)
 qqHH_dl_hbbhww.add_process(qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhww)
 qqHH_dl_hbbhww.add_process(qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhww)
 
+qqHH_CV_1_C2V_1_kl_1_hbbhww.add_process(qqHH_CV_1_C2V_1_kl_1_dl_hbbhww)
+qqHH_CV_1_C2V_1_kl_0_hbbhww.add_process(qqHH_CV_1_C2V_1_kl_0_dl_hbbhww)
+qqHH_CV_1_C2V_1_kl_2_hbbhww.add_process(qqHH_CV_1_C2V_1_kl_2_dl_hbbhww)
+qqHH_CV_1_C2V_0_kl_1_hbbhww.add_process(qqHH_CV_1_C2V_0_kl_1_dl_hbbhww)
+qqHH_CV_1_C2V_2_kl_1_hbbhww.add_process(qqHH_CV_1_C2V_2_kl_1_dl_hbbhww)
+qqHH_CV_0p5_C2V_1_kl_1_hbbhww.add_process(qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhww)
+qqHH_CV_1p5_C2V_1_kl_1_hbbhww.add_process(qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhww)
+
+##############################################################
+#
+# HH -> bbZZ
+#
+##############################################################
+
+#
+# HH -> bbZZ (incl), ggf
+#
+
+ggHH_hbbhzz = ggHH_dl_hbbhvv.add_process(
+    name="ggHH_hbbhzz",
+    id=21300,
+    label=r"$HH_{ggf} \rightarrow bbZZ$",
+)
+
+ggHH_kl_0_kt_1_hbbhzz = ggHH_kl_0_kt_1_hbbhvv.add_process(
+    name="ggHH_kl_0_kt_1_hbbhzz",
+    id=21301,
+    label=r"$HH_{ggf}^{\kappa\lambda=0} \rightarrow bbZZ$",
+    xsecs=multiply_xsecs(ggHH_kl_0_kt_1, const.br_hh.bbzz),
+)
+
+ggHH_kl_1_kt_1_hbbhzz = ggHH_kl_1_kt_1_hbbhvv.add_process(
+    name="ggHH_kl_1_kt_1_hbbhzz",
+    label=r"$HH_{ggf}^{\kappa\lambda=1} \rightarrow bbZZ$",
+    id=21302,
+    xsecs=multiply_xsecs(ggHH_kl_1_kt_1, const.br_hh.bbzz),
+)
+
+ggHH_kl_2p45_kt_1_hbbhzz = ggHH_kl_2p45_kt_1_hbbhvv.add_process(
+    name="ggHH_kl_2p45_kt_1_hbbhzz",
+    label=r"$HH_{ggf}^{\kappa\lambda=2.45} \rightarrow bbZZ$",
+    id=21303,
+    xsecs=multiply_xsecs(ggHH_kl_2p45_kt_1, const.br_hh.bbzz),
+)
+
+ggHH_kl_5_kt_1_hbbhzz = ggHH_kl_5_kt_1_hbbhvv.add_process(
+    name="ggHH_kl_5_kt_1_hbbhzz",
+    label=r"$HH_{ggf}^{\kappa\lambda=5} \rightarrow bbZZ$",
+    id=21304,
+    xsecs=multiply_xsecs(ggHH_kl_5_kt_1, const.br_hh.bbzz),
+)
+
+# add process dependencies
+ggHH_hbbhzz.add_process(ggHH_kl_0_kt_1_hbbhzz)
+ggHH_hbbhzz.add_process(ggHH_kl_1_kt_1_hbbhzz)
+ggHH_hbbhzz.add_process(ggHH_kl_2p45_kt_1_hbbhzz)
+ggHH_hbbhzz.add_process(ggHH_kl_5_kt_1_hbbhzz)
+
+#
+# HH -> bbZZ(incl), vbf
+#
+
+qqHH_hbbhzz = qqHH_hbbhvv.add_process(
+    name="qqHH_hbbhzz",
+    id=22300,
+    label=r"$HH_{vbf} \rightarrow $",
+)
+
+qqHH_CV_1_C2V_1_kl_1_hbbhzz = qqHH_CV_1_C2V_1_kl_1_hbbhvv.add_process(
+    name="qqHH_CV_1_C2V_1_kl_1_hbbhzz",
+    label=r"$HH_{vbf}^{1,1,1} \rightarrow bbZZ$",
+    id=22301,
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_1, const.br_hh.bbzz),
+)
+
+qqHH_CV_1_C2V_1_kl_0_hbbhzz = qqHH_CV_1_C2V_1_kl_0_hbbhvv.add_process(
+    name="qqHH_CV_1_C2V_1_kl_0_hbbhzz",
+    label=r"$HH_{vbf}^{1,1,0} \rightarrow bbZZ$",
+    id=22302,
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_0, const.br_hh.bbzz),
+)
+
+qqHH_CV_1_C2V_1_kl_2_hbbhzz = qqHH_CV_1_C2V_1_kl_2_hbbhvv.add_process(
+    name="qqHH_CV_1_C2V_1_kl_2_hbbhzz",
+    label=r"$HH_{vbf}^{1,1,2} \rightarrow bbZZ$",
+    id=22303,
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_1_kl_2, const.br_hh.bbzz),
+)
+
+qqHH_CV_1_C2V_0_kl_1_hbbhzz = qqHH_CV_1_C2V_0_kl_1_hbbhvv.add_process(
+    name="qqHH_CV_1_C2V_0_kl_1_hbbhzz",
+    label=r"$HH_{vbf}^{1,0,1} \rightarrow bbZZ$",
+    id=22304,
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_0_kl_1, const.br_hh.bbzz),
+)
+
+qqHH_CV_1_C2V_2_kl_1_hbbhzz = qqHH_CV_1_C2V_2_kl_1_hbbhvv.add_process(
+    name="qqHH_CV_1_C2V_2_kl_1_hbbhzz",
+    label=r"$HH_{vbf}^{1,2,1} \rightarrow bbZZ$",
+    id=22305,
+    xsecs=multiply_xsecs(qqHH_CV_1_C2V_2_kl_1, const.br_hh.bbzz),
+)
+
+qqHH_CV_0p5_C2V_1_kl_1_hbbhzz = qqHH_CV_0p5_C2V_1_kl_1_hbbhvv.add_process(
+    name="qqHH_CV_0p5_C2V_1_kl_1_hbbhzz",
+    label=r"$HH_{vbf}^{0.5,1,1} \rightarrow bbZZ$",
+    id=22306,
+    xsecs=multiply_xsecs(qqHH_CV_0p5_C2V_1_kl_1, const.br_hh.bbzz),
+)
+
+qqHH_CV_1p5_C2V_1_kl_1_hbbhzz = qqHH_CV_1p5_C2V_1_kl_1_hbbhvv.add_process(
+    name="qqHH_CV_1p5_C2V_1_kl_1_hbbhzz",
+    label=r"$HH_{vbf}^{1.5,1,1} \rightarrow bbZZ$",
+    id=22307,
+    xsecs=multiply_xsecs(qqHH_CV_1p5_C2V_1_kl_1, const.br_hh.bbzz),
+)
+
+# add process dependencies
+qqHH_hbbhzz.add_process(qqHH_CV_1_C2V_1_kl_1_hbbhzz)
+qqHH_hbbhzz.add_process(qqHH_CV_1_C2V_1_kl_0_hbbhzz)
+qqHH_hbbhzz.add_process(qqHH_CV_1_C2V_1_kl_2_hbbhzz)
+qqHH_hbbhzz.add_process(qqHH_CV_1_C2V_0_kl_1_hbbhzz)
+qqHH_hbbhzz.add_process(qqHH_CV_1_C2V_2_kl_1_hbbhzz)
+qqHH_hbbhzz.add_process(qqHH_CV_0p5_C2V_1_kl_1_hbbhzz)
+qqHH_hbbhzz.add_process(qqHH_CV_1p5_C2V_1_kl_1_hbbhzz)
+
 #
 # HH -> bbZZ, ggf
 #
@@ -624,6 +997,11 @@ ggHH_dl_hbbhzz.add_process(ggHH_kl_0_kt_1_dl_hbbhzz)
 ggHH_dl_hbbhzz.add_process(ggHH_kl_1_kt_1_dl_hbbhzz)
 ggHH_dl_hbbhzz.add_process(ggHH_kl_2p45_kt_1_dl_hbbhzz)
 ggHH_dl_hbbhzz.add_process(ggHH_kl_5_kt_1_dl_hbbhzz)
+
+ggHH_kl_0_kt_1_hbbhzz.add_process(ggHH_kl_0_kt_1_dl_hbbhzz)
+ggHH_kl_1_kt_1_hbbhzz.add_process(ggHH_kl_1_kt_1_dl_hbbhzz)
+ggHH_kl_2p45_kt_1_hbbhzz.add_process(ggHH_kl_2p45_kt_1_dl_hbbhzz)
+ggHH_kl_5_kt_1_hbbhzz.add_process(ggHH_kl_5_kt_1_dl_hbbhzz)
 
 
 #
@@ -693,6 +1071,22 @@ qqHH_dl_hbbhzz.add_process(qqHH_CV_1_C2V_0_kl_1_dl_hbbhzz)
 qqHH_dl_hbbhzz.add_process(qqHH_CV_1_C2V_2_kl_1_dl_hbbhzz)
 qqHH_dl_hbbhzz.add_process(qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhzz)
 qqHH_dl_hbbhzz.add_process(qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhzz)
+
+qqHH_CV_1_C2V_1_kl_1_hbbhzz.add_process(qqHH_CV_1_C2V_1_kl_1_dl_hbbhzz)
+qqHH_CV_1_C2V_1_kl_0_hbbhzz.add_process(qqHH_CV_1_C2V_1_kl_0_dl_hbbhzz)
+qqHH_CV_1_C2V_1_kl_2_hbbhzz.add_process(qqHH_CV_1_C2V_1_kl_2_dl_hbbhzz)
+qqHH_CV_1_C2V_0_kl_1_hbbhzz.add_process(qqHH_CV_1_C2V_0_kl_1_dl_hbbhzz)
+qqHH_CV_1_C2V_2_kl_1_hbbhzz.add_process(qqHH_CV_1_C2V_2_kl_1_dl_hbbhzz)
+qqHH_CV_0p5_C2V_1_kl_1_hbbhzz.add_process(qqHH_CV_0p5_C2V_1_kl_1_dl_hbbhzz)
+qqHH_CV_1p5_C2V_1_kl_1_hbbhzz.add_process(qqHH_CV_1p5_C2V_1_kl_1_dl_hbbhzz)
+
+
+#############################################################
+#
+# HH resonant
+#
+#############################################################
+
 
 #
 # ggF -> radion -> HH

--- a/cmsdb/processes/hh2bbww.py
+++ b/cmsdb/processes/hh2bbww.py
@@ -92,10 +92,10 @@ from cmsdb.processes.higgs import (
 #
 
 br_bbvv = const.br_hh.bbww + const.br_hh.bbzz
-br_bbvv_dl = const.br_hh.bbww * const.br_ww.dl + const.br_hh.bbzz * const.br_z.clep ** 2
+br_bbvv_dl = const.br_hh.bbww * const.br_ww.dl + const.br_hh.bbzz * const.br_zz.dl
 br_bbww_sl = const.br_hh.bbww * const.br_ww.sl
 br_bbww_dl = const.br_hh.bbww * const.br_ww.dl
-br_bbzz_dl = const.br_hh.bbzz * const.br_ww.dl
+br_bbzz_dl = const.br_hh.bbzz * const.br_zz.dl
 
 #
 # HH -> bbVV


### PR DESCRIPTION
This PR adds the hh2bbvv processes requested in #31 and (hopefully) all relevant subprocesses.

This leads to a total of 104 processes:

- 8 different "main" processes (bbVV, bbVV_sl, bbVV_dl, bbWW, bbWW_sl, bbWW_dl, bbZZ, bbZZ_dl) for both ggf and vbf
- for each "main" ggf process, 4 sub-processes for kl variations --> (4+1)*8=40 ggf processes
- for each "main" vbf process, 7 sub-processes for kl,cv,c2v variations --> (7+1)*8=64 vbf processes

Note that there are no HH (vbf+ggf) processes. We could add them, but I don't think we need them.

The ID scheme is documented in the docstring.

Closes #31 