### PR TITLE
Added Marcel's custom NanoAoD to the 2016HIPM campaign

### DIFF
--- a/cmsdb/campaigns/run2_2016_HIPM_nano_uhh_v12/__init__.py
+++ b/cmsdb/campaigns/run2_2016_HIPM_nano_uhh_v12/__init__.py
@@ -31,10 +31,11 @@ campaign_run2_2016_HIPM_nano_uhh_v12 = Campaign(
         "year": 2016,
         "vfp": "pre",
         "version": 12,
+        "vfp": "pre",
         "custom": {
             "name": "run2_2016_HIPM_nano_uhh_v12",
             "creator": "uhh",
-            "location": "davs://dcache-cms-webdav-wan.desy.de:2880/pnfs/desy.de/cms/tier2/store/user/aalvesan/nano_uhh_v12_2016_HIPM/merged_2048.0MB",  # noqa
+            "location": "davs://dcache-cms-webdav-wan.desy.de:2880/pnfs/desy.de/cms/tier2/store/user/mrieger/nanogen_store/CreateNano/config_ul16pre/prod2",  # noqa
         },
     },
 )
@@ -43,6 +44,6 @@ campaign_run2_2016_HIPM_nano_uhh_v12 = Campaign(
 import cmsdb.campaigns.run2_2016_HIPM_nano_uhh_v12.data  # noqa
 import cmsdb.campaigns.run2_2016_HIPM_nano_uhh_v12.ewk  # noqa
 import cmsdb.campaigns.run2_2016_HIPM_nano_uhh_v12.hh2bbtautau  # noqa
-import cmsdb.campaigns.run2_2016_HIPM_nano_uhh_v12.higgs  # noqa
+# import cmsdb.campaigns.run2_2016_HIPM_nano_uhh_v12.higgs  # noqa  # not yet available
 import cmsdb.campaigns.run2_2016_HIPM_nano_uhh_v12.st  # noqa
 import cmsdb.campaigns.run2_2016_HIPM_nano_uhh_v12.ttbar  # noqa

--- a/cmsdb/campaigns/run2_2016_HIPM_nano_uhh_v12/data.py
+++ b/cmsdb/campaigns/run2_2016_HIPM_nano_uhh_v12/data.py
@@ -16,10 +16,10 @@ cpn.add_dataset(
     is_data=True,
     processes=[procs.data_e],
     keys=[
-        "/SingleElectron/Run2016B-ver2_HIPM_UL2016_MiniAODv2-v2/NANOAOD",  # noqa
+        "/SingleElectron/Run2016B-ver2_HIPM_UL2016_MiniAODv2_NanoAODAPVv12UHH-v2/NANOAOD",  # noqa
     ],
-    n_files=97,
-    n_events=246440440,
+    n_files=1_921,
+    n_events=246_440_440,
     aux={
         "era": "B",
     },
@@ -31,10 +31,10 @@ cpn.add_dataset(
     is_data=True,
     processes=[procs.data_e],
     keys=[
-        "/SingleElectron/Run2016C-HIPM_UL2016_MiniAODv2-v2/NANOAOD",  # noqa
+        "/SingleElectron/Run2016C-HIPM_UL2016_MiniAODv2_NanoAODAPVv12UHH-v2/NANOAOD",  # noqa
     ],
-    n_files=41,
-    n_events=97259854,
+    n_files=817,
+    n_events=97_259_854,
     aux={
         "era": "C",
     },
@@ -46,10 +46,10 @@ cpn.add_dataset(
     is_data=True,
     processes=[procs.data_e],
     keys=[
-        "/SingleElectron/Run2016D-HIPM_UL2016_MiniAODv2-v2/NANOAOD",  # noqa
+        "/SingleElectron/Run2016D-HIPM_UL2016_MiniAODv2_NanoAODAPVv12UHH-v2/NANOAOD",  # noqa
     ],
-    n_files=60,
-    n_events=148167727,
+    n_files=1_135,
+    n_events=148_167_727,
     aux={
         "era": "D",
     },
@@ -61,10 +61,10 @@ cpn.add_dataset(
     is_data=True,
     processes=[procs.data_e],
     keys=[
-        "/SingleElectron/Run2016E-HIPM_UL2016_MiniAODv2-v5/NANOAOD",  # noqa
+        "/SingleElectron/Run2016E-HIPM_UL2016_MiniAODv2_NanoAODAPVv12UHH-v5/NANOAOD",  # noqa
     ],
-    n_files=49,
-    n_events=117269446,
+    n_files=1_024,
+    n_events=117_269_446,
     aux={
         "era": "E",
     },
@@ -76,10 +76,10 @@ cpn.add_dataset(
     is_data=True,
     processes=[procs.data_e],
     keys=[
-        "/SingleElectron/Run2016F-HIPM_UL2016_MiniAODv2-v2/NANOAOD",  # noqa
+        "/SingleElectron/Run2016F-HIPM_UL2016_MiniAODv2_NanoAODAPVv12UHH-v2/NANOAOD",  # noqa
     ],
-    n_files=27,
-    n_events=61735326,
+    n_files=549,
+    n_events=61_735_326,
     aux={
         "era": "F",
     },
@@ -93,10 +93,10 @@ cpn.add_dataset(
     is_data=True,
     processes=[procs.data_mu],
     keys=[
-        "/SingleMuon/Run2016B-ver2_HIPM_UL2016_MiniAODv2-v2/NANOAOD",  # noqa
+        "/SingleMuon/Run2016B-ver2_HIPM_UL2016_MiniAODv2_NanoAODAPVv12UHH-v2/NANOAOD",  # noqa
     ],
-    n_files=52,
-    n_events=158145722,
+    n_files=986,
+    n_events=158_145_722,
     aux={
         "era": "B",
     },
@@ -108,10 +108,10 @@ cpn.add_dataset(
     is_data=True,
     processes=[procs.data_mu],
     keys=[
-        "/SingleMuon/Run2016C-HIPM_UL2016_MiniAODv2-v2/NANOAOD",  # noqa
+        "/SingleMuon/Run2016C-HIPM_UL2016_MiniAODv2_NanoAODAPVv12UHH-v2/NANOAOD",  # noqa
     ],
-    n_files=24,
-    n_events=67441308,
+    n_files=448,
+    n_events=67_441_308,
     aux={
         "era": "C",
     },
@@ -123,10 +123,10 @@ cpn.add_dataset(
     is_data=True,
     processes=[procs.data_mu],
     keys=[
-        "/SingleMuon/Run2016D-HIPM_UL2016_MiniAODv2-v2/NANOAOD",  # noqa
+        "/SingleMuon/Run2016D-HIPM_UL2016_MiniAODv2_NanoAODAPVv12UHH-v2/NANOAOD",  # noqa
     ],
-    n_files=34,
-    n_events=98017996,
+    n_files=630,
+    n_events=98_017_996,
     aux={
         "era": "D",
     },
@@ -138,10 +138,10 @@ cpn.add_dataset(
     is_data=True,
     processes=[procs.data_mu],
     keys=[
-        "/SingleMuon/Run2016E-HIPM_UL2016_MiniAODv2-v2/NANOAOD",  # noqa
+        "/SingleMuon/Run2016E-HIPM_UL2016_MiniAODv2_NanoAODAPVv12UHH-v2/NANOAOD",  # noqa
     ],
-    n_files=32,
-    n_events=90984718,
+    n_files=640,
+    n_events=90_984_718,
     aux={
         "era": "E",
     },
@@ -153,10 +153,10 @@ cpn.add_dataset(
     is_data=True,
     processes=[procs.data_mu],
     keys=[
-        "/SingleMuon/Run2016F-HIPM_UL2016_MiniAODv2-v2/NANOAOD",  # noqa
+        "/SingleMuon/Run2016F-HIPM_UL2016_MiniAODv2_NanoAODAPVv12UHH-v2/NANOAOD",  # noqa
     ],
-    n_files=21,
-    n_events=57465359,
+    n_files=433,
+    n_events=57_465_359,
     aux={
         "era": "F",
     },
@@ -171,10 +171,10 @@ cpn.add_dataset(
     is_data=True,
     processes=[procs.data_tau],
     keys=[
-        "/Tau/Run2016B-ver2_HIPM_UL2016_MiniAODv2-v1/NANOAOD",  # noqa
+        "/Tau/Run2016B-ver2_HIPM_UL2016_MiniAODv2_NanoAODAPVv12UHH-v1/NANOAOD",  # noqa
     ],
-    n_files=32,
-    n_events=68736788,
+    n_files=512,
+    n_events=68_736_788,
     aux={
         "era": "B",
     },
@@ -186,10 +186,10 @@ cpn.add_dataset(
     is_data=True,
     processes=[procs.data_tau],
     keys=[
-        "/Tau/Run2016C-HIPM_UL2016_MiniAODv2-v1/NANOAOD",  # noqa
+        "/Tau/Run2016C-HIPM_UL2016_MiniAODv2_NanoAODAPVv12UHH-v1/NANOAOD",  # noqa
     ],
-    n_files=18,
-    n_events=36931473,
+    n_files=301,
+    n_events=36_931_473,
     aux={
         "era": "C",
     },
@@ -201,10 +201,10 @@ cpn.add_dataset(
     is_data=True,
     processes=[procs.data_tau],
     keys=[
-        "/Tau/Run2016D-HIPM_UL2016_MiniAODv2-v1/NANOAOD",  # noqa
+        "/Tau/Run2016D-HIPM_UL2016_MiniAODv2_NanoAODAPVv12UHH-v1/NANOAOD",  # noqa
     ],
-    n_files=27,
-    n_events=56827771,
+    n_files=510,
+    n_events=56_827_771,
     aux={
         "era": "D",
     },
@@ -216,10 +216,10 @@ cpn.add_dataset(
     is_data=True,
     processes=[procs.data_tau],
     keys=[
-        "/Tau/Run2016E-HIPM_UL2016_MiniAODv2-v1/NANOAOD",  # noqa
+        "/Tau/Run2016E-HIPM_UL2016_MiniAODv2_NanoAODAPVv12UHH-v1/NANOAOD",  # noqa
     ],
-    n_files=29,
-    n_events=58343324,
+    n_files=507,
+    n_events=58_343_324,
     aux={
         "era": "E",
     },
@@ -231,10 +231,10 @@ cpn.add_dataset(
     is_data=True,
     processes=[procs.data_tau],
     keys=[
-        "/Tau/Run2016F-HIPM_UL2016_MiniAODv2-v1/NANOAOD",  # noqa
+        "/Tau/Run2016F-HIPM_UL2016_MiniAODv2_NanoAODAPVv12UHH-v1/NANOAOD",  # noqa
     ],
-    n_files=18,
-    n_events=36189610,
+    n_files=315,
+    n_events=36_189_610,
     aux={
         "era": "F",
     },
@@ -249,9 +249,9 @@ cpn.add_dataset(
     is_data=True,
     processes=[procs.data_met],
     keys=[
-        "/MET/Run2016B-ver2_HIPM_UL2016_MiniAODv2-v2/NANOAOD",  # noqa
+        "/MET/Run2016B-ver2_HIPM_UL2016_MiniAODv2_NanoAODAPVv12UHH-v2/NANOAOD",  # noqa
     ],
-    n_files=14,
+    n_files=274,
     n_events=35987712,
     aux={
         "era": "B",
@@ -264,9 +264,9 @@ cpn.add_dataset(
     is_data=True,
     processes=[procs.data_met],
     keys=[
-        "/MET/Run2016C-HIPM_UL2016_MiniAODv2-v2/NANOAOD",  # noqa
+        "/MET/Run2016C-HIPM_UL2016_MiniAODv2_NanoAODAPVv12UHH-v2/NANOAOD",  # noqa
     ],
-    n_files=7,
+    n_files=142,
     n_events=17381222,
     aux={
         "era": "C",
@@ -279,9 +279,9 @@ cpn.add_dataset(
     is_data=True,
     processes=[procs.data_met],
     keys=[
-        "/MET/Run2016D-HIPM_UL2016_MiniAODv2-v2/NANOAOD",  # noqa
+        "/MET/Run2016D-HIPM_UL2016_MiniAODv2_NanoAODAPVv12UHH-v2/NANOAOD",  # noqa
     ],
-    n_files=10,
+    n_files=187,
     n_events=20947429,
     aux={
         "era": "D",
@@ -295,9 +295,9 @@ cpn.add_dataset(
     is_data=True,
     processes=[procs.data_met],
     keys=[
-        "/MET/Run2016E-HIPM_UL2016_MiniAODv2-v2/NANOAOD",  # noqa
+        "/MET/Run2016E-HIPM_UL2016_MiniAODv2_NanoAODAPVv12UHH-v2/NANOAOD",  # noqa
     ],
-    n_files=11,
+    n_files=215,
     n_events=22348402,
     aux={
         "era": "E",
@@ -310,9 +310,9 @@ cpn.add_dataset(
     is_data=True,
     processes=[procs.data_met],
     keys=[
-        "/MET/Run2016F-HIPM_UL2016_MiniAODv2-v2/NANOAOD",  # noqa
+        "/MET/Run2016F-HIPM_UL2016_MiniAODv2_NanoAODAPVv12UHH-v2/NANOAOD",  # noqa
     ],
-    n_files=6,
+    n_files=114,
     n_events=11936579,
     aux={
         "era": "F",

--- a/cmsdb/campaigns/run2_2016_HIPM_nano_uhh_v12/ewk.py
+++ b/cmsdb/campaigns/run2_2016_HIPM_nano_uhh_v12/ewk.py
@@ -14,10 +14,10 @@ cpn.add_dataset(
     id=14217420,
     processes=[procs.ewk_wm_lnu_m50],
     keys=[
-        "/EWKWMinus2Jets_WToLNu_M-50_TuneCP5_withDipoleRecoil_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM",  # noqa
+        "/EWKWMinus2Jets_WToLNu_M-50_TuneCP5_withDipoleRecoil_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v1/NANOAODSIM",  # noqa
     ],
-    n_files=2,
-    n_events=2248000,
+    n_files=29,
+    n_events=2_248_000,
 )
 
 cpn.add_dataset(
@@ -25,10 +25,10 @@ cpn.add_dataset(
     id=14216470,
     processes=[procs.ewk_wp_lnu_m50],
     keys=[
-        "/EWKWPlus2Jets_WToLNu_M-50_TuneCP5_withDipoleRecoil_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM",  # noqa
+        "/EWKWPlus2Jets_WToLNu_M-50_TuneCP5_withDipoleRecoil_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v1/NANOAODSIM",  # noqa
     ],
-    n_files=2,
-    n_events=2185000,
+    n_files=46,
+    n_events=2_185_000,
 )
 
 cpn.add_dataset(
@@ -36,10 +36,10 @@ cpn.add_dataset(
     id=14214791,
     processes=[procs.ewk_z_ll_m50],
     keys=[
-        "/EWKZ2Jets_ZToLL_M-50_TuneCP5_withDipoleRecoil_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM",  # noqa
+        "/EWKZ2Jets_ZToLL_M-50_TuneCP5_withDipoleRecoil_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v1/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=500000,
+    n_files=12,
+    n_events=500_000,
 )
 
 # DY
@@ -49,10 +49,10 @@ cpn.add_dataset(
     id=14212297,
     processes=[procs.dy_lep_m50],
     keys=[
-        "/DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM",  # noqa
+        "/DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v1/NANOAODSIM",  # noqa
     ],
-    n_files=49,
-    n_events=90947213,
+    n_files=980,
+    n_events=90_947_213,
 )
 
 cpn.add_dataset(
@@ -60,10 +60,10 @@ cpn.add_dataset(
     id=14212804,
     processes=[procs.dy_lep_0j],
     keys=[
-        "/DYJetsToLL_0J_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM",  # noqa
+        "/DYJetsToLL_0J_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v1/NANOAODSIM",  # noqa
     ],
-    n_files=41,
-    n_events=79751592,
+    n_files=882,
+    n_events=79_751_592,
 )
 
 cpn.add_dataset(
@@ -71,10 +71,10 @@ cpn.add_dataset(
     id=14238480,
     processes=[procs.dy_lep_1j],
     keys=[
-        "/DYJetsToLL_1J_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM",  # noqa
+        "/DYJetsToLL_1J_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v1/NANOAODSIM",  # noqa
     ],
-    n_files=54,
-    n_events=88364975,
+    n_files=907,
+    n_events=88_364_975,
 )
 
 cpn.add_dataset(
@@ -82,10 +82,10 @@ cpn.add_dataset(
     id=14212211,
     processes=[procs.dy_lep_2j],
     keys=[
-        "/DYJetsToLL_2J_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM",  # noqa
+        "/DYJetsToLL_2J_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v1/NANOAODSIM",  # noqa
     ],
-    n_files=32,
-    n_events=42948118,
+    n_files=669,
+    n_events=42_948_118,
 )
 
 cpn.add_dataset(
@@ -93,10 +93,10 @@ cpn.add_dataset(
     id=14342843,
     processes=[procs.dy_lep_pt100To250],
     keys=[
-        "/DYJetsToLL_LHEFilterPtZ-100To250_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/DYJetsToLL_LHEFilterPtZ-100To250_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=33,
-    n_events=40104234,
+    n_files=1_273,
+    n_events=40_115_413,
 )
 
 cpn.add_dataset(
@@ -104,10 +104,10 @@ cpn.add_dataset(
     id=14346965,
     processes=[procs.dy_lep_pt250To400],
     keys=[
-        "/DYJetsToLL_LHEFilterPtZ-250To400_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/DYJetsToLL_LHEFilterPtZ-250To400_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=13,
-    n_events=12085183,
+    n_files=356,
+    n_events=12_085_183,
 )
 
 cpn.add_dataset(
@@ -115,10 +115,10 @@ cpn.add_dataset(
     id=14335914,
     processes=[procs.dy_lep_pt50To100],
     keys=[
-        "/DYJetsToLL_LHEFilterPtZ-50To100_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/DYJetsToLL_LHEFilterPtZ-50To100_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=42,
-    n_events=60848787,
+    n_files=1_762,
+    n_events=60_848_787,
 )
 
 cpn.add_dataset(
@@ -126,10 +126,10 @@ cpn.add_dataset(
     id=14339864,
     processes=[procs.dy_lep_pt0To50],
     keys=[
-        "/DYJetsToLL_LHEFilterPtZ-0To50_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/DYJetsToLL_LHEFilterPtZ-0To50_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=62,
-    n_events=101338633,
+    n_files=2_335,
+    n_events=101_338_633,
 )
 
 cpn.add_dataset(
@@ -137,10 +137,10 @@ cpn.add_dataset(
     id=14349654,
     processes=[procs.dy_lep_pt650],
     keys=[
-        "/DYJetsToLL_LHEFilterPtZ-650ToInf_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/DYJetsToLL_LHEFilterPtZ-650ToInf_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=3,
-    n_events=1999583,
+    n_files=82,
+    n_events=1_999_583,
 )
 
 cpn.add_dataset(
@@ -148,45 +148,45 @@ cpn.add_dataset(
     id=14350490,
     processes=[procs.dy_lep_pt400To650],
     keys=[
-        "/DYJetsToLL_LHEFilterPtZ-400To650_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/DYJetsToLL_LHEFilterPtZ-400To650_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=3,
-    n_events=1993002,
+    n_files=79,
+    n_events=1_993_002,
 )
 
 # multi boson
 
 cpn.add_dataset(
     name="zzz_amcatnlo",
-    id=14213425,
-    processes=[procs.zzz],
-    keys=[
-        "/ZZZ_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=81000,
-)
-
-cpn.add_dataset(
-    name="zzz_ext_amcatnlo",
     id=14215019,
     processes=[procs.zzz],
     keys=[
-        "/ZZZ_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_ext1-v1/NANOAODSIM",  # noqa
+        "/ZZZ_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_ext1_NanoAODAPVv12UHH-v1/NANOAODSIM",  # noqa
     ],
-    n_files=5,
-    n_events=5302000,
+    n_files=98,
+    n_events=5_302_000,
 )
+
+# cpn.add_dataset(
+#     name="zzz_ext_amcatnlo",
+#     id=14215019,
+#     processes=[procs.zzz],
+#     keys=[
+#         "/ZZZ_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_ext1_NanoAODAPVv12UHH-v1/NANOAODSIM",  # noqa
+#     ],
+#     n_files=5,
+#     n_events=5302000,
+# )
 
 cpn.add_dataset(
     name="ww_pythia",
     id=14214902,
     processes=[procs.ww],
     keys=[
-        "/WW_TuneCP5_13TeV-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM",  # noqa
+        "/WW_TuneCP5_13TeV-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v1/NANOAODSIM",  # noqa
     ],
-    n_files=9,
-    n_events=15859000,
+    n_files=185,
+    n_events=15_859_000,
 )
 
 cpn.add_dataset(
@@ -194,10 +194,10 @@ cpn.add_dataset(
     id=14214976,
     processes=[procs.wz],
     keys=[
-        "/WZ_TuneCP5_13TeV-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM",  # noqa
+        "/WZ_TuneCP5_13TeV-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v1/NANOAODSIM",  # noqa
     ],
-    n_files=5,
-    n_events=7934000,
+    n_files=103,
+    n_events=7_934_000,
 )
 
 cpn.add_dataset(
@@ -205,43 +205,44 @@ cpn.add_dataset(
     id=14214813,
     processes=[procs.zz],
     keys=[
-        "/ZZ_TuneCP5_13TeV-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM",  # noqa
+        "/ZZ_TuneCP5_13TeV-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v1/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=1282000,
+    n_files=24,
+    n_events=1_282_000,
 )
 
 cpn.add_dataset(
     name="www_amcatnlo",
-    id=14213401,
-    processes=[procs.www],
-    keys=[
-        "/WWW_4F_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=71000,
-)
-
-cpn.add_dataset(
-    name="www_ext_amcatnlo",
     id=14215136,
     processes=[procs.www],
     keys=[
-        "/WWW_4F_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_ext1-v1/NANOAODSIM",  # noqa
+        "/WWW_4F_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_ext1_NanoAODAPVv12UHH-v1/NANOAODSIM",  # noqa
     ],
-    n_files=5,
-    n_events=5190000,
+    n_files=88,
+    n_events=5_190_000,
 )
+
+# cpn.add_dataset(
+#     name="www_ext_amcatnlo",
+#     id=14215136,
+#     processes=[procs.www],
+#     keys=[
+#         "/WWW_4F_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_ext1_NanoAODAPVv12UHH-v1/NANOAODSIM",  # noqa
+#     ],
+#     n_files=5,
+#     n_events=5190000,
+# )
+
 
 cpn.add_dataset(
     name="wzz_amcatnlo",
     id=14214901,
     processes=[procs.wzz],
     keys=[
-        "/WZZ_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_ext1-v1/NANOAODSIM",  # noqa
+        "/WZZ_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_ext1_NanoAODAPVv12UHH-v1/NANOAODSIM",  # noqa
     ],
-    n_files=5,
-    n_events=5394000,
+    n_files=85,
+    n_events=5_394_000,
 )
 
 cpn.add_dataset(
@@ -249,10 +250,10 @@ cpn.add_dataset(
     id=14214960,
     processes=[procs.wwz],
     keys=[
-        "/WWZ_4F_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_ext1-v1/NANOAODSIM",  # noqa
+        "/WWZ_4F_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_ext1_NanoAODAPVv12UHH-v1/NANOAODSIM",  # noqa
     ],
-    n_files=5,
-    n_events=5072000,
+    n_files=83,
+    n_events=5_072_000,
 )
 
 # W
@@ -262,10 +263,10 @@ cpn.add_dataset(
     id=14270880,
     processes=[procs.w_lnu],
     keys=[
-        "/WJetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/WJetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=32,
-    n_events=74676454,
+    n_files=859,
+    n_events=74_676_454,
 )
 
 cpn.add_dataset(
@@ -273,10 +274,10 @@ cpn.add_dataset(
     id=14266888,
     processes=[procs.w_lnu_ht2500],
     keys=[
-        "/WJetsToLNu_HT-2500ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/WJetsToLNu_HT-2500ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=2,
-    n_events=808649,
+    n_files=31,
+    n_events=808_649,
 )
 
 cpn.add_dataset(
@@ -284,10 +285,10 @@ cpn.add_dataset(
     id=14300594,
     processes=[procs.w_lnu_ht70To100],
     keys=[
-        "/WJetsToLNu_HT-70To100_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM",  # noqa
+        "/WJetsToLNu_HT-70To100_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v1/NANOAODSIM",  # noqa
     ],
-    n_files=10,
-    n_events=16931765,
+    n_files=225,
+    n_events=16_931_765,
 )
 
 cpn.add_dataset(
@@ -295,10 +296,10 @@ cpn.add_dataset(
     id=14221276,
     processes=[procs.w_lnu_ht100To200],
     keys=[
-        "/WJetsToLNu_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM",  # noqa
+        "/WJetsToLNu_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v1/NANOAODSIM",  # noqa
     ],
-    n_files=14,
-    n_events=21734530,
+    n_files=328,
+    n_events=21_734_530,
 )
 
 cpn.add_dataset(
@@ -306,10 +307,10 @@ cpn.add_dataset(
     id=14226935,
     processes=[procs.w_lnu_ht1200To2500],
     keys=[
-        "/WJetsToLNu_HT-1200To2500_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM",  # noqa
+        "/WJetsToLNu_HT-1200To2500_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v1/NANOAODSIM",  # noqa
     ],
-    n_files=3,
-    n_events=2119975,
+    n_files=71,
+    n_events=2_119_975,
 )
 
 cpn.add_dataset(
@@ -317,10 +318,10 @@ cpn.add_dataset(
     id=14213493,
     processes=[procs.w_lnu_ht400To600],
     keys=[
-        "/WJetsToLNu_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM",  # noqa
+        "/WJetsToLNu_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v1/NANOAODSIM",  # noqa
     ],
-    n_files=3,
-    n_events=2467498,
+    n_files=63,
+    n_events=2_467_498,
 )
 
 cpn.add_dataset(
@@ -328,10 +329,10 @@ cpn.add_dataset(
     id=14227116,
     processes=[procs.w_lnu_ht600To800],
     keys=[
-        "/WJetsToLNu_HT-600To800_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM",  # noqa
+        "/WJetsToLNu_HT-600To800_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v1/NANOAODSIM",  # noqa
     ],
-    n_files=3,
-    n_events=2344130,
+    n_files=56,
+    n_events=2_344_130,
 )
 
 cpn.add_dataset(
@@ -339,10 +340,10 @@ cpn.add_dataset(
     id=14212489,
     processes=[procs.w_lnu_ht800To1200],
     keys=[
-        "/WJetsToLNu_HT-800To1200_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM",  # noqa
+        "/WJetsToLNu_HT-800To1200_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v1/NANOAODSIM",  # noqa
     ],
-    n_files=3,
-    n_events=2510487,
+    n_files=96,
+    n_events=2_510_487,
 )
 
 cpn.add_dataset(
@@ -350,131 +351,131 @@ cpn.add_dataset(
     id=14212310,
     processes=[procs.w_lnu_ht200To400],
     keys=[
-        "/WJetsToLNu_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM",  # noqa
+        "/WJetsToLNu_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v1/NANOAODSIM",  # noqa
     ],
-    n_files=14,
-    n_events=17870845,
+    n_files=283,
+    n_events=17_870_845,
 )
 
 # Z
 
-cpn.add_dataset(
-    name="z_nunu_ht600to800_madgraph",
-    id=14238483,
-    processes=[procs.z_nunu_ht600to800],
-    keys=[
-        "/ZJetsToNuNu_HT-600To800_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=2,
-    n_events=2030858,
-)
+# cpn.add_dataset(
+#     name="z_nunu_ht600to800_madgraph",
+#     id=14238483,
+#     processes=[procs.z_nunu_ht600to800],
+#     keys=[
+#         "/ZJetsToNuNu_HT-600To800_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=2,
+#     n_events=2030858,
+# )
 
-cpn.add_dataset(
-    name="z_nunu_ht400to600_madgraph",
-    id=14238470,
-    processes=[procs.z_nunu_ht400to600],
-    keys=[
-        "/ZJetsToNuNu_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=6,
-    n_events=6632524,
-)
+# cpn.add_dataset(
+#     name="z_nunu_ht400to600_madgraph",
+#     id=14238470,
+#     processes=[procs.z_nunu_ht400to600],
+#     keys=[
+#         "/ZJetsToNuNu_HT-400To600_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=6,
+#     n_events=6632524,
+# )
 
-cpn.add_dataset(
-    name="z_nunu_ht200to400_madgraph",
-    id=14216548,
-    processes=[procs.z_nunu_ht200to400],
-    keys=[
-        "/ZJetsToNuNu_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM",  # noqa
-    ],
-    n_files=5,
-    n_events=7531529,
-)
+# cpn.add_dataset(
+#     name="z_nunu_ht200to400_madgraph",
+#     id=14216548,
+#     processes=[procs.z_nunu_ht200to400],
+#     keys=[
+#         "/ZJetsToNuNu_HT-200To400_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM",  # noqa
+#     ],
+#     n_files=5,
+#     n_events=7531529,
+# )
 
-cpn.add_dataset(
-    name="z_nunu_ht800to1200_madgraph",
-    id=14285553,
-    processes=[procs.z_nunu_ht800to1200],
-    keys=[
-        "/ZJetsToNuNu_HT-800To1200_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=703970,
-)
+# cpn.add_dataset(
+#     name="z_nunu_ht800to1200_madgraph",
+#     id=14285553,
+#     processes=[procs.z_nunu_ht800to1200],
+#     keys=[
+#         "/ZJetsToNuNu_HT-800To1200_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=703970,
+# )
 
-cpn.add_dataset(
-    name="z_nunu_ht1200to2500_madgraph",
-    id=14240780,
-    processes=[procs.z_nunu_ht1200to2500],
-    keys=[
-        "/ZJetsToNuNu_HT-1200To2500_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=136393,
-)
+# cpn.add_dataset(
+#     name="z_nunu_ht1200to2500_madgraph",
+#     id=14240780,
+#     processes=[procs.z_nunu_ht1200to2500],
+#     keys=[
+#         "/ZJetsToNuNu_HT-1200To2500_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=136393,
+# )
 
-cpn.add_dataset(
-    name="z_nunu_ht2500_madgraph",
-    id=14242842,
-    processes=[procs.z_nunu_ht2500],
-    keys=[
-        "/ZJetsToNuNu_HT-2500ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=111838,
-)
+# cpn.add_dataset(
+#     name="z_nunu_ht2500_madgraph",
+#     id=14242842,
+#     processes=[procs.z_nunu_ht2500],
+#     keys=[
+#         "/ZJetsToNuNu_HT-2500ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=111838,
+# )
 
-cpn.add_dataset(
-    name="z_nunu_ht100to200_madgraph",
-    id=14212946,
-    processes=[procs.z_nunu_ht100to200],
-    keys=[
-        "/ZJetsToNuNu_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM",  # noqa
-    ],
-    n_files=5,
-    n_events=7784090,
-)
+# cpn.add_dataset(
+#     name="z_nunu_ht100to200_madgraph",
+#     id=14212946,
+#     processes=[procs.z_nunu_ht100to200],
+#     keys=[
+#         "/ZJetsToNuNu_HT-100To200_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM",  # noqa
+#     ],
+#     n_files=5,
+#     n_events=7784090,
+# )
 
-cpn.add_dataset(
-    name="z_qq_ht200to400_madgraph",
-    id=14303395,
-    processes=[procs.z_qq_ht200to400],
-    keys=[
-        "/ZJetsToQQ_HT-200to400_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=6,
-    n_events=8753905,
-)
+# cpn.add_dataset(
+#     name="z_qq_ht200to400_madgraph",
+#     id=14303395,
+#     processes=[procs.z_qq_ht200to400],
+#     keys=[
+#         "/ZJetsToQQ_HT-200to400_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=6,
+#     n_events=8753905,
+# )
 
-cpn.add_dataset(
-    name="z_qq_ht400to600_madgraph",
-    id=14284977,
-    processes=[procs.z_qq_ht400to600],
-    keys=[
-        "/ZJetsToQQ_HT-400to600_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=7,
-    n_events=7709128,
-)
+# cpn.add_dataset(
+#     name="z_qq_ht400to600_madgraph",
+#     id=14284977,
+#     processes=[procs.z_qq_ht400to600],
+#     keys=[
+#         "/ZJetsToQQ_HT-400to600_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=7,
+#     n_events=7709128,
+# )
 
-cpn.add_dataset(
-    name="z_qq_ht600to800_madgraph",
-    id=14275517,
-    processes=[procs.z_qq_ht600to800],
-    keys=[
-        "/ZJetsToQQ_HT-600to800_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=7,
-    n_events=6116617,
-)
+# cpn.add_dataset(
+#     name="z_qq_ht600to800_madgraph",
+#     id=14275517,
+#     processes=[procs.z_qq_ht600to800],
+#     keys=[
+#         "/ZJetsToQQ_HT-600to800_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=7,
+#     n_events=6116617,
+# )
 
-cpn.add_dataset(
-    name="z_qq_ht800_madgraph",
-    id=14305027,
-    processes=[procs.z_qq_ht800],
-    keys=[
-        "/ZJetsToQQ_HT-800toInf_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=5,
-    n_events=3726992,
-)
+# cpn.add_dataset(
+#     name="z_qq_ht800_madgraph",
+#     id=14305027,
+#     processes=[procs.z_qq_ht800],
+#     keys=[
+#         "/ZJetsToQQ_HT-800toInf_TuneCP5_13TeV-madgraphMLM-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=5,
+#     n_events=3726992,
+# )

--- a/cmsdb/campaigns/run2_2016_HIPM_nano_uhh_v12/hh2bbtautau.py
+++ b/cmsdb/campaigns/run2_2016_HIPM_nano_uhh_v12/hh2bbtautau.py
@@ -15,147 +15,147 @@ from cmsdb.campaigns.run2_2016_HIPM_nano_uhh_v12 import campaign_run2_2016_HIPM_
 # ggF -> H -> HH
 
 cpn.add_dataset(
-    name="hh_ggf_bbtautau_node10_madgraph",
-    id=14355626,
-    processes=[procs.hh_ggf_bbtautau_node10],
-    keys=[
-        "/GluGluToHHTo2B2Tau_TuneCP5_PSWeights_node_10_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=216000,
-)
-
-cpn.add_dataset(
-    name="hh_ggf_bbtautau_node6_madgraph",
-    id=14347302,
-    processes=[procs.hh_ggf_bbtautau_node6],
-    keys=[
-        "/GluGluToHHTo2B2Tau_TuneCP5_PSWeights_node_6_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=216000,
-)
-
-cpn.add_dataset(
-    name="hh_ggf_bbtautau_node9_madgraph",
-    id=14359169,
-    processes=[procs.hh_ggf_bbtautau_node9],
-    keys=[
-        "/GluGluToHHTo2B2Tau_TuneCP5_PSWeights_node_9_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=216000,
-)
-
-cpn.add_dataset(
-    name="hh_ggf_bbtautau_node11_madgraph",
-    id=14351156,
-    processes=[procs.hh_ggf_bbtautau_node11],
-    keys=[
-        "/GluGluToHHTo2B2Tau_TuneCP5_PSWeights_node_11_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=216000,
-)
-
-cpn.add_dataset(
-    name="hh_ggf_bbtautau_node2_madgraph",
-    id=14342671,
-    processes=[procs.hh_ggf_bbtautau_node2],
-    keys=[
-        "/GluGluToHHTo2B2Tau_TuneCP5_PSWeights_node_2_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=210000,
-)
-
-cpn.add_dataset(
-    name="hh_ggf_bbtautau_node8_madgraph",
-    id=14343392,
-    processes=[procs.hh_ggf_bbtautau_node8],
-    keys=[
-        "/GluGluToHHTo2B2Tau_TuneCP5_PSWeights_node_8_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=216000,
-)
-
-cpn.add_dataset(
-    name="hh_ggf_bbtautau_node4_madgraph",
-    id=14363921,
-    processes=[procs.hh_ggf_bbtautau_node4],
-    keys=[
-        "/GluGluToHHTo2B2Tau_TuneCP5_PSWeights_node_4_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=216000,
-)
-
-cpn.add_dataset(
-    name="hh_ggf_bbtautau_node5_madgraph",
-    id=14359164,
-    processes=[procs.hh_ggf_bbtautau_node5],
-    keys=[
-        "/GluGluToHHTo2B2Tau_TuneCP5_PSWeights_node_5_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=216000,
-)
-
-cpn.add_dataset(
     name="hh_ggf_bbtautau_madgraph",
     id=14335916,
     processes=[procs.hh_ggf_bbtautau],
     keys=[
-        "/GluGluToHHTo2B2Tau_TuneCP5_PSWeights_node_SM_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/GluGluToHHTo2B2Tau_TuneCP5_PSWeights_node_SM_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=216000,
+    n_files=7,
+    n_events=216_000,
 )
 
-cpn.add_dataset(
-    name="hh_ggf_bbtautau_node7_madgraph",
-    id=14358610,
-    processes=[procs.hh_ggf_bbtautau_node7],
-    keys=[
-        "/GluGluToHHTo2B2Tau_TuneCP5_PSWeights_node_7_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=216000,
-)
+# cpn.add_dataset(
+#     name="hh_ggf_bbtautau_node10_madgraph",
+#     id=14355626,
+#     processes=[procs.hh_ggf_bbtautau_node10],
+#     keys=[
+#         "/GluGluToHHTo2B2Tau_TuneCP5_PSWeights_node_10_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=216000,
+# )
 
-cpn.add_dataset(
-    name="hh_ggf_bbtautau_node1_madgraph",
-    id=14349843,
-    processes=[procs.hh_ggf_bbtautau_node1],
-    keys=[
-        "/GluGluToHHTo2B2Tau_TuneCP5_PSWeights_node_1_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=216000,
-)
+# cpn.add_dataset(
+#     name="hh_ggf_bbtautau_node6_madgraph",
+#     id=14347302,
+#     processes=[procs.hh_ggf_bbtautau_node6],
+#     keys=[
+#         "/GluGluToHHTo2B2Tau_TuneCP5_PSWeights_node_6_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=216000,
+# )
 
-cpn.add_dataset(
-    name="hh_ggf_bbtautau_node12_madgraph",
-    id=14332443,
-    processes=[procs.hh_ggf_bbtautau_node12],
-    keys=[
-        "/GluGluToHHTo2B2Tau_TuneCP5_PSWeights_node_12_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=216000,
-)
+# cpn.add_dataset(
+#     name="hh_ggf_bbtautau_node9_madgraph",
+#     id=14359169,
+#     processes=[procs.hh_ggf_bbtautau_node9],
+#     keys=[
+#         "/GluGluToHHTo2B2Tau_TuneCP5_PSWeights_node_9_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=216000,
+# )
 
-cpn.add_dataset(
-    name="hh_ggf_bbtautau_node3_madgraph",
-    id=14351327,
-    processes=[procs.hh_ggf_bbtautau_node3],
-    keys=[
-        "/GluGluToHHTo2B2Tau_TuneCP5_PSWeights_node_3_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=216000,
-)
+# cpn.add_dataset(
+#     name="hh_ggf_bbtautau_node11_madgraph",
+#     id=14351156,
+#     processes=[procs.hh_ggf_bbtautau_node11],
+#     keys=[
+#         "/GluGluToHHTo2B2Tau_TuneCP5_PSWeights_node_11_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=216000,
+# )
+
+# cpn.add_dataset(
+#     name="hh_ggf_bbtautau_node2_madgraph",
+#     id=14342671,
+#     processes=[procs.hh_ggf_bbtautau_node2],
+#     keys=[
+#         "/GluGluToHHTo2B2Tau_TuneCP5_PSWeights_node_2_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=210000,
+# )
+
+# cpn.add_dataset(
+#     name="hh_ggf_bbtautau_node8_madgraph",
+#     id=14343392,
+#     processes=[procs.hh_ggf_bbtautau_node8],
+#     keys=[
+#         "/GluGluToHHTo2B2Tau_TuneCP5_PSWeights_node_8_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=216000,
+# )
+
+# cpn.add_dataset(
+#     name="hh_ggf_bbtautau_node4_madgraph",
+#     id=14363921,
+#     processes=[procs.hh_ggf_bbtautau_node4],
+#     keys=[
+#         "/GluGluToHHTo2B2Tau_TuneCP5_PSWeights_node_4_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=216000,
+# )
+
+# cpn.add_dataset(
+#     name="hh_ggf_bbtautau_node5_madgraph",
+#     id=14359164,
+#     processes=[procs.hh_ggf_bbtautau_node5],
+#     keys=[
+#         "/GluGluToHHTo2B2Tau_TuneCP5_PSWeights_node_5_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=216000,
+# )
+
+# cpn.add_dataset(
+#     name="hh_ggf_bbtautau_node7_madgraph",
+#     id=14358610,
+#     processes=[procs.hh_ggf_bbtautau_node7],
+#     keys=[
+#         "/GluGluToHHTo2B2Tau_TuneCP5_PSWeights_node_7_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=216000,
+# )
+
+# cpn.add_dataset(
+#     name="hh_ggf_bbtautau_node1_madgraph",
+#     id=14349843,
+#     processes=[procs.hh_ggf_bbtautau_node1],
+#     keys=[
+#         "/GluGluToHHTo2B2Tau_TuneCP5_PSWeights_node_1_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=216000,
+# )
+
+# cpn.add_dataset(
+#     name="hh_ggf_bbtautau_node12_madgraph",
+#     id=14332443,
+#     processes=[procs.hh_ggf_bbtautau_node12],
+#     keys=[
+#         "/GluGluToHHTo2B2Tau_TuneCP5_PSWeights_node_12_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=216000,
+# )
+
+# cpn.add_dataset(
+#     name="hh_ggf_bbtautau_node3_madgraph",
+#     id=14351327,
+#     processes=[procs.hh_ggf_bbtautau_node3],
+#     keys=[
+#         "/GluGluToHHTo2B2Tau_TuneCP5_PSWeights_node_3_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=216000,
+# )
 
 ################
 # BSM scenarios
@@ -168,10 +168,10 @@ cpn.add_dataset(
     id=14346431,
     processes=[procs.radion_hh_ggf_bbtautau_m700],
     keys=[
-        "/GluGluToRadionToHHTo2B2Tau_M-700_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/GluGluToRadionToHHTo2B2Tau_M-700_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=108000,
+    n_files=6,
+    n_events=108_000,
 )
 
 cpn.add_dataset(
@@ -179,10 +179,10 @@ cpn.add_dataset(
     id=14346648,
     processes=[procs.radion_hh_ggf_bbtautau_m450],
     keys=[
-        "/GluGluToRadionToHHTo2B2Tau_M-450_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/GluGluToRadionToHHTo2B2Tau_M-450_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=162000,
+    n_files=14,
+    n_events=162_000,
 )
 
 cpn.add_dataset(
@@ -190,10 +190,10 @@ cpn.add_dataset(
     id=14346436,
     processes=[procs.radion_hh_ggf_bbtautau_m300],
     keys=[
-        "/GluGluToRadionToHHTo2B2Tau_M-300_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/GluGluToRadionToHHTo2B2Tau_M-300_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=162000,
+    n_files=6,
+    n_events=162_000,
 )
 
 cpn.add_dataset(
@@ -201,10 +201,10 @@ cpn.add_dataset(
     id=14346867,
     processes=[procs.radion_hh_ggf_bbtautau_m350],
     keys=[
-        "/GluGluToRadionToHHTo2B2Tau_M-350_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/GluGluToRadionToHHTo2B2Tau_M-350_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=162000,
+    n_files=12,
+    n_events=162_000,
 )
 
 cpn.add_dataset(
@@ -212,10 +212,10 @@ cpn.add_dataset(
     id=14346824,
     processes=[procs.radion_hh_ggf_bbtautau_m750],
     keys=[
-        "/GluGluToRadionToHHTo2B2Tau_M-750_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/GluGluToRadionToHHTo2B2Tau_M-750_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=108000,
+    n_files=3,
+    n_events=108_000,
 )
 
 cpn.add_dataset(
@@ -223,10 +223,10 @@ cpn.add_dataset(
     id=14346661,
     processes=[procs.radion_hh_ggf_bbtautau_m800],
     keys=[
-        "/GluGluToRadionToHHTo2B2Tau_M-800_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/GluGluToRadionToHHTo2B2Tau_M-800_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=108000,
+    n_files=8,
+    n_events=108_000,
 )
 
 cpn.add_dataset(
@@ -234,10 +234,10 @@ cpn.add_dataset(
     id=14346643,
     processes=[procs.radion_hh_ggf_bbtautau_m3000],
     keys=[
-        "/GluGluToRadionToHHTo2B2Tau_M-3000_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/GluGluToRadionToHHTo2B2Tau_M-3000_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=54000,
+    n_files=7,
+    n_events=54_000,
 )
 
 cpn.add_dataset(
@@ -245,10 +245,10 @@ cpn.add_dataset(
     id=14347450,
     processes=[procs.radion_hh_ggf_bbtautau_m650],
     keys=[
-        "/GluGluToRadionToHHTo2B2Tau_M-650_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/GluGluToRadionToHHTo2B2Tau_M-650_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=108000,
+    n_files=9,
+    n_events=108_000,
 )
 
 cpn.add_dataset(
@@ -256,10 +256,10 @@ cpn.add_dataset(
     id=14346396,
     processes=[procs.radion_hh_ggf_bbtautau_m600],
     keys=[
-        "/GluGluToRadionToHHTo2B2Tau_M-600_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/GluGluToRadionToHHTo2B2Tau_M-600_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=108000,
+    n_files=2,
+    n_events=108_000,
 )
 
 cpn.add_dataset(
@@ -267,10 +267,10 @@ cpn.add_dataset(
     id=14346575,
     processes=[procs.radion_hh_ggf_bbtautau_m400],
     keys=[
-        "/GluGluToRadionToHHTo2B2Tau_M-400_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/GluGluToRadionToHHTo2B2Tau_M-400_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=162000,
+    n_files=5,
+    n_events=162_000,
 )
 
 cpn.add_dataset(
@@ -278,10 +278,10 @@ cpn.add_dataset(
     id=14357712,
     processes=[procs.radion_hh_ggf_bbtautau_m280],
     keys=[
-        "/GluGluToRadionToHHTo2B2Tau_M-280_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/GluGluToRadionToHHTo2B2Tau_M-280_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=214000,
+    n_files=14,
+    n_events=214_000,
 )
 
 cpn.add_dataset(
@@ -289,10 +289,10 @@ cpn.add_dataset(
     id=14346515,
     processes=[procs.radion_hh_ggf_bbtautau_m850],
     keys=[
-        "/GluGluToRadionToHHTo2B2Tau_M-850_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/GluGluToRadionToHHTo2B2Tau_M-850_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=108000,
+    n_files=10,
+    n_events=108_000,
 )
 
 cpn.add_dataset(
@@ -300,10 +300,10 @@ cpn.add_dataset(
     id=14346497,
     processes=[procs.radion_hh_ggf_bbtautau_m900],
     keys=[
-        "/GluGluToRadionToHHTo2B2Tau_M-900_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/GluGluToRadionToHHTo2B2Tau_M-900_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=96000,
+    n_files=7,
+    n_events=96_000,
 )
 
 cpn.add_dataset(
@@ -311,10 +311,10 @@ cpn.add_dataset(
     id=14346666,
     processes=[procs.radion_hh_ggf_bbtautau_m500],
     keys=[
-        "/GluGluToRadionToHHTo2B2Tau_M-500_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/GluGluToRadionToHHTo2B2Tau_M-500_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=162000,
+    n_files=16,
+    n_events=162_000,
 )
 
 cpn.add_dataset(
@@ -322,10 +322,10 @@ cpn.add_dataset(
     id=14346716,
     processes=[procs.radion_hh_ggf_bbtautau_m320],
     keys=[
-        "/GluGluToRadionToHHTo2B2Tau_M-320_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/GluGluToRadionToHHTo2B2Tau_M-320_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=162000,
+    n_files=16,
+    n_events=162_000,
 )
 
 cpn.add_dataset(
@@ -333,10 +333,10 @@ cpn.add_dataset(
     id=14346591,
     processes=[procs.radion_hh_ggf_bbtautau_m550],
     keys=[
-        "/GluGluToRadionToHHTo2B2Tau_M-550_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/GluGluToRadionToHHTo2B2Tau_M-550_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=108000,
+    n_files=19,
+    n_events=108_000,
 )
 
 cpn.add_dataset(
@@ -344,10 +344,10 @@ cpn.add_dataset(
     id=14346791,
     processes=[procs.radion_hh_ggf_bbtautau_m270],
     keys=[
-        "/GluGluToRadionToHHTo2B2Tau_M-270_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/GluGluToRadionToHHTo2B2Tau_M-270_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=214000,
+    n_files=15,
+    n_events=214_000,
 )
 
 cpn.add_dataset(
@@ -355,10 +355,10 @@ cpn.add_dataset(
     id=14346788,
     processes=[procs.radion_hh_ggf_bbtautau_m260],
     keys=[
-        "/GluGluToRadionToHHTo2B2Tau_M-260_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/GluGluToRadionToHHTo2B2Tau_M-260_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=216000,
+    n_files=19,
+    n_events=216_000,
 )
 
 cpn.add_dataset(
@@ -366,10 +366,10 @@ cpn.add_dataset(
     id=14346427,
     processes=[procs.radion_hh_ggf_bbtautau_m2500],
     keys=[
-        "/GluGluToRadionToHHTo2B2Tau_M-2500_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/GluGluToRadionToHHTo2B2Tau_M-2500_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=54000,
+    n_files=7,
+    n_events=54_000,
 )
 
 cpn.add_dataset(
@@ -377,10 +377,10 @@ cpn.add_dataset(
     id=14346555,
     processes=[procs.radion_hh_ggf_bbtautau_m250],
     keys=[
-        "/GluGluToRadionToHHTo2B2Tau_M-250_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/GluGluToRadionToHHTo2B2Tau_M-250_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=216000,
+    n_files=12,
+    n_events=216_000,
 )
 
 cpn.add_dataset(
@@ -388,10 +388,10 @@ cpn.add_dataset(
     id=14346581,
     processes=[procs.radion_hh_ggf_bbtautau_m2000],
     keys=[
-        "/GluGluToRadionToHHTo2B2Tau_M-2000_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/GluGluToRadionToHHTo2B2Tau_M-2000_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=54000,
+    n_files=10,
+    n_events=54_000,
 )
 
 cpn.add_dataset(
@@ -399,10 +399,10 @@ cpn.add_dataset(
     id=14346610,
     processes=[procs.radion_hh_ggf_bbtautau_m1750],
     keys=[
-        "/GluGluToRadionToHHTo2B2Tau_M-1750_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/GluGluToRadionToHHTo2B2Tau_M-1750_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=54000,
+    n_files=7,
+    n_events=54_000,
 )
 
 cpn.add_dataset(
@@ -410,10 +410,10 @@ cpn.add_dataset(
     id=14346361,
     processes=[procs.radion_hh_ggf_bbtautau_m1500],
     keys=[
-        "/GluGluToRadionToHHTo2B2Tau_M-1500_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/GluGluToRadionToHHTo2B2Tau_M-1500_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=54000,
+    n_files=4,
+    n_events=54_000,
 )
 
 cpn.add_dataset(
@@ -421,10 +421,10 @@ cpn.add_dataset(
     id=14646635,
     processes=[procs.radion_hh_ggf_bbtautau_m1250],
     keys=[
-        "/GluGluToRadionToHHTo2B2Tau_M-1250_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v3/NANOAODSIM",  # noqa
+        "/GluGluToRadionToHHTo2B2Tau_M-1250_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v3/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=54000,
+    n_files=4,
+    n_events=54_000,
 )
 
 cpn.add_dataset(
@@ -432,10 +432,142 @@ cpn.add_dataset(
     id=14346516,
     processes=[procs.radion_hh_ggf_bbtautau_m1000],
     keys=[
-        "/GluGluToRadionToHHTo2B2Tau_M-1000_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/GluGluToRadionToHHTo2B2Tau_M-1000_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=54000,
+    n_files=3,
+    n_events=54_000,
+)
+
+cpn.add_dataset(
+    name="radion_hh_ggf_bbtautau_m1100_madgraph",
+    id=14411934,
+    processes=[procs.radion_hh_ggf_bbtautau_m1100],
+    keys=[
+        "/GluGluToRadionToHHTo2B2Tau_M-1100_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=8,
+    n_events=216_000,
+)
+
+cpn.add_dataset(
+    name="radion_hh_ggf_bbtautau_m1200_madgraph",
+    id=14419410,
+    processes=[procs.radion_hh_ggf_bbtautau_m1200],
+    keys=[
+        "/GluGluToRadionToHHTo2B2Tau_M-1200_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=8,
+    n_events=216_000,
+)
+
+cpn.add_dataset(
+    name="radion_hh_ggf_bbtautau_m1300_madgraph",
+    id=14412110,
+    processes=[procs.radion_hh_ggf_bbtautau_m1300],
+    keys=[
+        "/GluGluToRadionToHHTo2B2Tau_M-1300_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=6,
+    n_events=216_000,
+)
+
+cpn.add_dataset(
+    name="radion_hh_ggf_bbtautau_m1400_madgraph",
+    id=14397712,
+    processes=[procs.radion_hh_ggf_bbtautau_m1400],
+    keys=[
+        "/GluGluToRadionToHHTo2B2Tau_M-1400_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v3/NANOAODSIM",  # noqa
+    ],
+    n_files=25,
+    n_events=216_000,
+)
+
+cpn.add_dataset(
+    name="radion_hh_ggf_bbtautau_m1600_madgraph",
+    id=14413443,
+    processes=[procs.radion_hh_ggf_bbtautau_m1600],
+    keys=[
+        "/GluGluToRadionToHHTo2B2Tau_M-1600_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=5,
+    n_events=213_000,
+)
+
+cpn.add_dataset(
+    name="radion_hh_ggf_bbtautau_m1700_madgraph",
+    id=14419235,
+    processes=[procs.radion_hh_ggf_bbtautau_m1700],
+    keys=[
+        "/GluGluToRadionToHHTo2B2Tau_M-1700_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=5,
+    n_events=216_000,
+)
+
+cpn.add_dataset(
+    name="radion_hh_ggf_bbtautau_m1800_madgraph",
+    id=14391871,
+    processes=[procs.radion_hh_ggf_bbtautau_m1800],
+    keys=[
+        "/GluGluToRadionToHHTo2B2Tau_M-1800_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v3/NANOAODSIM",  # noqa
+    ],
+    n_files=17,
+    n_events=216_000,
+)
+
+cpn.add_dataset(
+    name="radion_hh_ggf_bbtautau_m1900_madgraph",
+    id=14395552,
+    processes=[procs.radion_hh_ggf_bbtautau_m1900],
+    keys=[
+        "/GluGluToRadionToHHTo2B2Tau_M-1900_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v3/NANOAODSIM",  # noqa
+    ],
+    n_files=28,
+    n_events=216_000,
+)
+
+cpn.add_dataset(
+    name="radion_hh_ggf_bbtautau_m2200_madgraph",
+    id=14414886,
+    processes=[procs.radion_hh_ggf_bbtautau_m2200],
+    keys=[
+        "/GluGluToRadionToHHTo2B2Tau_M-2200_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v3/NANOAODSIM",  # noqa
+    ],
+    n_files=21,
+    n_events=214_000,
+)
+
+cpn.add_dataset(
+    name="radion_hh_ggf_bbtautau_m2400_madgraph",
+    id=14397821,
+    processes=[procs.radion_hh_ggf_bbtautau_m2400],
+    keys=[
+        "/GluGluToRadionToHHTo2B2Tau_M-2400_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v4/NANOAODSIM",  # noqa
+    ],
+    n_files=27,
+    n_events=216_000,
+)
+
+cpn.add_dataset(
+    name="radion_hh_ggf_bbtautau_m2600_madgraph",
+    id=14397727,
+    processes=[procs.radion_hh_ggf_bbtautau_m2600],
+    keys=[
+        "/GluGluToRadionToHHTo2B2Tau_M-2600_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v3/NANOAODSIM",  # noqa
+    ],
+    n_files=18,
+    n_events=213_000,
+)
+
+cpn.add_dataset(
+    name="radion_hh_ggf_bbtautau_m2800_madgraph",
+    id=14396084,
+    processes=[procs.radion_hh_ggf_bbtautau_m2800],
+    keys=[
+        "/GluGluToRadionToHHTo2B2Tau_M-2800_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v4/NANOAODSIM",  # noqa
+    ],
+    n_files=29,
+    n_events=216_000,
 )
 
 
@@ -446,10 +578,10 @@ cpn.add_dataset(
     id=14346388,
     processes=[procs.graviton_hh_ggf_bbtautau_m900],
     keys=[
-        "/GluGluToBulkGravitonToHHTo2B2Tau_M-900_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/GluGluToBulkGravitonToHHTo2B2Tau_M-900_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=106000,
+    n_files=4,
+    n_events=106_000,
 )
 
 cpn.add_dataset(
@@ -457,10 +589,10 @@ cpn.add_dataset(
     id=14346601,
     processes=[procs.graviton_hh_ggf_bbtautau_m850],
     keys=[
-        "/GluGluToBulkGravitonToHHTo2B2Tau_M-850_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/GluGluToBulkGravitonToHHTo2B2Tau_M-850_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=108000,
+    n_files=12,
+    n_events=108_000,
 )
 
 cpn.add_dataset(
@@ -468,10 +600,10 @@ cpn.add_dataset(
     id=14346568,
     processes=[procs.graviton_hh_ggf_bbtautau_m800],
     keys=[
-        "/GluGluToBulkGravitonToHHTo2B2Tau_M-800_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/GluGluToBulkGravitonToHHTo2B2Tau_M-800_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=108000,
+    n_files=9,
+    n_events=108_000,
 )
 
 cpn.add_dataset(
@@ -479,10 +611,10 @@ cpn.add_dataset(
     id=14346412,
     processes=[procs.graviton_hh_ggf_bbtautau_m750],
     keys=[
-        "/GluGluToBulkGravitonToHHTo2B2Tau_M-750_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/GluGluToBulkGravitonToHHTo2B2Tau_M-750_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=108000,
+    n_files=10,
+    n_events=108_000,
 )
 
 cpn.add_dataset(
@@ -490,10 +622,10 @@ cpn.add_dataset(
     id=14346469,
     processes=[procs.graviton_hh_ggf_bbtautau_m700],
     keys=[
-        "/GluGluToBulkGravitonToHHTo2B2Tau_M-700_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/GluGluToBulkGravitonToHHTo2B2Tau_M-700_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=108000,
+    n_files=4,
+    n_events=108_000,
 )
 
 cpn.add_dataset(
@@ -501,10 +633,10 @@ cpn.add_dataset(
     id=14346723,
     processes=[procs.graviton_hh_ggf_bbtautau_m650],
     keys=[
-        "/GluGluToBulkGravitonToHHTo2B2Tau_M-650_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/GluGluToBulkGravitonToHHTo2B2Tau_M-650_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=108000,
+    n_files=13,
+    n_events=108_000,
 )
 
 cpn.add_dataset(
@@ -512,10 +644,10 @@ cpn.add_dataset(
     id=14346637,
     processes=[procs.graviton_hh_ggf_bbtautau_m600],
     keys=[
-        "/GluGluToBulkGravitonToHHTo2B2Tau_M-600_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/GluGluToBulkGravitonToHHTo2B2Tau_M-600_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=108000,
+    n_files=14,
+    n_events=108_000,
 )
 
 cpn.add_dataset(
@@ -523,10 +655,10 @@ cpn.add_dataset(
     id=14346640,
     processes=[procs.graviton_hh_ggf_bbtautau_m550],
     keys=[
-        "/GluGluToBulkGravitonToHHTo2B2Tau_M-550_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/GluGluToBulkGravitonToHHTo2B2Tau_M-550_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=108000,
+    n_files=9,
+    n_events=108_000,
 )
 
 cpn.add_dataset(
@@ -534,10 +666,10 @@ cpn.add_dataset(
     id=14346606,
     processes=[procs.graviton_hh_ggf_bbtautau_m500],
     keys=[
-        "/GluGluToBulkGravitonToHHTo2B2Tau_M-500_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/GluGluToBulkGravitonToHHTo2B2Tau_M-500_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=162000,
+    n_files=13,
+    n_events=162_000,
 )
 
 cpn.add_dataset(
@@ -545,10 +677,10 @@ cpn.add_dataset(
     id=14346556,
     processes=[procs.graviton_hh_ggf_bbtautau_m450],
     keys=[
-        "/GluGluToBulkGravitonToHHTo2B2Tau_M-450_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/GluGluToBulkGravitonToHHTo2B2Tau_M-450_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=162000,
+    n_files=10,
+    n_events=162_000,
 )
 
 cpn.add_dataset(
@@ -556,10 +688,10 @@ cpn.add_dataset(
     id=14346409,
     processes=[procs.graviton_hh_ggf_bbtautau_m400],
     keys=[
-        "/GluGluToBulkGravitonToHHTo2B2Tau_M-400_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/GluGluToBulkGravitonToHHTo2B2Tau_M-400_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=152000,
+    n_files=4,
+    n_events=152_000,
 )
 
 cpn.add_dataset(
@@ -567,10 +699,10 @@ cpn.add_dataset(
     id=14346554,
     processes=[procs.graviton_hh_ggf_bbtautau_m350],
     keys=[
-        "/GluGluToBulkGravitonToHHTo2B2Tau_M-350_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/GluGluToBulkGravitonToHHTo2B2Tau_M-350_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=162000,
+    n_files=6,
+    n_events=162_000,
 )
 
 cpn.add_dataset(
@@ -578,10 +710,10 @@ cpn.add_dataset(
     id=14346528,
     processes=[procs.graviton_hh_ggf_bbtautau_m320],
     keys=[
-        "/GluGluToBulkGravitonToHHTo2B2Tau_M-320_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/GluGluToBulkGravitonToHHTo2B2Tau_M-320_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=162000,
+    n_files=13,
+    n_events=162_000,
 )
 
 cpn.add_dataset(
@@ -589,10 +721,10 @@ cpn.add_dataset(
     id=14346475,
     processes=[procs.graviton_hh_ggf_bbtautau_m3000],
     keys=[
-        "/GluGluToBulkGravitonToHHTo2B2Tau_M-3000_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/GluGluToBulkGravitonToHHTo2B2Tau_M-3000_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=52000,
+    n_files=11,
+    n_events=52_000,
 )
 
 cpn.add_dataset(
@@ -600,10 +732,10 @@ cpn.add_dataset(
     id=14346580,
     processes=[procs.graviton_hh_ggf_bbtautau_m300],
     keys=[
-        "/GluGluToBulkGravitonToHHTo2B2Tau_M-300_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/GluGluToBulkGravitonToHHTo2B2Tau_M-300_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=162000,
+    n_files=16,
+    n_events=162_000,
 )
 
 cpn.add_dataset(
@@ -611,10 +743,10 @@ cpn.add_dataset(
     id=14346410,
     processes=[procs.graviton_hh_ggf_bbtautau_m280],
     keys=[
-        "/GluGluToBulkGravitonToHHTo2B2Tau_M-280_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/GluGluToBulkGravitonToHHTo2B2Tau_M-280_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=216000,
+    n_files=11,
+    n_events=216_000,
 )
 
 cpn.add_dataset(
@@ -622,10 +754,10 @@ cpn.add_dataset(
     id=14346718,
     processes=[procs.graviton_hh_ggf_bbtautau_m270],
     keys=[
-        "/GluGluToBulkGravitonToHHTo2B2Tau_M-270_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/GluGluToBulkGravitonToHHTo2B2Tau_M-270_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=216000,
+    n_files=14,
+    n_events=216_000,
 )
 
 cpn.add_dataset(
@@ -633,10 +765,10 @@ cpn.add_dataset(
     id=14346710,
     processes=[procs.graviton_hh_ggf_bbtautau_m260],
     keys=[
-        "/GluGluToBulkGravitonToHHTo2B2Tau_M-260_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/GluGluToBulkGravitonToHHTo2B2Tau_M-260_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=216000,
+    n_files=18,
+    n_events=216_000,
 )
 
 cpn.add_dataset(
@@ -644,10 +776,10 @@ cpn.add_dataset(
     id=14346628,
     processes=[procs.graviton_hh_ggf_bbtautau_m250],
     keys=[
-        "/GluGluToBulkGravitonToHHTo2B2Tau_M-250_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/GluGluToBulkGravitonToHHTo2B2Tau_M-250_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=216000,
+    n_files=16,
+    n_events=216_000,
 )
 
 cpn.add_dataset(
@@ -655,10 +787,10 @@ cpn.add_dataset(
     id=14346511,
     processes=[procs.graviton_hh_ggf_bbtautau_m2500],
     keys=[
-        "/GluGluToBulkGravitonToHHTo2B2Tau_M-2500_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/GluGluToBulkGravitonToHHTo2B2Tau_M-2500_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=52000,
+    n_files=7,
+    n_events=52_000,
 )
 
 cpn.add_dataset(
@@ -666,10 +798,10 @@ cpn.add_dataset(
     id=14346848,
     processes=[procs.graviton_hh_ggf_bbtautau_m2000],
     keys=[
-        "/GluGluToBulkGravitonToHHTo2B2Tau_M-2000_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/GluGluToBulkGravitonToHHTo2B2Tau_M-2000_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=54000,
+    n_files=14,
+    n_events=54_000,
 )
 
 cpn.add_dataset(
@@ -677,10 +809,10 @@ cpn.add_dataset(
     id=14347595,
     processes=[procs.graviton_hh_ggf_bbtautau_m1750],
     keys=[
-        "/GluGluToBulkGravitonToHHTo2B2Tau_M-1750_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/GluGluToBulkGravitonToHHTo2B2Tau_M-1750_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=54000,
+    n_files=12,
+    n_events=54_000,
 )
 
 cpn.add_dataset(
@@ -688,10 +820,10 @@ cpn.add_dataset(
     id=14346362,
     processes=[procs.graviton_hh_ggf_bbtautau_m1500],
     keys=[
-        "/GluGluToBulkGravitonToHHTo2B2Tau_M-1500_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/GluGluToBulkGravitonToHHTo2B2Tau_M-1500_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=54000,
+    n_files=11,
+    n_events=54_000,
 )
 
 cpn.add_dataset(
@@ -699,10 +831,10 @@ cpn.add_dataset(
     id=14346454,
     processes=[procs.graviton_hh_ggf_bbtautau_m1250],
     keys=[
-        "/GluGluToBulkGravitonToHHTo2B2Tau_M-1250_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/GluGluToBulkGravitonToHHTo2B2Tau_M-1250_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=54000,
+    n_files=9,
+    n_events=54_000,
 )
 
 cpn.add_dataset(
@@ -710,563 +842,563 @@ cpn.add_dataset(
     id=14346419,
     processes=[procs.graviton_hh_ggf_bbtautau_m1000],
     keys=[
-        "/GluGluToBulkGravitonToHHTo2B2Tau_M-1000_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/GluGluToBulkGravitonToHHTo2B2Tau_M-1000_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=54000,
+    n_files=11,
+    n_events=54_000,
 )
 
 # VBF -> radion -> HH
 
-cpn.add_dataset(
-    name="radion_hh_vbf_bbtautau_m500_madgraph",
-    id=14311131,
-    processes=[procs.radion_hh_vbf_bbtautau_m500],
-    keys=[
-        "/VBFToRadionToHHTo2B2Tau_M-500_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=160000,
-)
+# cpn.add_dataset(
+#     name="radion_hh_vbf_bbtautau_m500_madgraph",
+#     id=14311131,
+#     processes=[procs.radion_hh_vbf_bbtautau_m500],
+#     keys=[
+#         "/VBFToRadionToHHTo2B2Tau_M-500_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=160000,
+# )
 
-cpn.add_dataset(
-    name="radion_hh_vbf_bbtautau_m320_madgraph",
-    id=14310796,
-    processes=[procs.radion_hh_vbf_bbtautau_m320],
-    keys=[
-        "/VBFToRadionToHHTo2B2Tau_M-320_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=162000,
-)
+# cpn.add_dataset(
+#     name="radion_hh_vbf_bbtautau_m320_madgraph",
+#     id=14310796,
+#     processes=[procs.radion_hh_vbf_bbtautau_m320],
+#     keys=[
+#         "/VBFToRadionToHHTo2B2Tau_M-320_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=162000,
+# )
 
-cpn.add_dataset(
-    name="radion_hh_vbf_bbtautau_m400_madgraph",
-    id=14311092,
-    processes=[procs.radion_hh_vbf_bbtautau_m400],
-    keys=[
-        "/VBFToRadionToHHTo2B2Tau_M-400_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=160000,
-)
+# cpn.add_dataset(
+#     name="radion_hh_vbf_bbtautau_m400_madgraph",
+#     id=14311092,
+#     processes=[procs.radion_hh_vbf_bbtautau_m400],
+#     keys=[
+#         "/VBFToRadionToHHTo2B2Tau_M-400_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=160000,
+# )
 
-cpn.add_dataset(
-    name="radion_hh_vbf_bbtautau_m450_madgraph",
-    id=14310489,
-    processes=[procs.radion_hh_vbf_bbtautau_m450],
-    keys=[
-        "/VBFToRadionToHHTo2B2Tau_M-450_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=162000,
-)
+# cpn.add_dataset(
+#     name="radion_hh_vbf_bbtautau_m450_madgraph",
+#     id=14310489,
+#     processes=[procs.radion_hh_vbf_bbtautau_m450],
+#     keys=[
+#         "/VBFToRadionToHHTo2B2Tau_M-450_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=162000,
+# )
 
-cpn.add_dataset(
-    name="radion_hh_vbf_bbtautau_m650_madgraph",
-    id=14310467,
-    processes=[procs.radion_hh_vbf_bbtautau_m650],
-    keys=[
-        "/VBFToRadionToHHTo2B2Tau_M-650_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=108000,
-)
+# cpn.add_dataset(
+#     name="radion_hh_vbf_bbtautau_m650_madgraph",
+#     id=14310467,
+#     processes=[procs.radion_hh_vbf_bbtautau_m650],
+#     keys=[
+#         "/VBFToRadionToHHTo2B2Tau_M-650_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=108000,
+# )
 
-cpn.add_dataset(
-    name="radion_hh_vbf_bbtautau_m600_madgraph",
-    id=14309147,
-    processes=[procs.radion_hh_vbf_bbtautau_m600],
-    keys=[
-        "/VBFToRadionToHHTo2B2Tau_M-600_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=104000,
-)
+# cpn.add_dataset(
+#     name="radion_hh_vbf_bbtautau_m600_madgraph",
+#     id=14309147,
+#     processes=[procs.radion_hh_vbf_bbtautau_m600],
+#     keys=[
+#         "/VBFToRadionToHHTo2B2Tau_M-600_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=104000,
+# )
 
-cpn.add_dataset(
-    name="radion_hh_vbf_bbtautau_m260_madgraph",
-    id=14310633,
-    processes=[procs.radion_hh_vbf_bbtautau_m260],
-    keys=[
-        "/VBFToRadionToHHTo2B2Tau_M-260_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=216000,
-)
+# cpn.add_dataset(
+#     name="radion_hh_vbf_bbtautau_m260_madgraph",
+#     id=14310633,
+#     processes=[procs.radion_hh_vbf_bbtautau_m260],
+#     keys=[
+#         "/VBFToRadionToHHTo2B2Tau_M-260_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=216000,
+# )
 
-cpn.add_dataset(
-    name="radion_hh_vbf_bbtautau_m3000_madgraph",
-    id=14311354,
-    processes=[procs.radion_hh_vbf_bbtautau_m3000],
-    keys=[
-        "/VBFToRadionToHHTo2B2Tau_M-3000_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=52000,
-)
+# cpn.add_dataset(
+#     name="radion_hh_vbf_bbtautau_m3000_madgraph",
+#     id=14311354,
+#     processes=[procs.radion_hh_vbf_bbtautau_m3000],
+#     keys=[
+#         "/VBFToRadionToHHTo2B2Tau_M-3000_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=52000,
+# )
 
-cpn.add_dataset(
-    name="radion_hh_vbf_bbtautau_m550_madgraph",
-    id=14310820,
-    processes=[procs.radion_hh_vbf_bbtautau_m550],
-    keys=[
-        "/VBFToRadionToHHTo2B2Tau_M-550_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=108000,
-)
+# cpn.add_dataset(
+#     name="radion_hh_vbf_bbtautau_m550_madgraph",
+#     id=14310820,
+#     processes=[procs.radion_hh_vbf_bbtautau_m550],
+#     keys=[
+#         "/VBFToRadionToHHTo2B2Tau_M-550_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=108000,
+# )
 
-cpn.add_dataset(
-    name="radion_hh_vbf_bbtautau_m1500_madgraph",
-    id=14310564,
-    processes=[procs.radion_hh_vbf_bbtautau_m1500],
-    keys=[
-        "/VBFToRadionToHHTo2B2Tau_M-1500_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=54000,
-)
+# cpn.add_dataset(
+#     name="radion_hh_vbf_bbtautau_m1500_madgraph",
+#     id=14310564,
+#     processes=[procs.radion_hh_vbf_bbtautau_m1500],
+#     keys=[
+#         "/VBFToRadionToHHTo2B2Tau_M-1500_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=54000,
+# )
 
-cpn.add_dataset(
-    name="radion_hh_vbf_bbtautau_m250_madgraph",
-    id=14311026,
-    processes=[procs.radion_hh_vbf_bbtautau_m250],
-    keys=[
-        "/VBFToRadionToHHTo2B2Tau_M-250_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=210000,
-)
+# cpn.add_dataset(
+#     name="radion_hh_vbf_bbtautau_m250_madgraph",
+#     id=14311026,
+#     processes=[procs.radion_hh_vbf_bbtautau_m250],
+#     keys=[
+#         "/VBFToRadionToHHTo2B2Tau_M-250_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=210000,
+# )
 
-cpn.add_dataset(
-    name="radion_hh_vbf_bbtautau_m800_madgraph",
-    id=14310585,
-    processes=[procs.radion_hh_vbf_bbtautau_m800],
-    keys=[
-        "/VBFToRadionToHHTo2B2Tau_M-800_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=108000,
-)
+# cpn.add_dataset(
+#     name="radion_hh_vbf_bbtautau_m800_madgraph",
+#     id=14310585,
+#     processes=[procs.radion_hh_vbf_bbtautau_m800],
+#     keys=[
+#         "/VBFToRadionToHHTo2B2Tau_M-800_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=108000,
+# )
 
-cpn.add_dataset(
-    name="radion_hh_vbf_bbtautau_m300_madgraph",
-    id=14309129,
-    processes=[procs.radion_hh_vbf_bbtautau_m300],
-    keys=[
-        "/VBFToRadionToHHTo2B2Tau_M-300_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=162000,
-)
+# cpn.add_dataset(
+#     name="radion_hh_vbf_bbtautau_m300_madgraph",
+#     id=14309129,
+#     processes=[procs.radion_hh_vbf_bbtautau_m300],
+#     keys=[
+#         "/VBFToRadionToHHTo2B2Tau_M-300_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=162000,
+# )
 
-cpn.add_dataset(
-    name="radion_hh_vbf_bbtautau_m350_madgraph",
-    id=14310922,
-    processes=[procs.radion_hh_vbf_bbtautau_m350],
-    keys=[
-        "/VBFToRadionToHHTo2B2Tau_M-350_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=162000,
-)
+# cpn.add_dataset(
+#     name="radion_hh_vbf_bbtautau_m350_madgraph",
+#     id=14310922,
+#     processes=[procs.radion_hh_vbf_bbtautau_m350],
+#     keys=[
+#         "/VBFToRadionToHHTo2B2Tau_M-350_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=162000,
+# )
 
-cpn.add_dataset(
-    name="radion_hh_vbf_bbtautau_m850_madgraph",
-    id=14311176,
-    processes=[procs.radion_hh_vbf_bbtautau_m850],
-    keys=[
-        "/VBFToRadionToHHTo2B2Tau_M-850_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=106000,
-)
+# cpn.add_dataset(
+#     name="radion_hh_vbf_bbtautau_m850_madgraph",
+#     id=14311176,
+#     processes=[procs.radion_hh_vbf_bbtautau_m850],
+#     keys=[
+#         "/VBFToRadionToHHTo2B2Tau_M-850_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=106000,
+# )
 
-cpn.add_dataset(
-    name="radion_hh_vbf_bbtautau_m280_madgraph",
-    id=14310610,
-    processes=[procs.radion_hh_vbf_bbtautau_m280],
-    keys=[
-        "/VBFToRadionToHHTo2B2Tau_M-280_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=216000,
-)
+# cpn.add_dataset(
+#     name="radion_hh_vbf_bbtautau_m280_madgraph",
+#     id=14310610,
+#     processes=[procs.radion_hh_vbf_bbtautau_m280],
+#     keys=[
+#         "/VBFToRadionToHHTo2B2Tau_M-280_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=216000,
+# )
 
-cpn.add_dataset(
-    name="radion_hh_vbf_bbtautau_m1000_madgraph",
-    id=14311373,
-    processes=[procs.radion_hh_vbf_bbtautau_m1000],
-    keys=[
-        "/VBFToRadionToHHTo2B2Tau_M-1000_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=52000,
-)
+# cpn.add_dataset(
+#     name="radion_hh_vbf_bbtautau_m1000_madgraph",
+#     id=14311373,
+#     processes=[procs.radion_hh_vbf_bbtautau_m1000],
+#     keys=[
+#         "/VBFToRadionToHHTo2B2Tau_M-1000_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=52000,
+# )
 
-cpn.add_dataset(
-    name="radion_hh_vbf_bbtautau_m1750_madgraph",
-    id=14311180,
-    processes=[procs.radion_hh_vbf_bbtautau_m1750],
-    keys=[
-        "/VBFToRadionToHHTo2B2Tau_M-1750_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=54000,
-)
+# cpn.add_dataset(
+#     name="radion_hh_vbf_bbtautau_m1750_madgraph",
+#     id=14311180,
+#     processes=[procs.radion_hh_vbf_bbtautau_m1750],
+#     keys=[
+#         "/VBFToRadionToHHTo2B2Tau_M-1750_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=54000,
+# )
 
-cpn.add_dataset(
-    name="radion_hh_vbf_bbtautau_m2500_madgraph",
-    id=14309857,
-    processes=[procs.radion_hh_vbf_bbtautau_m2500],
-    keys=[
-        "/VBFToRadionToHHTo2B2Tau_M-2500_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=52000,
-)
+# cpn.add_dataset(
+#     name="radion_hh_vbf_bbtautau_m2500_madgraph",
+#     id=14309857,
+#     processes=[procs.radion_hh_vbf_bbtautau_m2500],
+#     keys=[
+#         "/VBFToRadionToHHTo2B2Tau_M-2500_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=52000,
+# )
 
-cpn.add_dataset(
-    name="radion_hh_vbf_bbtautau_m270_madgraph",
-    id=14311009,
-    processes=[procs.radion_hh_vbf_bbtautau_m270],
-    keys=[
-        "/VBFToRadionToHHTo2B2Tau_M-270_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=214000,
-)
+# cpn.add_dataset(
+#     name="radion_hh_vbf_bbtautau_m270_madgraph",
+#     id=14311009,
+#     processes=[procs.radion_hh_vbf_bbtautau_m270],
+#     keys=[
+#         "/VBFToRadionToHHTo2B2Tau_M-270_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=214000,
+# )
 
-cpn.add_dataset(
-    name="radion_hh_vbf_bbtautau_m900_madgraph",
-    id=14309240,
-    processes=[procs.radion_hh_vbf_bbtautau_m900],
-    keys=[
-        "/VBFToRadionToHHTo2B2Tau_M-900_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=106000,
-)
+# cpn.add_dataset(
+#     name="radion_hh_vbf_bbtautau_m900_madgraph",
+#     id=14309240,
+#     processes=[procs.radion_hh_vbf_bbtautau_m900],
+#     keys=[
+#         "/VBFToRadionToHHTo2B2Tau_M-900_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=106000,
+# )
 
-cpn.add_dataset(
-    name="radion_hh_vbf_bbtautau_m750_madgraph",
-    id=14309178,
-    processes=[procs.radion_hh_vbf_bbtautau_m750],
-    keys=[
-        "/VBFToRadionToHHTo2B2Tau_M-750_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=106000,
-)
+# cpn.add_dataset(
+#     name="radion_hh_vbf_bbtautau_m750_madgraph",
+#     id=14309178,
+#     processes=[procs.radion_hh_vbf_bbtautau_m750],
+#     keys=[
+#         "/VBFToRadionToHHTo2B2Tau_M-750_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=106000,
+# )
 
-cpn.add_dataset(
-    name="radion_hh_vbf_bbtautau_m2000_madgraph",
-    id=14310672,
-    processes=[procs.radion_hh_vbf_bbtautau_m2000],
-    keys=[
-        "/VBFToRadionToHHTo2B2Tau_M-2000_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=54000,
-)
+# cpn.add_dataset(
+#     name="radion_hh_vbf_bbtautau_m2000_madgraph",
+#     id=14310672,
+#     processes=[procs.radion_hh_vbf_bbtautau_m2000],
+#     keys=[
+#         "/VBFToRadionToHHTo2B2Tau_M-2000_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=54000,
+# )
 
-cpn.add_dataset(
-    name="radion_hh_vbf_bbtautau_m700_madgraph",
-    id=14311299,
-    processes=[procs.radion_hh_vbf_bbtautau_m700],
-    keys=[
-        "/VBFToRadionToHHTo2B2Tau_M-700_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=106000,
-)
+# cpn.add_dataset(
+#     name="radion_hh_vbf_bbtautau_m700_madgraph",
+#     id=14311299,
+#     processes=[procs.radion_hh_vbf_bbtautau_m700],
+#     keys=[
+#         "/VBFToRadionToHHTo2B2Tau_M-700_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=106000,
+# )
 
-cpn.add_dataset(
-    name="radion_hh_vbf_bbtautau_m1250_madgraph",
-    id=14309599,
-    processes=[procs.radion_hh_vbf_bbtautau_m1250],
-    keys=[
-        "/VBFToRadionToHHTo2B2Tau_M-1250_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=54000,
-)
+# cpn.add_dataset(
+#     name="radion_hh_vbf_bbtautau_m1250_madgraph",
+#     id=14309599,
+#     processes=[procs.radion_hh_vbf_bbtautau_m1250],
+#     keys=[
+#         "/VBFToRadionToHHTo2B2Tau_M-1250_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=54000,
+# )
 
 
-# VBF -> graviton -> HH
+# # VBF -> graviton -> HH
 
-cpn.add_dataset(
-    name="graviton_hh_vbf_bbtautau_m900_madgraph",
-    id=14309476,
-    processes=[procs.graviton_hh_vbf_bbtautau_m900],
-    keys=[
-        "/VBFToBulkGravitonToHHTo2B2Tau_M-900_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=108000,
-)
+# cpn.add_dataset(
+#     name="graviton_hh_vbf_bbtautau_m900_madgraph",
+#     id=14309476,
+#     processes=[procs.graviton_hh_vbf_bbtautau_m900],
+#     keys=[
+#         "/VBFToBulkGravitonToHHTo2B2Tau_M-900_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=108000,
+# )
 
-cpn.add_dataset(
-    name="graviton_hh_vbf_bbtautau_m850_madgraph",
-    id=14309603,
-    processes=[procs.graviton_hh_vbf_bbtautau_m850],
-    keys=[
-        "/VBFToBulkGravitonToHHTo2B2Tau_M-850_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=108000,
-)
+# cpn.add_dataset(
+#     name="graviton_hh_vbf_bbtautau_m850_madgraph",
+#     id=14309603,
+#     processes=[procs.graviton_hh_vbf_bbtautau_m850],
+#     keys=[
+#         "/VBFToBulkGravitonToHHTo2B2Tau_M-850_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=108000,
+# )
 
-cpn.add_dataset(
-    name="graviton_hh_vbf_bbtautau_m800_madgraph",
-    id=14311096,
-    processes=[procs.graviton_hh_vbf_bbtautau_m800],
-    keys=[
-        "/VBFToBulkGravitonToHHTo2B2Tau_M-800_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=104000,
-)
+# cpn.add_dataset(
+#     name="graviton_hh_vbf_bbtautau_m800_madgraph",
+#     id=14311096,
+#     processes=[procs.graviton_hh_vbf_bbtautau_m800],
+#     keys=[
+#         "/VBFToBulkGravitonToHHTo2B2Tau_M-800_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=104000,
+# )
 
-cpn.add_dataset(
-    name="graviton_hh_vbf_bbtautau_m750_madgraph",
-    id=14310181,
-    processes=[procs.graviton_hh_vbf_bbtautau_m750],
-    keys=[
-        "/VBFToBulkGravitonToHHTo2B2Tau_M-750_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=106000,
-)
+# cpn.add_dataset(
+#     name="graviton_hh_vbf_bbtautau_m750_madgraph",
+#     id=14310181,
+#     processes=[procs.graviton_hh_vbf_bbtautau_m750],
+#     keys=[
+#         "/VBFToBulkGravitonToHHTo2B2Tau_M-750_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=106000,
+# )
 
-cpn.add_dataset(
-    name="graviton_hh_vbf_bbtautau_m700_madgraph",
-    id=14309734,
-    processes=[procs.graviton_hh_vbf_bbtautau_m700],
-    keys=[
-        "/VBFToBulkGravitonToHHTo2B2Tau_M-700_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=108000,
-)
+# cpn.add_dataset(
+#     name="graviton_hh_vbf_bbtautau_m700_madgraph",
+#     id=14309734,
+#     processes=[procs.graviton_hh_vbf_bbtautau_m700],
+#     keys=[
+#         "/VBFToBulkGravitonToHHTo2B2Tau_M-700_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=108000,
+# )
 
-cpn.add_dataset(
-    name="graviton_hh_vbf_bbtautau_m650_madgraph",
-    id=14309837,
-    processes=[procs.graviton_hh_vbf_bbtautau_m650],
-    keys=[
-        "/VBFToBulkGravitonToHHTo2B2Tau_M-650_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=108000,
-)
+# cpn.add_dataset(
+#     name="graviton_hh_vbf_bbtautau_m650_madgraph",
+#     id=14309837,
+#     processes=[procs.graviton_hh_vbf_bbtautau_m650],
+#     keys=[
+#         "/VBFToBulkGravitonToHHTo2B2Tau_M-650_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=108000,
+# )
 
-cpn.add_dataset(
-    name="graviton_hh_vbf_bbtautau_m600_madgraph",
-    id=14310214,
-    processes=[procs.graviton_hh_vbf_bbtautau_m600],
-    keys=[
-        "/VBFToBulkGravitonToHHTo2B2Tau_M-600_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=108000,
-)
+# cpn.add_dataset(
+#     name="graviton_hh_vbf_bbtautau_m600_madgraph",
+#     id=14310214,
+#     processes=[procs.graviton_hh_vbf_bbtautau_m600],
+#     keys=[
+#         "/VBFToBulkGravitonToHHTo2B2Tau_M-600_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=108000,
+# )
 
-cpn.add_dataset(
-    name="graviton_hh_vbf_bbtautau_m550_madgraph",
-    id=14309850,
-    processes=[procs.graviton_hh_vbf_bbtautau_m550],
-    keys=[
-        "/VBFToBulkGravitonToHHTo2B2Tau_M-550_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=108000,
-)
+# cpn.add_dataset(
+#     name="graviton_hh_vbf_bbtautau_m550_madgraph",
+#     id=14309850,
+#     processes=[procs.graviton_hh_vbf_bbtautau_m550],
+#     keys=[
+#         "/VBFToBulkGravitonToHHTo2B2Tau_M-550_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=108000,
+# )
 
-cpn.add_dataset(
-    name="graviton_hh_vbf_bbtautau_m500_madgraph",
-    id=14309834,
-    processes=[procs.graviton_hh_vbf_bbtautau_m500],
-    keys=[
-        "/VBFToBulkGravitonToHHTo2B2Tau_M-500_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=162000,
-)
+# cpn.add_dataset(
+#     name="graviton_hh_vbf_bbtautau_m500_madgraph",
+#     id=14309834,
+#     processes=[procs.graviton_hh_vbf_bbtautau_m500],
+#     keys=[
+#         "/VBFToBulkGravitonToHHTo2B2Tau_M-500_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=162000,
+# )
 
-cpn.add_dataset(
-    name="graviton_hh_vbf_bbtautau_m450_madgraph",
-    id=14310948,
-    processes=[procs.graviton_hh_vbf_bbtautau_m450],
-    keys=[
-        "/VBFToBulkGravitonToHHTo2B2Tau_M-450_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=160000,
-)
+# cpn.add_dataset(
+#     name="graviton_hh_vbf_bbtautau_m450_madgraph",
+#     id=14310948,
+#     processes=[procs.graviton_hh_vbf_bbtautau_m450],
+#     keys=[
+#         "/VBFToBulkGravitonToHHTo2B2Tau_M-450_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=160000,
+# )
 
-cpn.add_dataset(
-    name="graviton_hh_vbf_bbtautau_m400_madgraph",
-    id=14311043,
-    processes=[procs.graviton_hh_vbf_bbtautau_m400],
-    keys=[
-        "/VBFToBulkGravitonToHHTo2B2Tau_M-400_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=158000,
-)
+# cpn.add_dataset(
+#     name="graviton_hh_vbf_bbtautau_m400_madgraph",
+#     id=14311043,
+#     processes=[procs.graviton_hh_vbf_bbtautau_m400],
+#     keys=[
+#         "/VBFToBulkGravitonToHHTo2B2Tau_M-400_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=158000,
+# )
 
-cpn.add_dataset(
-    name="graviton_hh_vbf_bbtautau_m350_madgraph",
-    id=14310464,
-    processes=[procs.graviton_hh_vbf_bbtautau_m350],
-    keys=[
-        "/VBFToBulkGravitonToHHTo2B2Tau_M-350_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=162000,
-)
+# cpn.add_dataset(
+#     name="graviton_hh_vbf_bbtautau_m350_madgraph",
+#     id=14310464,
+#     processes=[procs.graviton_hh_vbf_bbtautau_m350],
+#     keys=[
+#         "/VBFToBulkGravitonToHHTo2B2Tau_M-350_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=162000,
+# )
 
-cpn.add_dataset(
-    name="graviton_hh_vbf_bbtautau_m320_madgraph",
-    id=14309870,
-    processes=[procs.graviton_hh_vbf_bbtautau_m320],
-    keys=[
-        "/VBFToBulkGravitonToHHTo2B2Tau_M-320_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=160000,
-)
+# cpn.add_dataset(
+#     name="graviton_hh_vbf_bbtautau_m320_madgraph",
+#     id=14309870,
+#     processes=[procs.graviton_hh_vbf_bbtautau_m320],
+#     keys=[
+#         "/VBFToBulkGravitonToHHTo2B2Tau_M-320_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=160000,
+# )
 
-cpn.add_dataset(
-    name="graviton_hh_vbf_bbtautau_m3000_madgraph",
-    id=14309851,
-    processes=[procs.graviton_hh_vbf_bbtautau_m3000],
-    keys=[
-        "/VBFToBulkGravitonToHHTo2B2Tau_M-3000_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=54000,
-)
+# cpn.add_dataset(
+#     name="graviton_hh_vbf_bbtautau_m3000_madgraph",
+#     id=14309851,
+#     processes=[procs.graviton_hh_vbf_bbtautau_m3000],
+#     keys=[
+#         "/VBFToBulkGravitonToHHTo2B2Tau_M-3000_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=54000,
+# )
 
-cpn.add_dataset(
-    name="graviton_hh_vbf_bbtautau_m300_madgraph",
-    id=14310056,
-    processes=[procs.graviton_hh_vbf_bbtautau_m300],
-    keys=[
-        "/VBFToBulkGravitonToHHTo2B2Tau_M-300_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=162000,
-)
+# cpn.add_dataset(
+#     name="graviton_hh_vbf_bbtautau_m300_madgraph",
+#     id=14310056,
+#     processes=[procs.graviton_hh_vbf_bbtautau_m300],
+#     keys=[
+#         "/VBFToBulkGravitonToHHTo2B2Tau_M-300_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=162000,
+# )
 
-cpn.add_dataset(
-    name="graviton_hh_vbf_bbtautau_m280_madgraph",
-    id=14310550,
-    processes=[procs.graviton_hh_vbf_bbtautau_m280],
-    keys=[
-        "/VBFToBulkGravitonToHHTo2B2Tau_M-280_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=214000,
-)
+# cpn.add_dataset(
+#     name="graviton_hh_vbf_bbtautau_m280_madgraph",
+#     id=14310550,
+#     processes=[procs.graviton_hh_vbf_bbtautau_m280],
+#     keys=[
+#         "/VBFToBulkGravitonToHHTo2B2Tau_M-280_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=214000,
+# )
 
-cpn.add_dataset(
-    name="graviton_hh_vbf_bbtautau_m270_madgraph",
-    id=14309919,
-    processes=[procs.graviton_hh_vbf_bbtautau_m270],
-    keys=[
-        "/VBFToBulkGravitonToHHTo2B2Tau_M-270_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=216000,
-)
+# cpn.add_dataset(
+#     name="graviton_hh_vbf_bbtautau_m270_madgraph",
+#     id=14309919,
+#     processes=[procs.graviton_hh_vbf_bbtautau_m270],
+#     keys=[
+#         "/VBFToBulkGravitonToHHTo2B2Tau_M-270_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=216000,
+# )
 
-cpn.add_dataset(
-    name="graviton_hh_vbf_bbtautau_m260_madgraph",
-    id=14311171,
-    processes=[procs.graviton_hh_vbf_bbtautau_m260],
-    keys=[
-        "/VBFToBulkGravitonToHHTo2B2Tau_M-260_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=214000,
-)
+# cpn.add_dataset(
+#     name="graviton_hh_vbf_bbtautau_m260_madgraph",
+#     id=14311171,
+#     processes=[procs.graviton_hh_vbf_bbtautau_m260],
+#     keys=[
+#         "/VBFToBulkGravitonToHHTo2B2Tau_M-260_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=214000,
+# )
 
-cpn.add_dataset(
-    name="graviton_hh_vbf_bbtautau_m2500_madgraph",
-    id=14309744,
-    processes=[procs.graviton_hh_vbf_bbtautau_m2500],
-    keys=[
-        "/VBFToBulkGravitonToHHTo2B2Tau_M-2500_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=54000,
-)
+# cpn.add_dataset(
+#     name="graviton_hh_vbf_bbtautau_m2500_madgraph",
+#     id=14309744,
+#     processes=[procs.graviton_hh_vbf_bbtautau_m2500],
+#     keys=[
+#         "/VBFToBulkGravitonToHHTo2B2Tau_M-2500_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=54000,
+# )
 
-cpn.add_dataset(
-    name="graviton_hh_vbf_bbtautau_m250_madgraph",
-    id=14311070,
-    processes=[procs.graviton_hh_vbf_bbtautau_m250],
-    keys=[
-        "/VBFToBulkGravitonToHHTo2B2Tau_M-250_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=214000,
-)
+# cpn.add_dataset(
+#     name="graviton_hh_vbf_bbtautau_m250_madgraph",
+#     id=14311070,
+#     processes=[procs.graviton_hh_vbf_bbtautau_m250],
+#     keys=[
+#         "/VBFToBulkGravitonToHHTo2B2Tau_M-250_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=214000,
+# )
 
-cpn.add_dataset(
-    name="graviton_hh_vbf_bbtautau_m2000_madgraph",
-    id=14309508,
-    processes=[procs.graviton_hh_vbf_bbtautau_m2000],
-    keys=[
-        "/VBFToBulkGravitonToHHTo2B2Tau_M-2000_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=54000,
-)
+# cpn.add_dataset(
+#     name="graviton_hh_vbf_bbtautau_m2000_madgraph",
+#     id=14309508,
+#     processes=[procs.graviton_hh_vbf_bbtautau_m2000],
+#     keys=[
+#         "/VBFToBulkGravitonToHHTo2B2Tau_M-2000_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=54000,
+# )
 
-cpn.add_dataset(
-    name="graviton_hh_vbf_bbtautau_m1750_madgraph",
-    id=14309405,
-    processes=[procs.graviton_hh_vbf_bbtautau_m1750],
-    keys=[
-        "/VBFToBulkGravitonToHHTo2B2Tau_M-1750_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=54000,
-)
+# cpn.add_dataset(
+#     name="graviton_hh_vbf_bbtautau_m1750_madgraph",
+#     id=14309405,
+#     processes=[procs.graviton_hh_vbf_bbtautau_m1750],
+#     keys=[
+#         "/VBFToBulkGravitonToHHTo2B2Tau_M-1750_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=54000,
+# )
 
-cpn.add_dataset(
-    name="graviton_hh_vbf_bbtautau_m1500_madgraph",
-    id=14309566,
-    processes=[procs.graviton_hh_vbf_bbtautau_m1500],
-    keys=[
-        "/VBFToBulkGravitonToHHTo2B2Tau_M-1500_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=54000,
-)
+# cpn.add_dataset(
+#     name="graviton_hh_vbf_bbtautau_m1500_madgraph",
+#     id=14309566,
+#     processes=[procs.graviton_hh_vbf_bbtautau_m1500],
+#     keys=[
+#         "/VBFToBulkGravitonToHHTo2B2Tau_M-1500_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=54000,
+# )
 
-cpn.add_dataset(
-    name="graviton_hh_vbf_bbtautau_m1250_madgraph",
-    id=14309555,
-    processes=[procs.graviton_hh_vbf_bbtautau_m1250],
-    keys=[
-        "/VBFToBulkGravitonToHHTo2B2Tau_M-1250_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=54000,
-)
+# cpn.add_dataset(
+#     name="graviton_hh_vbf_bbtautau_m1250_madgraph",
+#     id=14309555,
+#     processes=[procs.graviton_hh_vbf_bbtautau_m1250],
+#     keys=[
+#         "/VBFToBulkGravitonToHHTo2B2Tau_M-1250_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=54000,
+# )
 
-cpn.add_dataset(
-    name="graviton_hh_vbf_bbtautau_m1000_madgraph",
-    id=14309686,
-    processes=[procs.graviton_hh_vbf_bbtautau_m1000],
-    keys=[
-        "/VBFToBulkGravitonToHHTo2B2Tau_M-1000_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-    ],
-    n_files=1,
-    n_events=54000,
-)
+# cpn.add_dataset(
+#     name="graviton_hh_vbf_bbtautau_m1000_madgraph",
+#     id=14309686,
+#     processes=[procs.graviton_hh_vbf_bbtautau_m1000],
+#     keys=[
+#         "/VBFToBulkGravitonToHHTo2B2Tau_M-1000_TuneCP5_PSWeights_narrow_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+#     ],
+#     n_files=1,
+#     n_events=54000,
+# )

--- a/cmsdb/campaigns/run2_2016_HIPM_nano_uhh_v12/st.py
+++ b/cmsdb/campaigns/run2_2016_HIPM_nano_uhh_v12/st.py
@@ -17,10 +17,10 @@ cpn.add_dataset(
     id=14213957,
     processes=[procs.st_twchannel_t],
     keys=[
-	"/ST_tW_top_5f_inclusiveDecays_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM",  # noqa
+        "/ST_tW_top_5f_inclusiveDecays_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v1/NANOAODSIM",  # noqa
     ],
-    n_files=2,
-    n_events=2300000,
+    n_files=35,
+    n_events=2_300_000,
 )
 
 # ST_tW_antitop
@@ -29,10 +29,10 @@ cpn.add_dataset(
     id=14212973,
     processes=[procs.st_twchannel_tbar],
     keys=[
-	"/ST_tW_antitop_5f_inclusiveDecays_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM",  # noqa
+        "/ST_tW_antitop_5f_inclusiveDecays_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v1/NANOAODSIM",  # noqa
     ],
-    n_files=2,
-    n_events=2300000,
+    n_files=33,
+    n_events=2_300_000,
 )
 
 
@@ -40,57 +40,42 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="st_tchannel_tbar_powheg",
     id=14225486,
-    is_data=False,
     processes=[procs.st_tchannel_tbar],
     info=dict(
         nominal=DatasetInfo(
             keys=[
-                "/ST_t-channel_antitop_4f_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v3/NANOAODSIM",  # noqa
+                "/ST_t-channel_antitop_4f_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v3/NANOAODSIM",  # noqa
             ],
-            n_files=28,
-            n_events=31024000,
-        ),
-        tune_up=DatasetInfo(
-            keys=[
-                "/ST_t-channel_antitop_4f_InclusiveDecays_TuneCP5up_13TeV-powheg-madspin-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v3/NANOAODSIM", # noqa
-            ],
-            n_files=8,
-            n_events=10715000,
+            n_files=580,
+            n_events=31_024_000,
         ),
         tune_down=DatasetInfo(
             keys=[
-                "/ST_t-channel_antitop_4f_InclusiveDecays_TuneCP5down_13TeV-powheg-madspin-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v3/NANOAODSIM",  # noqa
+                "/ST_t-channel_antitop_4f_InclusiveDecays_TuneCP5down_13TeV-powheg-madspin-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v3/NANOAODSIM",  # noqa
             ],
-            n_files=8,
-            n_events=10854000,
+            n_files=196,
+            n_events=10_854_000,
         ),
-        hdamp_down=DatasetInfo(
+        tune_up=DatasetInfo(
             keys=[
-                "/ST_t-channel_antitop_4f_hdampdown_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v3/NANOAODSIM",  # noqa
+                "/ST_t-channel_antitop_4f_InclusiveDecays_TuneCP5up_13TeV-powheg-madspin-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v3/NANOAODSIM",  # noqa
             ],
-            n_files=8,
-            n_events=10827000,
-        ),
-        hdamp_up=DatasetInfo(
-            keys=[
-                "/ST_t-channel_antitop_4f_hdampup_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v3/NANOAODSIM",  # noqa
-            ],
-            n_files=8,
-            n_events=10555000,
-        ),
-        mtop_up=DatasetInfo(
-            keys=[
-	            "/ST_t-channel_antitop_4f_InclusiveDecays_mtop1735_TuneCP5_13TeV-powheg-madspin-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v3/NANOAODSIM", # noqa
-            ],
-            n_files=9,
-            n_events=11101000,
+            n_files=196,
+            n_events=10_715_000,
         ),
         mtop_down=DatasetInfo(
             keys=[
-	            "/ST_t-channel_antitop_4f_InclusiveDecays_mtop1715_TuneCP5_13TeV-powheg-madspin-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v3/NANOAODSIM", # noqa
+                "/ST_t-channel_antitop_4f_InclusiveDecays_mtop1715_TuneCP5_13TeV-powheg-madspin-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v3/NANOAODSIM",  # noqa
             ],
-            n_files=8,
-            n_events=10626000,
+            n_files=240,
+            n_events=10_626_000,
+        ),
+        mtop_up=DatasetInfo(
+            keys=[
+                "/ST_t-channel_antitop_4f_InclusiveDecays_mtop1735_TuneCP5_13TeV-powheg-madspin-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=256,
+            n_events=11_101_000,
         ),
     ),
 )
@@ -100,57 +85,42 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="st_tchannel_t_powheg",
     id=14224840,
-    is_data=False,
     processes=[procs.st_tchannel_t],
     info=dict(
         nominal=DatasetInfo(
             keys=[
-                "/ST_t-channel_top_4f_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v3/NANOAODSIM",  # noqa
+                "/ST_t-channel_top_4f_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v3/NANOAODSIM",  # noqa
             ],
-            n_files=51,
-            n_events=55961000,
-        ),
-        tune_up=DatasetInfo(
-            keys=[
-                "/ST_t-channel_top_4f_InclusiveDecays_TuneCP5up_13TeV-powheg-madspin-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v3/NANOAODSIM",  # noqa
-            ],
-            n_files=17,
-            n_events=21927000,
+            n_files=908,
+            n_events=55_961_000,
         ),
         tune_down=DatasetInfo(
             keys=[
-	            "/ST_t-channel_top_4f_InclusiveDecays_TuneCP5down_13TeV-powheg-madspin-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v3/NANOAODSIM",  # noqa
+                "/ST_t-channel_top_4f_InclusiveDecays_TuneCP5down_13TeV-powheg-madspin-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v3/NANOAODSIM",  # noqa
             ],
-            n_files=17,
-            n_events=22073000,
+            n_files=366,
+            n_events=22_073_000,
         ),
-        hdamp_down=DatasetInfo(
+        tune_up=DatasetInfo(
             keys=[
-                "/ST_t-channel_top_4f_hdampdown_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v3/NANOAODSIM",  # noqa
+                "/ST_t-channel_top_4f_InclusiveDecays_TuneCP5up_13TeV-powheg-madspin-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v3/NANOAODSIM",  # noqa
             ],
-            n_files=17,
-            n_events=22237000,
-        ),
-        hdamp_up=DatasetInfo(
-            keys=[
-                "/ST_t-channel_top_4f_hdampup_InclusiveDecays_TuneCP5_13TeV-powheg-madspin-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v3/NANOAODSIM",  # noqa
-            ],
-            n_files=17,
-            n_events=22147000,
-        ),
-        mtop_up=DatasetInfo(
-            keys=[
-                "/ST_t-channel_top_4f_InclusiveDecays_mtop1735_TuneCP5_13TeV-powheg-madspin-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v3/NANOAODSIM", # noqa
-            ],
-            n_files=17,
-            n_events=22499000,
+            n_files=374,
+            n_events=21_927_000,
         ),
         mtop_down=DatasetInfo(
             keys=[
-                "/ST_t-channel_top_4f_InclusiveDecays_mtop1715_TuneCP5_13TeV-powheg-madspin-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v3/NANOAODSIM", # noqa
+                "/ST_t-channel_top_4f_InclusiveDecays_mtop1715_TuneCP5_13TeV-powheg-madspin-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v3/NANOAODSIM",  # noqa
             ],
-            n_files=17,
-            n_events=22239000,
+            n_files=452,
+            n_events=22_239_000,
+        ),
+        mtop_up=DatasetInfo(
+            keys=[
+                "/ST_t-channel_top_4f_InclusiveDecays_mtop1735_TuneCP5_13TeV-powheg-madspin-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=461,
+            n_events=22_499_000,
         ),
     ),
 )

--- a/cmsdb/campaigns/run2_2016_HIPM_nano_uhh_v12/ttbar.py
+++ b/cmsdb/campaigns/run2_2016_HIPM_nano_uhh_v12/ttbar.py
@@ -17,10 +17,10 @@ cpn.add_dataset(
     id=14214929,
     processes=[procs.ttww],
     keys=[
-        "/TTWW_TuneCP5_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM",  # noqa
+        "/TTWW_TuneCP5_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v1/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=278000,
+    n_files=14,
+    n_events=278_000,
 )
 
 # TTZToLLNuNu
@@ -28,29 +28,11 @@ cpn.add_dataset(
     name="ttz_llnunu_m10_amcatnlo",
     id=14213080,
     processes=[procs.ttz_llnunu_m10],
-    info=dict(
-        nominal=DatasetInfo(
-            keys=[
-                "/TTZToLLNuNu_M-10_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM",  # noqa
-            ],
-            n_files=7,
-            n_events=5792000,
-        ),
-        tune_up=DatasetInfo(
-            keys=[
-                "/TTZToLLNuNu_M-10_TuneCP5up_13TeV-amcatnlo-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-            ],
-            n_files=3,
-            n_events=2300000,
-        ),
-        tune_down=DatasetInfo(
-            keys=[
-                "/TTZToLLNuNu_M-10_TuneCP5down_13TeV-amcatnlo-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-            ],
-            n_files=3,
-            n_events=2298000,
-        ),
-    ),
+    keys=[
+        "/TTZToLLNuNu_M-10_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=110,
+    n_events=5_792_000,
 )
 
 # TTWJetsToQQ
@@ -59,10 +41,10 @@ cpn.add_dataset(
     id=14286376,
     processes=[procs.ttw_qq],
     keys=[
-        "/TTWJetsToQQ_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
+        "/TTWJetsToQQ_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=271496,
+    n_files=10,
+    n_events=271_496,
 )
 
 # TTWJetsToLNu
@@ -70,29 +52,11 @@ cpn.add_dataset(
     name="ttw_nlu_amcatnlo",
     id=14251563,
     processes=[procs.ttw_lnu],
-    info=dict(
-        nominal=DatasetInfo(
-            keys=[
-                "/TTWJetsToLNu_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-            ],
-            n_files=4,
-            n_events=2850164,
-        ),
-        tune_up=DatasetInfo(
-            keys=[
-                "/TTWJetsToLNu_TuneCP5up_13TeV-amcatnloFXFX-madspin-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-            ],
-            n_files=2,
-            n_events=1173511,
-        ),
-        tune_down=DatasetInfo(
-            keys=[
-                "/TTWJetsToLNu_TuneCP5down_13TeV-amcatnloFXFX-madspin-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v2/NANOAODSIM",  # noqa
-            ],
-            n_files=2,
-            n_events=1252285,
-        ),
-    ),
+    keys=[
+        "/TTWJetsToLNu_TuneCP5_13TeV-amcatnloFXFX-madspin-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=72,
+    n_events=2_850_164,
 )
 
 # TTWZ
@@ -101,10 +65,10 @@ cpn.add_dataset(
     id=14213653,
     processes=[procs.ttwz],
     keys=[
-        "/TTWZ_TuneCP5_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM",  # noqa
+        "/TTWZ_TuneCP5_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v1/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=140000,
+    n_files=5,
+    n_events=140_000,
 )
 
 # TTZZ
@@ -113,67 +77,66 @@ cpn.add_dataset(
     id=14213601,
     processes=[procs.ttzz],
     keys=[
-        "/TTZZ_TuneCP5_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM",  # noqa
+        "/TTZZ_TuneCP5_13TeV-madgraph-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v1/NANOAODSIM",  # noqa
     ],
-    n_files=1,
-    n_events=140000,
+    n_files=20,
+    n_events=140_000,
 )
 
 # TTTo2L2Nu
 cpn.add_dataset(
     name="tt_dl_powheg",
     id=14213146,
-    is_data=False,
     processes=[procs.tt_dl],
     info=dict(
         nominal=DatasetInfo(
             keys=[
-                "/TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM",  # noqa
+                "/TTTo2L2Nu_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v1/NANOAODSIM",  # noqa
             ],
-            n_files=35,
-            n_events=37505000,
-        ),
-        tune_up=DatasetInfo(
-            keys=[
-                "/TTTo2L2Nu_TuneCP5up_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM",  # noqa
-            ],
-            n_files=10,
-            n_events=10381000,
+            n_files=594,
+            n_events=37_505_000,
         ),
         tune_down=DatasetInfo(
             keys=[
-              "/TTTo2L2Nu_TuneCP5down_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM",  # noqa
+                "/TTTo2L2Nu_TuneCP5down_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v1/NANOAODSIM",  # noqa
             ],
-            n_files=20,
-            n_events=21583000,
+            n_files=340,
+            n_events=21_583_000,
         ),
-        hdamp_up=DatasetInfo(
+        tune_up=DatasetInfo(
             keys=[
-                "/TTTo2L2Nu_hdampUP_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM",  # noqa
+                "/TTTo2L2Nu_TuneCP5up_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v1/NANOAODSIM",  # noqa
             ],
-            n_files=14,
-            n_events=14865000,
+            n_files=173,
+            n_events=10_311_000,
         ),
         hdamp_down=DatasetInfo(
             keys=[
-                "/TTTo2L2Nu_hdampDOWN_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM",  # noqa
+                "/TTTo2L2Nu_hdampDOWN_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v1/NANOAODSIM",  # noqa
             ],
-            n_files=16,
-            n_events=16973000,
+            n_files=286,
+            n_events=16_973_000,
         ),
-        mtop_up=DatasetInfo(
+        hdamp_up=DatasetInfo(
             keys=[
-                "/TTTo2L2Nu_mtop173p5_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM",  # noqa
+                "/TTTo2L2Nu_hdampUP_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v1/NANOAODSIM",  # noqa
             ],
-            n_files=16,
-            n_events=16848000,
+            n_files=249,
+            n_events=14_865_000,
         ),
         mtop_down=DatasetInfo(
             keys=[
-                "/TTTo2L2Nu_mtop171p5_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM",  # noqa
+                "/TTTo2L2Nu_mtop171p5_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v1/NANOAODSIM",  # noqa
             ],
-            n_files=16,
-            n_events=16828000,
+            n_files=268,
+            n_events=16_828_000,
+        ),
+        mtop_up=DatasetInfo(
+            keys=[
+                "/TTTo2L2Nu_mtop173p5_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v1/NANOAODSIM",  # noqa
+            ],
+            n_files=280,
+            n_events=16_848_000,
         ),
     ),
 )
@@ -186,52 +149,52 @@ cpn.add_dataset(
     info=dict(
         nominal=DatasetInfo(
             keys=[
-                "/TTToHadronic_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM",  # noqa
+                "/TTToHadronic_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v1/NANOAODSIM",  # noqa
             ],
-            n_files=92,
-            n_events=97600000,
-        ),
-        tune_up=DatasetInfo(
-            keys=[
-            "/TTToHadronic_TuneCP5up_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM",  # noqa
-            ],
-            n_files=29,
-            n_events=28866000,
+            n_files=1_458,
+            n_events=97_600_000,
         ),
         tune_down=DatasetInfo(
             keys=[
-                "/TTToHadronic_TuneCP5down_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM",  # noqa
+                "/TTToHadronic_TuneCP5down_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v1/NANOAODSIM",  # noqa
             ],
-            n_files=39,
-            n_events=39035000,
+            n_files=623,
+            n_events=39_035_000,
         ),
-        hdamp_up=DatasetInfo(
+        tune_up=DatasetInfo(
             keys=[
-                "/TTToHadronic_hdampUP_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM",  # noqa
+                "/TTToHadronic_TuneCP5up_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v1/NANOAODSIM",  # noqa
             ],
-            n_files=31,
-            n_events=30504000,
+            n_files=456,
+            n_events=28_866_000,
         ),
         hdamp_down=DatasetInfo(
             keys=[
-                "/TTToHadronic_hdampDOWN_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM",  # noqa
+                "/TTToHadronic_hdampDOWN_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v1/NANOAODSIM",  # noqa
             ],
-            n_files=36,
-            n_events=36956000,
+            n_files=569,
+            n_events=36_956_000,
         ),
-        mtop_up=DatasetInfo(
+        hdamp_up=DatasetInfo(
             keys=[
-                "/TTToHadronic_mtop173p5_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM",  # noqa
+                "/TTToHadronic_hdampUP_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v1/NANOAODSIM",  # noqa
             ],
-            n_files=37,
-            n_events=39151000,
+            n_files=483,
+            n_events=30_504_000,
         ),
         mtop_down=DatasetInfo(
             keys=[
-                "/TTToHadronic_mtop171p5_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM",  # noqa
+                "/TTToHadronic_mtop171p5_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v1/NANOAODSIM",  # noqa
             ],
-            n_files=32,
-            n_events=32237000,
+            n_files=501,
+            n_events=32_237_000,
+        ),
+        mtop_up=DatasetInfo(
+            keys=[
+                "/TTToHadronic_mtop173p5_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v1/NANOAODSIM",  # noqa
+            ],
+            n_files=589,
+            n_events=39_151_000,
         ),
     ),
 )
@@ -244,52 +207,52 @@ cpn.add_dataset(
     info=dict(
         nominal=DatasetInfo(
             keys=[
-            "/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM",  # noqa
+                "/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v1/NANOAODSIM",  # noqa
             ],
-            n_files=124,
-            n_events=131990000,
+            n_files=1_979,
+            n_events=132_178_000,
         ),
         tune_down=DatasetInfo(
             keys=[
-            "/TTToSemiLeptonic_TuneCP5down_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM",  # noqa
+                "/TTToSemiLeptonic_TuneCP5down_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v1/NANOAODSIM",  # noqa
             ],
-            n_files=53,
-            n_events=55755500,
+            n_files=837,
+            n_events=55_755_500,
         ),
         tune_up=DatasetInfo(
             keys=[
-            "/TTToSemiLeptonic_TuneCP5up_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM",  # noqa
+                "/TTToSemiLeptonic_TuneCP5up_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v1/NANOAODSIM",  # noqa
             ],
-            n_files=44,
-            n_events=46535000,
+            n_files=690,
+            n_events=46_535_000,
         ),
         hdamp_down=DatasetInfo(
             keys=[
-            "/TTToSemiLeptonic_hdampDOWN_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM",  # noqa
+                "/TTToSemiLeptonic_hdampDOWN_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v1/NANOAODSIM",  # noqa
             ],
-            n_files=45,
-            n_events=47238000,
+            n_files=706,
+            n_events=47_238_000,
         ),
         hdamp_up=DatasetInfo(
             keys=[
-            "/TTToSemiLeptonic_hdampUP_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM",  # noqa
+                "/TTToSemiLeptonic_hdampUP_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v1/NANOAODSIM",  # noqa
             ],
-            n_files=55,
-            n_events=56968000,
-        ),
-        mtop_down=DatasetInfo(
-            keys=[
-                "/TTToSemiLeptonic_mtop171p5_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM",  # noqa
-            ],
-            n_files=52,
-            n_events=53342000,
+            n_files=818,
+            n_events=56_968_000,
         ),
         mtop_up=DatasetInfo(
             keys=[
-                "/TTToSemiLeptonic_mtop173p5_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11-v1/NANOAODSIM",  # noqa
+                "/TTToSemiLeptonic_mtop173p5_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v1/NANOAODSIM",  # noqa
             ],
-            n_files=53,
-            n_events=55256000,
+            n_files=840,
+            n_events=55_256_000,
+        ),
+        mtop_down=DatasetInfo(
+            keys=[
+                "/TTToSemiLeptonic_mtop171p5_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL16MiniAODAPVv2-106X_mcRun2_asymptotic_preVFP_v11_NanoAODAPVv12UHH-v1/NANOAODSIM",  # noqa
+            ],
+            n_files=821,
+            n_events=53_342_000,
         ),
     ),
 )

--- a/cmsdb/processes/hh2bbtautau.py
+++ b/cmsdb/processes/hh2bbtautau.py
@@ -19,7 +19,11 @@ __all__ = [
     "radion_hh_ggf_bbtautau_m800", "radion_hh_ggf_bbtautau_m850", "radion_hh_ggf_bbtautau_m900",
     "radion_hh_ggf_bbtautau_m1000", "radion_hh_ggf_bbtautau_m1250", "radion_hh_ggf_bbtautau_m1500",
     "radion_hh_ggf_bbtautau_m1750", "radion_hh_ggf_bbtautau_m2000", "radion_hh_ggf_bbtautau_m2500",
-    "radion_hh_ggf_bbtautau_m3000",
+    "radion_hh_ggf_bbtautau_m3000", "radion_hh_ggf_bbtautau_m1100", "radion_hh_ggf_bbtautau_m2400",
+    "radion_hh_ggf_bbtautau_m1300", "radion_hh_ggf_bbtautau_m1700", "radion_hh_ggf_bbtautau_m1200",
+    "radion_hh_ggf_bbtautau_m2200", "radion_hh_ggf_bbtautau_m2600", "radion_hh_ggf_bbtautau_m1400",
+    "radion_hh_ggf_bbtautau_m2800", "radion_hh_ggf_bbtautau_m1600", "radion_hh_ggf_bbtautau_m1900",
+    "radion_hh_ggf_bbtautau_m1800",
     "graviton_hh_ggf_bbtautau",
     "graviton_hh_ggf_bbtautau_m250", "graviton_hh_ggf_bbtautau_m260",
     "graviton_hh_ggf_bbtautau_m270", "graviton_hh_ggf_bbtautau_m280",
@@ -324,6 +328,78 @@ radion_hh_ggf_bbtautau_m3000 = radion_hh_ggf_bbtautau.add_process(
     xsecs={13: Number(0.1)},  # TODO
 )
 
+radion_hh_ggf_bbtautau_m1100 = radion_hh_ggf_bbtautau.add_process(
+    name="radion_hh_ggf_bbtautau_m1100",
+    id=23126,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+radion_hh_ggf_bbtautau_m2400 = radion_hh_ggf_bbtautau.add_process(
+    name="radion_hh_ggf_bbtautau_m2400",
+    id=23127,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+radion_hh_ggf_bbtautau_m1300 = radion_hh_ggf_bbtautau.add_process(
+    name="radion_hh_ggf_bbtautau_m1300",
+    id=23128,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+radion_hh_ggf_bbtautau_m1700 = radion_hh_ggf_bbtautau.add_process(
+    name="radion_hh_ggf_bbtautau_m1700",
+    id=23129,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+radion_hh_ggf_bbtautau_m1200 = radion_hh_ggf_bbtautau.add_process(
+    name="radion_hh_ggf_bbtautau_m1200",
+    id=23130,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+radion_hh_ggf_bbtautau_m2200 = radion_hh_ggf_bbtautau.add_process(
+    name="radion_hh_ggf_bbtautau_m2200",
+    id=23131,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+radion_hh_ggf_bbtautau_m2600 = radion_hh_ggf_bbtautau.add_process(
+    name="radion_hh_ggf_bbtautau_m2600",
+    id=23132,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+radion_hh_ggf_bbtautau_m1400 = radion_hh_ggf_bbtautau.add_process(
+    name="radion_hh_ggf_bbtautau_m1400",
+    id=23133,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+radion_hh_ggf_bbtautau_m2800 = radion_hh_ggf_bbtautau.add_process(
+    name="radion_hh_ggf_bbtautau_m2800",
+    id=23134,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+radion_hh_ggf_bbtautau_m1600 = radion_hh_ggf_bbtautau.add_process(
+    name="radion_hh_ggf_bbtautau_m1600",
+    id=23135,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+radion_hh_ggf_bbtautau_m1900 = radion_hh_ggf_bbtautau.add_process(
+    name="radion_hh_ggf_bbtautau_m1900",
+    id=23136,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+radion_hh_ggf_bbtautau_m1800 = radion_hh_ggf_bbtautau.add_process(
+    name="radion_hh_ggf_bbtautau_m1800",
+    id=23137,
+    xsecs={13: Number(0.1)},  # TODO
+)
 
 #
 # ggF -> bulk graviton -> HH


### PR DESCRIPTION
New:

- 2016 custom `NanoAoD` paths for `data`, `ewk`, `hh2bbtautau`, `st`, `ttbar` processes
- Added few new `hh2bbtautau` BSM (radion) processes, needed for some new datasets