### PR TITLE
Feature/update campaign tests

### DIFF
--- a/cmsdb/campaigns/run2_2016_HIPM_nano_uhh_v12/ttbar.py
+++ b/cmsdb/campaigns/run2_2016_HIPM_nano_uhh_v12/ttbar.py
@@ -49,7 +49,7 @@ cpn.add_dataset(
 
 # TTWJetsToLNu
 cpn.add_dataset(
-    name="ttw_nlu_amcatnlo",
+    name="ttw_lnu_amcatnlo",
     id=14251563,
     processes=[procs.ttw_lnu],
     keys=[

--- a/cmsdb/campaigns/run2_2016_nano_uhh_v12/hh2bbtautau.py
+++ b/cmsdb/campaigns/run2_2016_nano_uhh_v12/hh2bbtautau.py
@@ -1245,7 +1245,7 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="graviton_hh_vbf_bbtautau_m2000_madgrap",
+    name="graviton_hh_vbf_bbtautau_m2000_madgraph",
     id=14309506,
     processes=[procs.graviton_hh_vbf_bbtautau_m2000],
     keys=[

--- a/cmsdb/campaigns/run2_2016_nano_uhh_v12/top.py
+++ b/cmsdb/campaigns/run2_2016_nano_uhh_v12/top.py
@@ -288,7 +288,7 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="ttww_madgrap",
+    name="ttww_madgraph",
     id=14215222,
     processes=[procs.ttww],
     keys=[

--- a/cmsdb/campaigns/run2_2017_nano_uhh_v11/top.py
+++ b/cmsdb/campaigns/run2_2017_nano_uhh_v11/top.py
@@ -64,7 +64,7 @@ cpn.add_dataset(
 
 
 cpn.add_dataset(
-    name="ttw_nlu_amcatnlo",
+    name="ttw_lnu_amcatnlo",
     id=14197077,
     processes=[procs.ttw_lnu],
     keys=[

--- a/cmsdb/campaigns/run2_2017_nano_v9/top.py
+++ b/cmsdb/campaigns/run2_2017_nano_v9/top.py
@@ -221,7 +221,7 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="ttw_nlu_amcatnlo",
+    name="ttw_lnu_amcatnlo",
     id=14228083,
     processes=[procs.ttw_lnu],
     info=dict(

--- a/cmsdb/campaigns/run2_2018_nano_v9/__init__.py
+++ b/cmsdb/campaigns/run2_2018_nano_v9/__init__.py
@@ -43,7 +43,7 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="st_tchannel_t",
+    name="st_tchannel_t_powheg",
     id=14293903,
     processes=[procs.st_tchannel_t],
     info=dict(
@@ -86,7 +86,7 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="st_tchannel_tbar",
+    name="st_tchannel_tbar_powheg",
     id=14296756,
     processes=[procs.st_tchannel_tbar],
     info=dict(
@@ -129,7 +129,7 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="st_twchannel_t",
+    name="st_twchannel_t_powheg",
     id=14248830,
     processes=[procs.st_twchannel_t],
     info=dict(
@@ -144,7 +144,7 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="st_twchannel_tbar",
+    name="st_twchannel_tbar_powheg",
     id=14253778,
     processes=[procs.st_twchannel_tbar],
     info=dict(
@@ -159,7 +159,7 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="tt_sl",
+    name="tt_sl_powheg",
     id=14235437,
     processes=[procs.tt_sl],
     info=dict(
@@ -202,7 +202,7 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="tt_dl",
+    name="tt_dl_powheg",
     id=14234474,
     processes=[procs.tt_dl],
     info=dict(
@@ -245,7 +245,7 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="tt_fh",
+    name="tt_fh_powheg",
     id=14232068,
     processes=[procs.tt_fh],
     info=dict(

--- a/cmsdb/campaigns/run3_2022_postEE_nano_v12/top.py
+++ b/cmsdb/campaigns/run3_2022_postEE_nano_v12/top.py
@@ -22,7 +22,6 @@ cpn.add_dataset(
         nominal=DatasetInfo(
             keys=[
                 "/TTtoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
-
             ],
             n_files=523,
             n_events=267007920,
@@ -30,7 +29,6 @@ cpn.add_dataset(
         extension=DatasetInfo(
             keys=[
                 "/TTtoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6_ext1-v2/NANOAODSIM",  # noqa
-
             ],
             n_files=1786,
             n_events=275339453,
@@ -701,7 +699,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="st_twchannel_tbar_dl_powheg",
     id=14791494,
-    processes=[procs.st_twchannel_t_dl],
+    processes=[procs.st_twchannel_tbar_dl],
     info=dict(
         nominal=DatasetInfo(
             keys=[


### PR DESCRIPTION
This PR extends the campaign tests by a check of the generator name of the file.
Additionally, an optional test is added that checks the compatibility between dataset and process names. Since this is not fulfilled by all datasets, the test is currently disabled.
Finally, some inconsistencies in dataset names are fixed.