### PR TITLE
PR: add A->ZH samples to CMSDB

### DIFF
--- a/cmsdb/campaigns/run2_2017_nano_v9/__init__.py
+++ b/cmsdb/campaigns/run2_2017_nano_v9/__init__.py
@@ -30,6 +30,7 @@ campaign_run2_2017_nano_v9 = Campaign(
 
 # trailing imports to load datasets
 import cmsdb.campaigns.run2_2017_nano_v9.data  # noqa
+import cmsdb.campaigns.run2_2017_nano_v9.azh  # noqa
 import cmsdb.campaigns.run2_2017_nano_v9.top  # noqa
 import cmsdb.campaigns.run2_2017_nano_v9.ewk  # noqa
 import cmsdb.campaigns.run2_2017_nano_v9.qcd  # noqa

--- a/cmsdb/campaigns/run2_2017_nano_v9/azh.py
+++ b/cmsdb/campaigns/run2_2017_nano_v9/azh.py
@@ -12,11 +12,10 @@ from cmsdb.campaigns.run2_2017_nano_v9 import campaign_run2_2017_nano_v9 as cpn
 # AZH->Ztt->lltt
 #
 
-
 cpn.add_dataset(
     name="azh_ttll_a1000_h330",
     id=14640747,
-    processes=["procs.azh_ttll_a1000_h330"],
+    processes=[procs.azh_ttll_a1000_h330],
     keys=[
         "/AToZHToLLTTbar_MA-1000_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -26,7 +25,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1000_h350",
     id=14640749,
-    processes=["procs.azh_ttll_a1000_h350"],
+    processes=[procs.azh_ttll_a1000_h350],
     keys=[
         "/AToZHToLLTTbar_MA-1000_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -36,7 +35,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1000_h400",
     id=14644922,
-    processes=["procs.azh_ttll_a1000_h400"],
+    processes=[procs.azh_ttll_a1000_h400],
     keys=[
         "/AToZHToLLTTbar_MA-1000_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -46,7 +45,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1000_h450",
     id=14644445,
-    processes=["procs.azh_ttll_a1000_h450"],
+    processes=[procs.azh_ttll_a1000_h450],
     keys=[
         "/AToZHToLLTTbar_MA-1000_MH-450_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -56,7 +55,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1000_h500",
     id=14644631,
-    processes=["procs.azh_ttll_a1000_h500"],
+    processes=[procs.azh_ttll_a1000_h500],
     keys=[
         "/AToZHToLLTTbar_MA-1000_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -66,7 +65,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1000_h550",
     id=14637796,
-    processes=["procs.azh_ttll_a1000_h550"],
+    processes=[procs.azh_ttll_a1000_h550],
     keys=[
         "/AToZHToLLTTbar_MA-1000_MH-550_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -76,7 +75,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1000_h600",
     id=14548924,
-    processes=["procs.azh_ttll_a1000_h600"],
+    processes=[procs.azh_ttll_a1000_h600],
     keys=[
         "/AToZHToLLTTbar_MA-1000_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -86,7 +85,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1000_h650",
     id=14643976,
-    processes=["procs.azh_ttll_a1000_h650"],
+    processes=[procs.azh_ttll_a1000_h650],
     keys=[
         "/AToZHToLLTTbar_MA-1000_MH-650_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -96,7 +95,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1000_h700",
     id=14536925,
-    processes=["procs.azh_ttll_a1000_h700"],
+    processes=[procs.azh_ttll_a1000_h700],
     keys=[
         "/AToZHToLLTTbar_MA-1000_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -106,7 +105,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1000_h750",
     id=14636760,
-    processes=["procs.azh_ttll_a1000_h750"],
+    processes=[procs.azh_ttll_a1000_h750],
     keys=[
         "/AToZHToLLTTbar_MA-1000_MH-750_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -116,7 +115,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1000_h800",
     id=14548527,
-    processes=["procs.azh_ttll_a1000_h800"],
+    processes=[procs.azh_ttll_a1000_h800],
     keys=[
         "/AToZHToLLTTbar_MA-1000_MH-800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -126,7 +125,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1000_h850",
     id=14644480,
-    processes=["procs.azh_ttll_a1000_h850"],
+    processes=[procs.azh_ttll_a1000_h850],
     keys=[
         "/AToZHToLLTTbar_MA-1000_MH-850_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -136,7 +135,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1000_h900",
     id=14641365,
-    processes=["procs.azh_ttll_a1000_h900"],
+    processes=[procs.azh_ttll_a1000_h900],
     keys=[
         "/AToZHToLLTTbar_MA-1000_MH-900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -146,7 +145,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1050_h330",
     id=14644650,
-    processes=["procs.azh_ttll_a1050_h330"],
+    processes=[procs.azh_ttll_a1050_h330],
     keys=[
         "/AToZHToLLTTbar_MA-1050_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -156,7 +155,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1050_h350",
     id=14636601,
-    processes=["procs.azh_ttll_a1050_h350"],
+    processes=[procs.azh_ttll_a1050_h350],
     keys=[
         "/AToZHToLLTTbar_MA-1050_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -166,7 +165,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1050_h400",
     id=14637383,
-    processes=["procs.azh_ttll_a1050_h400"],
+    processes=[procs.azh_ttll_a1050_h400],
     keys=[
         "/AToZHToLLTTbar_MA-1050_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -176,7 +175,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1050_h450",
     id=14643202,
-    processes=["procs.azh_ttll_a1050_h450"],
+    processes=[procs.azh_ttll_a1050_h450],
     keys=[
         "/AToZHToLLTTbar_MA-1050_MH-450_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -186,7 +185,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1050_h500",
     id=14645580,
-    processes=["procs.azh_ttll_a1050_h500"],
+    processes=[procs.azh_ttll_a1050_h500],
     keys=[
         "/AToZHToLLTTbar_MA-1050_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -196,7 +195,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1050_h550",
     id=14637742,
-    processes=["procs.azh_ttll_a1050_h550"],
+    processes=[procs.azh_ttll_a1050_h550],
     keys=[
         "/AToZHToLLTTbar_MA-1050_MH-550_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -206,7 +205,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1050_h600",
     id=14637456,
-    processes=["procs.azh_ttll_a1050_h600"],
+    processes=[procs.azh_ttll_a1050_h600],
     keys=[
         "/AToZHToLLTTbar_MA-1050_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -216,7 +215,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1050_h700",
     id=14638692,
-    processes=["procs.azh_ttll_a1050_h700"],
+    processes=[procs.azh_ttll_a1050_h700],
     keys=[
         "/AToZHToLLTTbar_MA-1050_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -226,7 +225,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1050_h750",
     id=14637603,
-    processes=["procs.azh_ttll_a1050_h750"],
+    processes=[procs.azh_ttll_a1050_h750],
     keys=[
         "/AToZHToLLTTbar_MA-1050_MH-750_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -236,7 +235,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1050_h800",
     id=14639246,
-    processes=["procs.azh_ttll_a1050_h800"],
+    processes=[procs.azh_ttll_a1050_h800],
     keys=[
         "/AToZHToLLTTbar_MA-1050_MH-800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -246,7 +245,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1050_h850",
     id=14641223,
-    processes=["procs.azh_ttll_a1050_h850"],
+    processes=[procs.azh_ttll_a1050_h850],
     keys=[
         "/AToZHToLLTTbar_MA-1050_MH-850_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -256,7 +255,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1050_h900",
     id=14645437,
-    processes=["procs.azh_ttll_a1050_h900"],
+    processes=[procs.azh_ttll_a1050_h900],
     keys=[
         "/AToZHToLLTTbar_MA-1050_MH-900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -266,7 +265,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1050_h950",
     id=14644029,
-    processes=["procs.azh_ttll_a1050_h950"],
+    processes=[procs.azh_ttll_a1050_h950],
     keys=[
         "/AToZHToLLTTbar_MA-1050_MH-950_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -276,7 +275,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1100_h1000",
     id=14638003,
-    processes=["procs.azh_ttll_a1100_h1000"],
+    processes=[procs.azh_ttll_a1100_h1000],
     keys=[
         "/AToZHToLLTTbar_MA-1100_MH-1000_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -286,7 +285,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1100_h330",
     id=14643995,
-    processes=["procs.azh_ttll_a1100_h330"],
+    processes=[procs.azh_ttll_a1100_h330],
     keys=[
         "/AToZHToLLTTbar_MA-1100_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -296,7 +295,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1100_h350",
     id=14643757,
-    processes=["procs.azh_ttll_a1100_h350"],
+    processes=[procs.azh_ttll_a1100_h350],
     keys=[
         "/AToZHToLLTTbar_MA-1100_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -306,7 +305,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1100_h400",
     id=14644862,
-    processes=["procs.azh_ttll_a1100_h400"],
+    processes=[procs.azh_ttll_a1100_h400],
     keys=[
         "/AToZHToLLTTbar_MA-1100_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -316,7 +315,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1100_h450",
     id=14641209,
-    processes=["procs.azh_ttll_a1100_h450"],
+    processes=[procs.azh_ttll_a1100_h450],
     keys=[
         "/AToZHToLLTTbar_MA-1100_MH-450_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -326,7 +325,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1100_h500",
     id=14643951,
-    processes=["procs.azh_ttll_a1100_h500"],
+    processes=[procs.azh_ttll_a1100_h500],
     keys=[
         "/AToZHToLLTTbar_MA-1100_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -336,7 +335,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1100_h550",
     id=14640899,
-    processes=["procs.azh_ttll_a1100_h550"],
+    processes=[procs.azh_ttll_a1100_h550],
     keys=[
         "/AToZHToLLTTbar_MA-1100_MH-550_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -346,7 +345,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1100_h600",
     id=14640946,
-    processes=["procs.azh_ttll_a1100_h600"],
+    processes=[procs.azh_ttll_a1100_h600],
     keys=[
         "/AToZHToLLTTbar_MA-1100_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -356,7 +355,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1100_h650",
     id=14640680,
-    processes=["procs.azh_ttll_a1100_h650"],
+    processes=[procs.azh_ttll_a1100_h650],
     keys=[
         "/AToZHToLLTTbar_MA-1100_MH-650_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -366,7 +365,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1100_h700",
     id=14645549,
-    processes=["procs.azh_ttll_a1100_h700"],
+    processes=[procs.azh_ttll_a1100_h700],
     keys=[
         "/AToZHToLLTTbar_MA-1100_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -376,7 +375,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1100_h750",
     id=14637895,
-    processes=["procs.azh_ttll_a1100_h750"],
+    processes=[procs.azh_ttll_a1100_h750],
     keys=[
         "/AToZHToLLTTbar_MA-1100_MH-750_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -386,7 +385,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1100_h800",
     id=14636438,
-    processes=["procs.azh_ttll_a1100_h800"],
+    processes=[procs.azh_ttll_a1100_h800],
     keys=[
         "/AToZHToLLTTbar_MA-1100_MH-800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -396,7 +395,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1100_h850",
     id=14643264,
-    processes=["procs.azh_ttll_a1100_h850"],
+    processes=[procs.azh_ttll_a1100_h850],
     keys=[
         "/AToZHToLLTTbar_MA-1100_MH-850_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -406,7 +405,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1100_h900",
     id=14641361,
-    processes=["procs.azh_ttll_a1100_h900"],
+    processes=[procs.azh_ttll_a1100_h900],
     keys=[
         "/AToZHToLLTTbar_MA-1100_MH-900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -416,7 +415,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1100_h950",
     id=14641067,
-    processes=["procs.azh_ttll_a1100_h950"],
+    processes=[procs.azh_ttll_a1100_h950],
     keys=[
         "/AToZHToLLTTbar_MA-1100_MH-950_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -426,7 +425,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1150_h1050",
     id=14637047,
-    processes=["procs.azh_ttll_a1150_h1050"],
+    processes=[procs.azh_ttll_a1150_h1050],
     keys=[
         "/AToZHToLLTTbar_MA-1150_MH-1050_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -436,7 +435,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1150_h330",
     id=14645065,
-    processes=["procs.azh_ttll_a1150_h330"],
+    processes=[procs.azh_ttll_a1150_h330],
     keys=[
         "/AToZHToLLTTbar_MA-1150_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -446,7 +445,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1150_h350",
     id=14641502,
-    processes=["procs.azh_ttll_a1150_h350"],
+    processes=[procs.azh_ttll_a1150_h350],
     keys=[
         "/AToZHToLLTTbar_MA-1150_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -456,7 +455,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1150_h450",
     id=14638090,
-    processes=["procs.azh_ttll_a1150_h450"],
+    processes=[procs.azh_ttll_a1150_h450],
     keys=[
         "/AToZHToLLTTbar_MA-1150_MH-450_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -466,7 +465,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1150_h550",
     id=14645380,
-    processes=["procs.azh_ttll_a1150_h550"],
+    processes=[procs.azh_ttll_a1150_h550],
     keys=[
         "/AToZHToLLTTbar_MA-1150_MH-550_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -476,7 +475,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1150_h650",
     id=14637436,
-    processes=["procs.azh_ttll_a1150_h650"],
+    processes=[procs.azh_ttll_a1150_h650],
     keys=[
         "/AToZHToLLTTbar_MA-1150_MH-650_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -486,7 +485,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1150_h750",
     id=14644493,
-    processes=["procs.azh_ttll_a1150_h750"],
+    processes=[procs.azh_ttll_a1150_h750],
     keys=[
         "/AToZHToLLTTbar_MA-1150_MH-750_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -496,7 +495,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1150_h850",
     id=14645060,
-    processes=["procs.azh_ttll_a1150_h850"],
+    processes=[procs.azh_ttll_a1150_h850],
     keys=[
         "/AToZHToLLTTbar_MA-1150_MH-850_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -506,7 +505,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1150_h950",
     id=14644915,
-    processes=["procs.azh_ttll_a1150_h950"],
+    processes=[procs.azh_ttll_a1150_h950],
     keys=[
         "/AToZHToLLTTbar_MA-1150_MH-950_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -516,7 +515,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1200_h1000",
     id=14543193,
-    processes=["procs.azh_ttll_a1200_h1000"],
+    processes=[procs.azh_ttll_a1200_h1000],
     keys=[
         "/AToZHToLLTTbar_MA-1200_MH-1000_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -526,7 +525,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1200_h1100",
     id=14644025,
-    processes=["procs.azh_ttll_a1200_h1100"],
+    processes=[procs.azh_ttll_a1200_h1100],
     keys=[
         "/AToZHToLLTTbar_MA-1200_MH-1100_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -536,7 +535,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1200_h330",
     id=14637970,
-    processes=["procs.azh_ttll_a1200_h330"],
+    processes=[procs.azh_ttll_a1200_h330],
     keys=[
         "/AToZHToLLTTbar_MA-1200_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -546,7 +545,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1200_h350",
     id=14644005,
-    processes=["procs.azh_ttll_a1200_h350"],
+    processes=[procs.azh_ttll_a1200_h350],
     keys=[
         "/AToZHToLLTTbar_MA-1200_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -556,7 +555,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1200_h400",
     id=14647612,
-    processes=["procs.azh_ttll_a1200_h400"],
+    processes=[procs.azh_ttll_a1200_h400],
     keys=[
         "/AToZHToLLTTbar_MA-1200_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -566,7 +565,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1200_h500",
     id=14644884,
-    processes=["procs.azh_ttll_a1200_h500"],
+    processes=[procs.azh_ttll_a1200_h500],
     keys=[
         "/AToZHToLLTTbar_MA-1200_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -576,7 +575,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1200_h600",
     id=14644415,
-    processes=["procs.azh_ttll_a1200_h600"],
+    processes=[procs.azh_ttll_a1200_h600],
     keys=[
         "/AToZHToLLTTbar_MA-1200_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -586,7 +585,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1200_h700",
     id=14641569,
-    processes=["procs.azh_ttll_a1200_h700"],
+    processes=[procs.azh_ttll_a1200_h700],
     keys=[
         "/AToZHToLLTTbar_MA-1200_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -596,7 +595,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1200_h800",
     id=14639844,
-    processes=["procs.azh_ttll_a1200_h800"],
+    processes=[procs.azh_ttll_a1200_h800],
     keys=[
         "/AToZHToLLTTbar_MA-1200_MH-800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -606,7 +605,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1200_h850",
     id=14549534,
-    processes=["procs.azh_ttll_a1200_h850"],
+    processes=[procs.azh_ttll_a1200_h850],
     keys=[
         "/AToZHToLLTTbar_MA-1200_MH-850_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -616,7 +615,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1200_h900",
     id=14641099,
-    processes=["procs.azh_ttll_a1200_h900"],
+    processes=[procs.azh_ttll_a1200_h900],
     keys=[
         "/AToZHToLLTTbar_MA-1200_MH-900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -626,7 +625,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1300_h1000",
     id=14640819,
-    processes=["procs.azh_ttll_a1300_h1000"],
+    processes=[procs.azh_ttll_a1300_h1000],
     keys=[
         "/AToZHToLLTTbar_MA-1300_MH-1000_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -636,7 +635,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1300_h1100",
     id=14641489,
-    processes=["procs.azh_ttll_a1300_h1100"],
+    processes=[procs.azh_ttll_a1300_h1100],
     keys=[
         "/AToZHToLLTTbar_MA-1300_MH-1100_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -646,7 +645,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1300_h1200",
     id=14644883,
-    processes=["procs.azh_ttll_a1300_h1200"],
+    processes=[procs.azh_ttll_a1300_h1200],
     keys=[
         "/AToZHToLLTTbar_MA-1300_MH-1200_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -656,7 +655,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1300_h350",
     id=14645154,
-    processes=["procs.azh_ttll_a1300_h350"],
+    processes=[procs.azh_ttll_a1300_h350],
     keys=[
         "/AToZHToLLTTbar_MA-1300_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -666,7 +665,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1300_h400",
     id=14639378,
-    processes=["procs.azh_ttll_a1300_h400"],
+    processes=[procs.azh_ttll_a1300_h400],
     keys=[
         "/AToZHToLLTTbar_MA-1300_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -676,7 +675,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1300_h500",
     id=14640835,
-    processes=["procs.azh_ttll_a1300_h500"],
+    processes=[procs.azh_ttll_a1300_h500],
     keys=[
         "/AToZHToLLTTbar_MA-1300_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -686,7 +685,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1300_h600",
     id=14645563,
-    processes=["procs.azh_ttll_a1300_h600"],
+    processes=[procs.azh_ttll_a1300_h600],
     keys=[
         "/AToZHToLLTTbar_MA-1300_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -696,7 +695,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1300_h700",
     id=14637957,
-    processes=["procs.azh_ttll_a1300_h700"],
+    processes=[procs.azh_ttll_a1300_h700],
     keys=[
         "/AToZHToLLTTbar_MA-1300_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -706,7 +705,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1300_h800",
     id=14644759,
-    processes=["procs.azh_ttll_a1300_h800"],
+    processes=[procs.azh_ttll_a1300_h800],
     keys=[
         "/AToZHToLLTTbar_MA-1300_MH-800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -716,7 +715,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1300_h900",
     id=14636843,
-    processes=["procs.azh_ttll_a1300_h900"],
+    processes=[procs.azh_ttll_a1300_h900],
     keys=[
         "/AToZHToLLTTbar_MA-1300_MH-900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -726,7 +725,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1400_h1000",
     id=14641266,
-    processes=["procs.azh_ttll_a1400_h1000"],
+    processes=[procs.azh_ttll_a1400_h1000],
     keys=[
         "/AToZHToLLTTbar_MA-1400_MH-1000_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -736,7 +735,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1400_h1100",
     id=14643808,
-    processes=["procs.azh_ttll_a1400_h1100"],
+    processes=[procs.azh_ttll_a1400_h1100],
     keys=[
         "/AToZHToLLTTbar_MA-1400_MH-1100_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -746,7 +745,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1400_h1200",
     id=14645021,
-    processes=["procs.azh_ttll_a1400_h1200"],
+    processes=[procs.azh_ttll_a1400_h1200],
     keys=[
         "/AToZHToLLTTbar_MA-1400_MH-1200_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -756,7 +755,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1400_h1300",
     id=14640339,
-    processes=["procs.azh_ttll_a1400_h1300"],
+    processes=[procs.azh_ttll_a1400_h1300],
     keys=[
         "/AToZHToLLTTbar_MA-1400_MH-1300_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -766,7 +765,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1400_h350",
     id=14636494,
-    processes=["procs.azh_ttll_a1400_h350"],
+    processes=[procs.azh_ttll_a1400_h350],
     keys=[
         "/AToZHToLLTTbar_MA-1400_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -776,7 +775,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1400_h400",
     id=14644419,
-    processes=["procs.azh_ttll_a1400_h400"],
+    processes=[procs.azh_ttll_a1400_h400],
     keys=[
         "/AToZHToLLTTbar_MA-1400_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -786,7 +785,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1400_h500",
     id=14640681,
-    processes=["procs.azh_ttll_a1400_h500"],
+    processes=[procs.azh_ttll_a1400_h500],
     keys=[
         "/AToZHToLLTTbar_MA-1400_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -796,7 +795,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1400_h600",
     id=14643451,
-    processes=["procs.azh_ttll_a1400_h600"],
+    processes=[procs.azh_ttll_a1400_h600],
     keys=[
         "/AToZHToLLTTbar_MA-1400_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -806,7 +805,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1400_h700",
     id=14641327,
-    processes=["procs.azh_ttll_a1400_h700"],
+    processes=[procs.azh_ttll_a1400_h700],
     keys=[
         "/AToZHToLLTTbar_MA-1400_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -816,7 +815,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1400_h800",
     id=14644989,
-    processes=["procs.azh_ttll_a1400_h800"],
+    processes=[procs.azh_ttll_a1400_h800],
     keys=[
         "/AToZHToLLTTbar_MA-1400_MH-800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -826,7 +825,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1400_h900",
     id=14645622,
-    processes=["procs.azh_ttll_a1400_h900"],
+    processes=[procs.azh_ttll_a1400_h900],
     keys=[
         "/AToZHToLLTTbar_MA-1400_MH-900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -836,7 +835,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1500_h1000",
     id=14647495,
-    processes=["procs.azh_ttll_a1500_h1000"],
+    processes=[procs.azh_ttll_a1500_h1000],
     keys=[
         "/AToZHToLLTTbar_MA-1500_MH-1000_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -846,7 +845,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1500_h1100",
     id=14641077,
-    processes=["procs.azh_ttll_a1500_h1100"],
+    processes=[procs.azh_ttll_a1500_h1100],
     keys=[
         "/AToZHToLLTTbar_MA-1500_MH-1100_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -856,7 +855,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1500_h1200",
     id=14644354,
-    processes=["procs.azh_ttll_a1500_h1200"],
+    processes=[procs.azh_ttll_a1500_h1200],
     keys=[
         "/AToZHToLLTTbar_MA-1500_MH-1200_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -866,7 +865,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1500_h1300",
     id=14638120,
-    processes=["procs.azh_ttll_a1500_h1300"],
+    processes=[procs.azh_ttll_a1500_h1300],
     keys=[
         "/AToZHToLLTTbar_MA-1500_MH-1300_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -876,7 +875,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1500_h1400",
     id=14647514,
-    processes=["procs.azh_ttll_a1500_h1400"],
+    processes=[procs.azh_ttll_a1500_h1400],
     keys=[
         "/AToZHToLLTTbar_MA-1500_MH-1400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -886,7 +885,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1500_h350",
     id=14645022,
-    processes=["procs.azh_ttll_a1500_h350"],
+    processes=[procs.azh_ttll_a1500_h350],
     keys=[
         "/AToZHToLLTTbar_MA-1500_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -896,7 +895,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1500_h400",
     id=14548215,
-    processes=["procs.azh_ttll_a1500_h400"],
+    processes=[procs.azh_ttll_a1500_h400],
     keys=[
         "/AToZHToLLTTbar_MA-1500_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -906,7 +905,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1500_h500",
     id=14641173,
-    processes=["procs.azh_ttll_a1500_h500"],
+    processes=[procs.azh_ttll_a1500_h500],
     keys=[
         "/AToZHToLLTTbar_MA-1500_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -916,7 +915,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1500_h600",
     id=14637940,
-    processes=["procs.azh_ttll_a1500_h600"],
+    processes=[procs.azh_ttll_a1500_h600],
     keys=[
         "/AToZHToLLTTbar_MA-1500_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -926,7 +925,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1500_h700",
     id=14640888,
-    processes=["procs.azh_ttll_a1500_h700"],
+    processes=[procs.azh_ttll_a1500_h700],
     keys=[
         "/AToZHToLLTTbar_MA-1500_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -936,7 +935,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1500_h900",
     id=14643452,
-    processes=["procs.azh_ttll_a1500_h900"],
+    processes=[procs.azh_ttll_a1500_h900],
     keys=[
         "/AToZHToLLTTbar_MA-1500_MH-900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -946,7 +945,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1600_h1000",
     id=14641468,
-    processes=["procs.azh_ttll_a1600_h1000"],
+    processes=[procs.azh_ttll_a1600_h1000],
     keys=[
         "/AToZHToLLTTbar_MA-1600_MH-1000_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -956,7 +955,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1600_h1100",
     id=14637407,
-    processes=["procs.azh_ttll_a1600_h1100"],
+    processes=[procs.azh_ttll_a1600_h1100],
     keys=[
         "/AToZHToLLTTbar_MA-1600_MH-1100_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -966,7 +965,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1600_h1200",
     id=14638121,
-    processes=["procs.azh_ttll_a1600_h1200"],
+    processes=[procs.azh_ttll_a1600_h1200],
     keys=[
         "/AToZHToLLTTbar_MA-1600_MH-1200_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -976,7 +975,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1600_h1300",
     id=14641294,
-    processes=["procs.azh_ttll_a1600_h1300"],
+    processes=[procs.azh_ttll_a1600_h1300],
     keys=[
         "/AToZHToLLTTbar_MA-1600_MH-1300_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -986,7 +985,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1600_h1400",
     id=14636598,
-    processes=["procs.azh_ttll_a1600_h1400"],
+    processes=[procs.azh_ttll_a1600_h1400],
     keys=[
         "/AToZHToLLTTbar_MA-1600_MH-1400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -996,7 +995,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1600_h1500",
     id=14641495,
-    processes=["procs.azh_ttll_a1600_h1500"],
+    processes=[procs.azh_ttll_a1600_h1500],
     keys=[
         "/AToZHToLLTTbar_MA-1600_MH-1500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1006,7 +1005,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1600_h350",
     id=14637598,
-    processes=["procs.azh_ttll_a1600_h350"],
+    processes=[procs.azh_ttll_a1600_h350],
     keys=[
         "/AToZHToLLTTbar_MA-1600_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1016,7 +1015,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1600_h400",
     id=14644182,
-    processes=["procs.azh_ttll_a1600_h400"],
+    processes=[procs.azh_ttll_a1600_h400],
     keys=[
         "/AToZHToLLTTbar_MA-1600_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1026,7 +1025,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1600_h500",
     id=14641368,
-    processes=["procs.azh_ttll_a1600_h500"],
+    processes=[procs.azh_ttll_a1600_h500],
     keys=[
         "/AToZHToLLTTbar_MA-1600_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1036,7 +1035,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1600_h600",
     id=14644439,
-    processes=["procs.azh_ttll_a1600_h600"],
+    processes=[procs.azh_ttll_a1600_h600],
     keys=[
         "/AToZHToLLTTbar_MA-1600_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1046,7 +1045,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1600_h900",
     id=14640009,
-    processes=["procs.azh_ttll_a1600_h900"],
+    processes=[procs.azh_ttll_a1600_h900],
     keys=[
         "/AToZHToLLTTbar_MA-1600_MH-900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1056,7 +1055,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1700_h1000",
     id=14640900,
-    processes=["procs.azh_ttll_a1700_h1000"],
+    processes=[procs.azh_ttll_a1700_h1000],
     keys=[
         "/AToZHToLLTTbar_MA-1700_MH-1000_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1066,7 +1065,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1700_h1100",
     id=14645008,
-    processes=["procs.azh_ttll_a1700_h1100"],
+    processes=[procs.azh_ttll_a1700_h1100],
     keys=[
         "/AToZHToLLTTbar_MA-1700_MH-1100_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1076,7 +1075,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1700_h1200",
     id=14644904,
-    processes=["procs.azh_ttll_a1700_h1200"],
+    processes=[procs.azh_ttll_a1700_h1200],
     keys=[
         "/AToZHToLLTTbar_MA-1700_MH-1200_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1086,7 +1085,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1700_h1300",
     id=14636430,
-    processes=["procs.azh_ttll_a1700_h1300"],
+    processes=[procs.azh_ttll_a1700_h1300],
     keys=[
         "/AToZHToLLTTbar_MA-1700_MH-1300_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1096,7 +1095,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1700_h1400",
     id=14636571,
-    processes=["procs.azh_ttll_a1700_h1400"],
+    processes=[procs.azh_ttll_a1700_h1400],
     keys=[
         "/AToZHToLLTTbar_MA-1700_MH-1400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1106,7 +1105,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1700_h1500",
     id=14638199,
-    processes=["procs.azh_ttll_a1700_h1500"],
+    processes=[procs.azh_ttll_a1700_h1500],
     keys=[
         "/AToZHToLLTTbar_MA-1700_MH-1500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1116,7 +1115,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1700_h1600",
     id=14641481,
-    processes=["procs.azh_ttll_a1700_h1600"],
+    processes=[procs.azh_ttll_a1700_h1600],
     keys=[
         "/AToZHToLLTTbar_MA-1700_MH-1600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1126,7 +1125,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1700_h350",
     id=14645023,
-    processes=["procs.azh_ttll_a1700_h350"],
+    processes=[procs.azh_ttll_a1700_h350],
     keys=[
         "/AToZHToLLTTbar_MA-1700_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1136,7 +1135,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1700_h400",
     id=14645452,
-    processes=["procs.azh_ttll_a1700_h400"],
+    processes=[procs.azh_ttll_a1700_h400],
     keys=[
         "/AToZHToLLTTbar_MA-1700_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1146,7 +1145,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1700_h500",
     id=14636536,
-    processes=["procs.azh_ttll_a1700_h500"],
+    processes=[procs.azh_ttll_a1700_h500],
     keys=[
         "/AToZHToLLTTbar_MA-1700_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1156,7 +1155,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1700_h600",
     id=14644424,
-    processes=["procs.azh_ttll_a1700_h600"],
+    processes=[procs.azh_ttll_a1700_h600],
     keys=[
         "/AToZHToLLTTbar_MA-1700_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1166,7 +1165,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1700_h700",
     id=14636781,
-    processes=["procs.azh_ttll_a1700_h700"],
+    processes=[procs.azh_ttll_a1700_h700],
     keys=[
         "/AToZHToLLTTbar_MA-1700_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1176,7 +1175,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1700_h800",
     id=14644001,
-    processes=["procs.azh_ttll_a1700_h800"],
+    processes=[procs.azh_ttll_a1700_h800],
     keys=[
         "/AToZHToLLTTbar_MA-1700_MH-800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1186,7 +1185,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1700_h900",
     id=14637536,
-    processes=["procs.azh_ttll_a1700_h900"],
+    processes=[procs.azh_ttll_a1700_h900],
     keys=[
         "/AToZHToLLTTbar_MA-1700_MH-900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1196,7 +1195,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1800_h1000",
     id=14636446,
-    processes=["procs.azh_ttll_a1800_h1000"],
+    processes=[procs.azh_ttll_a1800_h1000],
     keys=[
         "/AToZHToLLTTbar_MA-1800_MH-1000_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1206,7 +1205,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1800_h1100",
     id=14645028,
-    processes=["procs.azh_ttll_a1800_h1100"],
+    processes=[procs.azh_ttll_a1800_h1100],
     keys=[
         "/AToZHToLLTTbar_MA-1800_MH-1100_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1216,7 +1215,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1800_h1200",
     id=14644991,
-    processes=["procs.azh_ttll_a1800_h1200"],
+    processes=[procs.azh_ttll_a1800_h1200],
     keys=[
         "/AToZHToLLTTbar_MA-1800_MH-1200_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1226,7 +1225,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1800_h1300",
     id=14643136,
-    processes=["procs.azh_ttll_a1800_h1300"],
+    processes=[procs.azh_ttll_a1800_h1300],
     keys=[
         "/AToZHToLLTTbar_MA-1800_MH-1300_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1236,7 +1235,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1800_h1400",
     id=14644377,
-    processes=["procs.azh_ttll_a1800_h1400"],
+    processes=[procs.azh_ttll_a1800_h1400],
     keys=[
         "/AToZHToLLTTbar_MA-1800_MH-1400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1246,7 +1245,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1800_h1500",
     id=14641545,
-    processes=["procs.azh_ttll_a1800_h1500"],
+    processes=[procs.azh_ttll_a1800_h1500],
     keys=[
         "/AToZHToLLTTbar_MA-1800_MH-1500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1256,7 +1255,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1800_h1600",
     id=14536346,
-    processes=["procs.azh_ttll_a1800_h1600"],
+    processes=[procs.azh_ttll_a1800_h1600],
     keys=[
         "/AToZHToLLTTbar_MA-1800_MH-1600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1266,7 +1265,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1800_h1700",
     id=14638264,
-    processes=["procs.azh_ttll_a1800_h1700"],
+    processes=[procs.azh_ttll_a1800_h1700],
     keys=[
         "/AToZHToLLTTbar_MA-1800_MH-1700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1276,7 +1275,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1800_h350",
     id=14645239,
-    processes=["procs.azh_ttll_a1800_h350"],
+    processes=[procs.azh_ttll_a1800_h350],
     keys=[
         "/AToZHToLLTTbar_MA-1800_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1286,7 +1285,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1800_h400",
     id=14647680,
-    processes=["procs.azh_ttll_a1800_h400"],
+    processes=[procs.azh_ttll_a1800_h400],
     keys=[
         "/AToZHToLLTTbar_MA-1800_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1296,7 +1295,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1800_h500",
     id=14636041,
-    processes=["procs.azh_ttll_a1800_h500"],
+    processes=[procs.azh_ttll_a1800_h500],
     keys=[
         "/AToZHToLLTTbar_MA-1800_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1306,7 +1305,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1800_h600",
     id=14638191,
-    processes=["procs.azh_ttll_a1800_h600"],
+    processes=[procs.azh_ttll_a1800_h600],
     keys=[
         "/AToZHToLLTTbar_MA-1800_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1316,7 +1315,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1800_h700",
     id=14641337,
-    processes=["procs.azh_ttll_a1800_h700"],
+    processes=[procs.azh_ttll_a1800_h700],
     keys=[
         "/AToZHToLLTTbar_MA-1800_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1326,7 +1325,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1800_h800",
     id=14641404,
-    processes=["procs.azh_ttll_a1800_h800"],
+    processes=[procs.azh_ttll_a1800_h800],
     keys=[
         "/AToZHToLLTTbar_MA-1800_MH-800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1336,7 +1335,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1800_h900",
     id=14644425,
-    processes=["procs.azh_ttll_a1800_h900"],
+    processes=[procs.azh_ttll_a1800_h900],
     keys=[
         "/AToZHToLLTTbar_MA-1800_MH-900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1346,7 +1345,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1900_h1000",
     id=14645483,
-    processes=["procs.azh_ttll_a1900_h1000"],
+    processes=[procs.azh_ttll_a1900_h1000],
     keys=[
         "/AToZHToLLTTbar_MA-1900_MH-1000_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1356,7 +1355,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1900_h1100",
     id=14641381,
-    processes=["procs.azh_ttll_a1900_h1100"],
+    processes=[procs.azh_ttll_a1900_h1100],
     keys=[
         "/AToZHToLLTTbar_MA-1900_MH-1100_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1366,7 +1365,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1900_h1200",
     id=14644032,
-    processes=["procs.azh_ttll_a1900_h1200"],
+    processes=[procs.azh_ttll_a1900_h1200],
     keys=[
         "/AToZHToLLTTbar_MA-1900_MH-1200_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1376,7 +1375,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1900_h1300",
     id=14640668,
-    processes=["procs.azh_ttll_a1900_h1300"],
+    processes=[procs.azh_ttll_a1900_h1300],
     keys=[
         "/AToZHToLLTTbar_MA-1900_MH-1300_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1386,7 +1385,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1900_h1400",
     id=14638513,
-    processes=["procs.azh_ttll_a1900_h1400"],
+    processes=[procs.azh_ttll_a1900_h1400],
     keys=[
         "/AToZHToLLTTbar_MA-1900_MH-1400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1396,7 +1395,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1900_h1500",
     id=14641448,
-    processes=["procs.azh_ttll_a1900_h1500"],
+    processes=[procs.azh_ttll_a1900_h1500],
     keys=[
         "/AToZHToLLTTbar_MA-1900_MH-1500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1406,7 +1405,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1900_h1600",
     id=14644761,
-    processes=["procs.azh_ttll_a1900_h1600"],
+    processes=[procs.azh_ttll_a1900_h1600],
     keys=[
         "/AToZHToLLTTbar_MA-1900_MH-1600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1416,7 +1415,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1900_h1700",
     id=14644521,
-    processes=["procs.azh_ttll_a1900_h1700"],
+    processes=[procs.azh_ttll_a1900_h1700],
     keys=[
         "/AToZHToLLTTbar_MA-1900_MH-1700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1426,7 +1425,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1900_h1800",
     id=14639947,
-    processes=["procs.azh_ttll_a1900_h1800"],
+    processes=[procs.azh_ttll_a1900_h1800],
     keys=[
         "/AToZHToLLTTbar_MA-1900_MH-1800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1436,7 +1435,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1900_h350",
     id=14645606,
-    processes=["procs.azh_ttll_a1900_h350"],
+    processes=[procs.azh_ttll_a1900_h350],
     keys=[
         "/AToZHToLLTTbar_MA-1900_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1446,7 +1445,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1900_h400",
     id=14640620,
-    processes=["procs.azh_ttll_a1900_h400"],
+    processes=[procs.azh_ttll_a1900_h400],
     keys=[
         "/AToZHToLLTTbar_MA-1900_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1456,7 +1455,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1900_h500",
     id=14644122,
-    processes=["procs.azh_ttll_a1900_h500"],
+    processes=[procs.azh_ttll_a1900_h500],
     keys=[
         "/AToZHToLLTTbar_MA-1900_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1466,7 +1465,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1900_h600",
     id=14638778,
-    processes=["procs.azh_ttll_a1900_h600"],
+    processes=[procs.azh_ttll_a1900_h600],
     keys=[
         "/AToZHToLLTTbar_MA-1900_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1476,7 +1475,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1900_h700",
     id=14643966,
-    processes=["procs.azh_ttll_a1900_h700"],
+    processes=[procs.azh_ttll_a1900_h700],
     keys=[
         "/AToZHToLLTTbar_MA-1900_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1486,7 +1485,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1900_h800",
     id=14644992,
-    processes=["procs.azh_ttll_a1900_h800"],
+    processes=[procs.azh_ttll_a1900_h800],
     keys=[
         "/AToZHToLLTTbar_MA-1900_MH-800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1496,7 +1495,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a1900_h900",
     id=14636485,
-    processes=["procs.azh_ttll_a1900_h900"],
+    processes=[procs.azh_ttll_a1900_h900],
     keys=[
         "/AToZHToLLTTbar_MA-1900_MH-900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1506,7 +1505,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a2000_h1000",
     id=14640348,
-    processes=["procs.azh_ttll_a2000_h1000"],
+    processes=[procs.azh_ttll_a2000_h1000],
     keys=[
         "/AToZHToLLTTbar_MA-2000_MH-1000_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1516,7 +1515,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a2000_h1100",
     id=14644809,
-    processes=["procs.azh_ttll_a2000_h1100"],
+    processes=[procs.azh_ttll_a2000_h1100],
     keys=[
         "/AToZHToLLTTbar_MA-2000_MH-1100_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1526,7 +1525,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a2000_h1200",
     id=14637610,
-    processes=["procs.azh_ttll_a2000_h1200"],
+    processes=[procs.azh_ttll_a2000_h1200],
     keys=[
         "/AToZHToLLTTbar_MA-2000_MH-1200_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1536,7 +1535,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a2000_h1300",
     id=14636407,
-    processes=["procs.azh_ttll_a2000_h1300"],
+    processes=[procs.azh_ttll_a2000_h1300],
     keys=[
         "/AToZHToLLTTbar_MA-2000_MH-1300_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1546,7 +1545,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a2000_h1400",
     id=14641386,
-    processes=["procs.azh_ttll_a2000_h1400"],
+    processes=[procs.azh_ttll_a2000_h1400],
     keys=[
         "/AToZHToLLTTbar_MA-2000_MH-1400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1556,7 +1555,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a2000_h1600",
     id=14636572,
-    processes=["procs.azh_ttll_a2000_h1600"],
+    processes=[procs.azh_ttll_a2000_h1600],
     keys=[
         "/AToZHToLLTTbar_MA-2000_MH-1600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1566,7 +1565,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a2000_h1700",
     id=14645641,
-    processes=["procs.azh_ttll_a2000_h1700"],
+    processes=[procs.azh_ttll_a2000_h1700],
     keys=[
         "/AToZHToLLTTbar_MA-2000_MH-1700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1576,7 +1575,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a2000_h1800",
     id=14638745,
-    processes=["procs.azh_ttll_a2000_h1800"],
+    processes=[procs.azh_ttll_a2000_h1800],
     keys=[
         "/AToZHToLLTTbar_MA-2000_MH-1800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1586,7 +1585,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a2000_h1900",
     id=14640887,
-    processes=["procs.azh_ttll_a2000_h1900"],
+    processes=[procs.azh_ttll_a2000_h1900],
     keys=[
         "/AToZHToLLTTbar_MA-2000_MH-1900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1596,7 +1595,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a2000_h350",
     id=14645372,
-    processes=["procs.azh_ttll_a2000_h350"],
+    processes=[procs.azh_ttll_a2000_h350],
     keys=[
         "/AToZHToLLTTbar_MA-2000_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1606,7 +1605,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a2000_h400",
     id=14640824,
-    processes=["procs.azh_ttll_a2000_h400"],
+    processes=[procs.azh_ttll_a2000_h400],
     keys=[
         "/AToZHToLLTTbar_MA-2000_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1616,7 +1615,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a2000_h500",
     id=14641466,
-    processes=["procs.azh_ttll_a2000_h500"],
+    processes=[procs.azh_ttll_a2000_h500],
     keys=[
         "/AToZHToLLTTbar_MA-2000_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1626,7 +1625,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a2000_h600",
     id=14644380,
-    processes=["procs.azh_ttll_a2000_h600"],
+    processes=[procs.azh_ttll_a2000_h600],
     keys=[
         "/AToZHToLLTTbar_MA-2000_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1636,7 +1635,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a2000_h700",
     id=14641216,
-    processes=["procs.azh_ttll_a2000_h700"],
+    processes=[procs.azh_ttll_a2000_h700],
     keys=[
         "/AToZHToLLTTbar_MA-2000_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1646,7 +1645,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a2000_h800",
     id=14636495,
-    processes=["procs.azh_ttll_a2000_h800"],
+    processes=[procs.azh_ttll_a2000_h800],
     keys=[
         "/AToZHToLLTTbar_MA-2000_MH-800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1656,7 +1655,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a2000_h900",
     id=14643988,
-    processes=["procs.azh_ttll_a2000_h900"],
+    processes=[procs.azh_ttll_a2000_h900],
     keys=[
         "/AToZHToLLTTbar_MA-2000_MH-900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1666,7 +1665,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a2100_h1000",
     id=14536369,
-    processes=["procs.azh_ttll_a2100_h1000"],
+    processes=[procs.azh_ttll_a2100_h1000],
     keys=[
         "/AToZHToLLTTbar_MA-2100_MH-1000_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1676,7 +1675,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a2100_h1100",
     id=14637855,
-    processes=["procs.azh_ttll_a2100_h1100"],
+    processes=[procs.azh_ttll_a2100_h1100],
     keys=[
         "/AToZHToLLTTbar_MA-2100_MH-1100_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1686,7 +1685,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a2100_h1200",
     id=14640710,
-    processes=["procs.azh_ttll_a2100_h1200"],
+    processes=[procs.azh_ttll_a2100_h1200],
     keys=[
         "/AToZHToLLTTbar_MA-2100_MH-1200_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1696,7 +1695,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a2100_h1300",
     id=14636479,
-    processes=["procs.azh_ttll_a2100_h1300"],
+    processes=[procs.azh_ttll_a2100_h1300],
     keys=[
         "/AToZHToLLTTbar_MA-2100_MH-1300_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1706,7 +1705,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a2100_h1400",
     id=14637248,
-    processes=["procs.azh_ttll_a2100_h1400"],
+    processes=[procs.azh_ttll_a2100_h1400],
     keys=[
         "/AToZHToLLTTbar_MA-2100_MH-1400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1716,7 +1715,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a2100_h1500",
     id=14645029,
-    processes=["procs.azh_ttll_a2100_h1500"],
+    processes=[procs.azh_ttll_a2100_h1500],
     keys=[
         "/AToZHToLLTTbar_MA-2100_MH-1500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1726,7 +1725,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a2100_h1700",
     id=14637551,
-    processes=["procs.azh_ttll_a2100_h1700"],
+    processes=[procs.azh_ttll_a2100_h1700],
     keys=[
         "/AToZHToLLTTbar_MA-2100_MH-1700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1736,7 +1735,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a2100_h1800",
     id=14638095,
-    processes=["procs.azh_ttll_a2100_h1800"],
+    processes=[procs.azh_ttll_a2100_h1800],
     keys=[
         "/AToZHToLLTTbar_MA-2100_MH-1800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1746,7 +1745,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a2100_h1900",
     id=14643999,
-    processes=["procs.azh_ttll_a2100_h1900"],
+    processes=[procs.azh_ttll_a2100_h1900],
     keys=[
         "/AToZHToLLTTbar_MA-2100_MH-1900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1756,7 +1755,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a2100_h2000",
     id=14536433,
-    processes=["procs.azh_ttll_a2100_h2000"],
+    processes=[procs.azh_ttll_a2100_h2000],
     keys=[
         "/AToZHToLLTTbar_MA-2100_MH-2000_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1766,7 +1765,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a2100_h350",
     id=14640847,
-    processes=["procs.azh_ttll_a2100_h350"],
+    processes=[procs.azh_ttll_a2100_h350],
     keys=[
         "/AToZHToLLTTbar_MA-2100_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1776,7 +1775,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a2100_h400",
     id=14549535,
-    processes=["procs.azh_ttll_a2100_h400"],
+    processes=[procs.azh_ttll_a2100_h400],
     keys=[
         "/AToZHToLLTTbar_MA-2100_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1786,7 +1785,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a2100_h500",
     id=14641088,
-    processes=["procs.azh_ttll_a2100_h500"],
+    processes=[procs.azh_ttll_a2100_h500],
     keys=[
         "/AToZHToLLTTbar_MA-2100_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1796,7 +1795,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a2100_h600",
     id=14645539,
-    processes=["procs.azh_ttll_a2100_h600"],
+    processes=[procs.azh_ttll_a2100_h600],
     keys=[
         "/AToZHToLLTTbar_MA-2100_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1806,7 +1805,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a2100_h700",
     id=14636576,
-    processes=["procs.azh_ttll_a2100_h700"],
+    processes=[procs.azh_ttll_a2100_h700],
     keys=[
         "/AToZHToLLTTbar_MA-2100_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1816,7 +1815,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a2100_h800",
     id=14644946,
-    processes=["procs.azh_ttll_a2100_h800"],
+    processes=[procs.azh_ttll_a2100_h800],
     keys=[
         "/AToZHToLLTTbar_MA-2100_MH-800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1826,7 +1825,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a2100_h900",
     id=14641004,
-    processes=["procs.azh_ttll_a2100_h900"],
+    processes=[procs.azh_ttll_a2100_h900],
     keys=[
         "/AToZHToLLTTbar_MA-2100_MH-900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1836,7 +1835,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a430_h330",
     id=14640871,
-    processes=["procs.azh_ttll_a430_h330"],
+    processes=[procs.azh_ttll_a430_h330],
     keys=[
         "/AToZHToLLTTbar_MA-430_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1846,7 +1845,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a450_h330",
     id=14641217,
-    processes=["procs.azh_ttll_a450_h330"],
+    processes=[procs.azh_ttll_a450_h330],
     keys=[
         "/AToZHToLLTTbar_MA-450_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1856,7 +1855,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a450_h350",
     id=14637724,
-    processes=["procs.azh_ttll_a450_h350"],
+    processes=[procs.azh_ttll_a450_h350],
     keys=[
         "/AToZHToLLTTbar_MA-450_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1866,7 +1865,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a500_h330",
     id=14645669,
-    processes=["procs.azh_ttll_a500_h330"],
+    processes=[procs.azh_ttll_a500_h330],
     keys=[
         "/AToZHToLLTTbar_MA-500_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1876,7 +1875,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a500_h350",
     id=14548216,
-    processes=["procs.azh_ttll_a500_h350"],
+    processes=[procs.azh_ttll_a500_h350],
     keys=[
         "/AToZHToLLTTbar_MA-500_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1886,7 +1885,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a500_h370",
     id=14648537,
-    processes=["procs.azh_ttll_a500_h370"],
+    processes=[procs.azh_ttll_a500_h370],
     keys=[
         "/AToZHToLLTTbar_MA-500_MH-370_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1896,7 +1895,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a500_h400",
     id=14537163,
-    processes=["procs.azh_ttll_a500_h400"],
+    processes=[procs.azh_ttll_a500_h400],
     keys=[
         "/AToZHToLLTTbar_MA-500_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1906,7 +1905,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a550_h330",
     id=14640737,
-    processes=["procs.azh_ttll_a550_h330"],
+    processes=[procs.azh_ttll_a550_h330],
     keys=[
         "/AToZHToLLTTbar_MA-550_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1916,7 +1915,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a550_h350",
     id=14641310,
-    processes=["procs.azh_ttll_a550_h350"],
+    processes=[procs.azh_ttll_a550_h350],
     keys=[
         "/AToZHToLLTTbar_MA-550_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1926,7 +1925,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a550_h400",
     id=14641298,
-    processes=["procs.azh_ttll_a550_h400"],
+    processes=[procs.azh_ttll_a550_h400],
     keys=[
         "/AToZHToLLTTbar_MA-550_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1936,7 +1935,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a550_h450",
     id=14644728,
-    processes=["procs.azh_ttll_a550_h450"],
+    processes=[procs.azh_ttll_a550_h450],
     keys=[
         "/AToZHToLLTTbar_MA-550_MH-450_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1946,7 +1945,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a600_h330",
     id=14643492,
-    processes=["procs.azh_ttll_a600_h330"],
+    processes=[procs.azh_ttll_a600_h330],
     keys=[
         "/AToZHToLLTTbar_MA-600_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1956,7 +1955,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a600_h350",
     id=14644865,
-    processes=["procs.azh_ttll_a600_h350"],
+    processes=[procs.azh_ttll_a600_h350],
     keys=[
         "/AToZHToLLTTbar_MA-600_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1966,7 +1965,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a600_h400",
     id=14640637,
-    processes=["procs.azh_ttll_a600_h400"],
+    processes=[procs.azh_ttll_a600_h400],
     keys=[
         "/AToZHToLLTTbar_MA-600_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1976,7 +1975,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a600_h450",
     id=14644417,
-    processes=["procs.azh_ttll_a600_h450"],
+    processes=[procs.azh_ttll_a600_h450],
     keys=[
         "/AToZHToLLTTbar_MA-600_MH-450_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1986,7 +1985,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a600_h500",
     id=14641414,
-    processes=["procs.azh_ttll_a600_h500"],
+    processes=[procs.azh_ttll_a600_h500],
     keys=[
         "/AToZHToLLTTbar_MA-600_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1996,7 +1995,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a650_h330",
     id=14644791,
-    processes=["procs.azh_ttll_a650_h330"],
+    processes=[procs.azh_ttll_a650_h330],
     keys=[
         "/AToZHToLLTTbar_MA-650_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2006,7 +2005,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a650_h350",
     id=14636505,
-    processes=["procs.azh_ttll_a650_h350"],
+    processes=[procs.azh_ttll_a650_h350],
     keys=[
         "/AToZHToLLTTbar_MA-650_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2016,7 +2015,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a650_h400",
     id=14643912,
-    processes=["procs.azh_ttll_a650_h400"],
+    processes=[procs.azh_ttll_a650_h400],
     keys=[
         "/AToZHToLLTTbar_MA-650_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2026,7 +2025,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a650_h450",
     id=14641233,
-    processes=["procs.azh_ttll_a650_h450"],
+    processes=[procs.azh_ttll_a650_h450],
     keys=[
         "/AToZHToLLTTbar_MA-650_MH-450_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2036,7 +2035,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a650_h500",
     id=14637773,
-    processes=["procs.azh_ttll_a650_h500"],
+    processes=[procs.azh_ttll_a650_h500],
     keys=[
         "/AToZHToLLTTbar_MA-650_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2046,7 +2045,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a650_h550",
     id=14637782,
-    processes=["procs.azh_ttll_a650_h550"],
+    processes=[procs.azh_ttll_a650_h550],
     keys=[
         "/AToZHToLLTTbar_MA-650_MH-550_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2056,7 +2055,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a700_h330",
     id=14637877,
-    processes=["procs.azh_ttll_a700_h330"],
+    processes=[procs.azh_ttll_a700_h330],
     keys=[
         "/AToZHToLLTTbar_MA-700_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2066,7 +2065,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a700_h350",
     id=14549119,
-    processes=["procs.azh_ttll_a700_h350"],
+    processes=[procs.azh_ttll_a700_h350],
     keys=[
         "/AToZHToLLTTbar_MA-700_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2076,7 +2075,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a700_h370",
     id=14548653,
-    processes=["procs.azh_ttll_a700_h370"],
+    processes=[procs.azh_ttll_a700_h370],
     keys=[
         "/AToZHToLLTTbar_MA-700_MH-370_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2086,7 +2085,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a700_h400",
     id=14550258,
-    processes=["procs.azh_ttll_a700_h400"],
+    processes=[procs.azh_ttll_a700_h400],
     keys=[
         "/AToZHToLLTTbar_MA-700_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2096,7 +2095,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a700_h450",
     id=14644343,
-    processes=["procs.azh_ttll_a700_h450"],
+    processes=[procs.azh_ttll_a700_h450],
     keys=[
         "/AToZHToLLTTbar_MA-700_MH-450_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2106,7 +2105,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a700_h500",
     id=14645288,
-    processes=["procs.azh_ttll_a700_h500"],
+    processes=[procs.azh_ttll_a700_h500],
     keys=[
         "/AToZHToLLTTbar_MA-700_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2116,7 +2115,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a700_h550",
     id=14644477,
-    processes=["procs.azh_ttll_a700_h550"],
+    processes=[procs.azh_ttll_a700_h550],
     keys=[
         "/AToZHToLLTTbar_MA-700_MH-550_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2126,7 +2125,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a750_h330",
     id=14641059,
-    processes=["procs.azh_ttll_a750_h330"],
+    processes=[procs.azh_ttll_a750_h330],
     keys=[
         "/AToZHToLLTTbar_MA-750_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2136,7 +2135,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a750_h350",
     id=14644713,
-    processes=["procs.azh_ttll_a750_h350"],
+    processes=[procs.azh_ttll_a750_h350],
     keys=[
         "/AToZHToLLTTbar_MA-750_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2146,7 +2145,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a750_h400",
     id=14637708,
-    processes=["procs.azh_ttll_a750_h400"],
+    processes=[procs.azh_ttll_a750_h400],
     keys=[
         "/AToZHToLLTTbar_MA-750_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2156,7 +2155,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a750_h450",
     id=14640716,
-    processes=["procs.azh_ttll_a750_h450"],
+    processes=[procs.azh_ttll_a750_h450],
     keys=[
         "/AToZHToLLTTbar_MA-750_MH-450_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2166,7 +2165,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a750_h500",
     id=14636467,
-    processes=["procs.azh_ttll_a750_h500"],
+    processes=[procs.azh_ttll_a750_h500],
     keys=[
         "/AToZHToLLTTbar_MA-750_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2176,7 +2175,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a750_h550",
     id=14644222,
-    processes=["procs.azh_ttll_a750_h550"],
+    processes=[procs.azh_ttll_a750_h550],
     keys=[
         "/AToZHToLLTTbar_MA-750_MH-550_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2186,7 +2185,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a750_h600",
     id=14644813,
-    processes=["procs.azh_ttll_a750_h600"],
+    processes=[procs.azh_ttll_a750_h600],
     keys=[
         "/AToZHToLLTTbar_MA-750_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2196,7 +2195,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a750_h650",
     id=14644183,
-    processes=["procs.azh_ttll_a750_h650"],
+    processes=[procs.azh_ttll_a750_h650],
     keys=[
         "/AToZHToLLTTbar_MA-750_MH-650_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2206,7 +2205,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a800_h330",
     id=14643977,
-    processes=["procs.azh_ttll_a800_h330"],
+    processes=[procs.azh_ttll_a800_h330],
     keys=[
         "/AToZHToLLTTbar_MA-800_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2216,7 +2215,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a800_h350",
     id=14638955,
-    processes=["procs.azh_ttll_a800_h350"],
+    processes=[procs.azh_ttll_a800_h350],
     keys=[
         "/AToZHToLLTTbar_MA-800_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2226,7 +2225,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a800_h400",
     id=14643987,
-    processes=["procs.azh_ttll_a800_h400"],
+    processes=[procs.azh_ttll_a800_h400],
     keys=[
         "/AToZHToLLTTbar_MA-800_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2236,7 +2235,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a800_h450",
     id=14637537,
-    processes=["procs.azh_ttll_a800_h450"],
+    processes=[procs.azh_ttll_a800_h450],
     keys=[
         "/AToZHToLLTTbar_MA-800_MH-450_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2246,7 +2245,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a800_h500",
     id=14636808,
-    processes=["procs.azh_ttll_a800_h500"],
+    processes=[procs.azh_ttll_a800_h500],
     keys=[
         "/AToZHToLLTTbar_MA-800_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2256,7 +2255,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a800_h550",
     id=14640965,
-    processes=["procs.azh_ttll_a800_h550"],
+    processes=[procs.azh_ttll_a800_h550],
     keys=[
         "/AToZHToLLTTbar_MA-800_MH-550_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2266,7 +2265,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a800_h600",
     id=14548217,
-    processes=["procs.azh_ttll_a800_h600"],
+    processes=[procs.azh_ttll_a800_h600],
     keys=[
         "/AToZHToLLTTbar_MA-800_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2276,7 +2275,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a800_h650",
     id=14647537,
-    processes=["procs.azh_ttll_a800_h650"],
+    processes=[procs.azh_ttll_a800_h650],
     keys=[
         "/AToZHToLLTTbar_MA-800_MH-650_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2286,7 +2285,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a800_h700",
     id=14637545,
-    processes=["procs.azh_ttll_a800_h700"],
+    processes=[procs.azh_ttll_a800_h700],
     keys=[
         "/AToZHToLLTTbar_MA-800_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2296,7 +2295,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a850_h330",
     id=14636408,
-    processes=["procs.azh_ttll_a850_h330"],
+    processes=[procs.azh_ttll_a850_h330],
     keys=[
         "/AToZHToLLTTbar_MA-850_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2306,7 +2305,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a850_h350",
     id=14640072,
-    processes=["procs.azh_ttll_a850_h350"],
+    processes=[procs.azh_ttll_a850_h350],
     keys=[
         "/AToZHToLLTTbar_MA-850_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2316,7 +2315,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a850_h400",
     id=14641161,
-    processes=["procs.azh_ttll_a850_h400"],
+    processes=[procs.azh_ttll_a850_h400],
     keys=[
         "/AToZHToLLTTbar_MA-850_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2326,7 +2325,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a850_h450",
     id=14644205,
-    processes=["procs.azh_ttll_a850_h450"],
+    processes=[procs.azh_ttll_a850_h450],
     keys=[
         "/AToZHToLLTTbar_MA-850_MH-450_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2336,7 +2335,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a850_h500",
     id=14636506,
-    processes=["procs.azh_ttll_a850_h500"],
+    processes=[procs.azh_ttll_a850_h500],
     keys=[
         "/AToZHToLLTTbar_MA-850_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2346,7 +2345,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a850_h550",
     id=14640940,
-    processes=["procs.azh_ttll_a850_h550"],
+    processes=[procs.azh_ttll_a850_h550],
     keys=[
         "/AToZHToLLTTbar_MA-850_MH-550_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2356,7 +2355,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a850_h600",
     id=14637903,
-    processes=["procs.azh_ttll_a850_h600"],
+    processes=[procs.azh_ttll_a850_h600],
     keys=[
         "/AToZHToLLTTbar_MA-850_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2366,7 +2365,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a850_h650",
     id=14644591,
-    processes=["procs.azh_ttll_a850_h650"],
+    processes=[procs.azh_ttll_a850_h650],
     keys=[
         "/AToZHToLLTTbar_MA-850_MH-650_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2376,7 +2375,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a850_h700",
     id=14645081,
-    processes=["procs.azh_ttll_a850_h700"],
+    processes=[procs.azh_ttll_a850_h700],
     keys=[
         "/AToZHToLLTTbar_MA-850_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2386,7 +2385,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a850_h750",
     id=14640939,
-    processes=["procs.azh_ttll_a850_h750"],
+    processes=[procs.azh_ttll_a850_h750],
     keys=[
         "/AToZHToLLTTbar_MA-850_MH-750_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2396,7 +2395,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a900_h330",
     id=14641018,
-    processes=["procs.azh_ttll_a900_h330"],
+    processes=[procs.azh_ttll_a900_h330],
     keys=[
         "/AToZHToLLTTbar_MA-900_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2406,7 +2405,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a900_h350",
     id=14647696,
-    processes=["procs.azh_ttll_a900_h350"],
+    processes=[procs.azh_ttll_a900_h350],
     keys=[
         "/AToZHToLLTTbar_MA-900_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2416,7 +2415,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a900_h370",
     id=14548218,
-    processes=["procs.azh_ttll_a900_h370"],
+    processes=[procs.azh_ttll_a900_h370],
     keys=[
         "/AToZHToLLTTbar_MA-900_MH-370_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2426,7 +2425,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a900_h400",
     id=14544289,
-    processes=["procs.azh_ttll_a900_h400"],
+    processes=[procs.azh_ttll_a900_h400],
     keys=[
         "/AToZHToLLTTbar_MA-900_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2436,7 +2435,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a900_h450",
     id=14637509,
-    processes=["procs.azh_ttll_a900_h450"],
+    processes=[procs.azh_ttll_a900_h450],
     keys=[
         "/AToZHToLLTTbar_MA-900_MH-450_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2446,7 +2445,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a900_h550",
     id=14640075,
-    processes=["procs.azh_ttll_a900_h550"],
+    processes=[procs.azh_ttll_a900_h550],
     keys=[
         "/AToZHToLLTTbar_MA-900_MH-550_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2456,7 +2455,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a900_h500",
     id=14640067,
-    processes=["procs.azh_ttll_a900_h500"],
+    processes=[procs.azh_ttll_a900_h500],
     keys=[
         "/AToZHToLLTTbar_MA-900_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2466,7 +2465,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a900_h600",
     id=14641600,
-    processes=["procs.azh_ttll_a900_h600"],
+    processes=[procs.azh_ttll_a900_h600],
     keys=[
         "/AToZHToLLTTbar_MA-900_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2476,7 +2475,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a900_h650",
     id=14645044,
-    processes=["procs.azh_ttll_a900_h650"],
+    processes=[procs.azh_ttll_a900_h650],
     keys=[
         "/AToZHToLLTTbar_MA-900_MH-650_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2486,7 +2485,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a900_h700",
     id=14644427,
-    processes=["procs.azh_ttll_a900_h700"],
+    processes=[procs.azh_ttll_a900_h700],
     keys=[
         "/AToZHToLLTTbar_MA-900_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2496,7 +2495,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a900_h750",
     id=14641142,
-    processes=["procs.azh_ttll_a900_h750"],
+    processes=[procs.azh_ttll_a900_h750],
     keys=[
         "/AToZHToLLTTbar_MA-900_MH-750_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2506,7 +2505,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a900_h800",
     id=14636409,
-    processes=["procs.azh_ttll_a900_h800"],
+    processes=[procs.azh_ttll_a900_h800],
     keys=[
         "/AToZHToLLTTbar_MA-900_MH-800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2516,7 +2515,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a950_h330",
     id=14636607,
-    processes=["procs.azh_ttll_a950_h330"],
+    processes=[procs.azh_ttll_a950_h330],
     keys=[
         "/AToZHToLLTTbar_MA-950_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2526,7 +2525,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a950_h350",
     id=14638010,
-    processes=["procs.azh_ttll_a950_h350"],
+    processes=[procs.azh_ttll_a950_h350],
     keys=[
         "/AToZHToLLTTbar_MA-950_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2536,7 +2535,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a950_h400",
     id=14638017,
-    processes=["procs.azh_ttll_a950_h400"],
+    processes=[procs.azh_ttll_a950_h400],
     keys=[
         "/AToZHToLLTTbar_MA-950_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2546,7 +2545,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a950_h450",
     id=14642920,
-    processes=["procs.azh_ttll_a950_h450"],
+    processes=[procs.azh_ttll_a950_h450],
     keys=[
         "/AToZHToLLTTbar_MA-950_MH-450_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2556,7 +2555,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a950_h500",
     id=14637960,
-    processes=["procs.azh_ttll_a950_h500"],
+    processes=[procs.azh_ttll_a950_h500],
     keys=[
         "/AToZHToLLTTbar_MA-950_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2566,7 +2565,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a950_h550",
     id=14641687,
-    processes=["procs.azh_ttll_a950_h550"],
+    processes=[procs.azh_ttll_a950_h550],
     keys=[
         "/AToZHToLLTTbar_MA-950_MH-550_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2576,7 +2575,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a950_h600",
     id=14637720,
-    processes=["procs.azh_ttll_a950_h600"],
+    processes=[procs.azh_ttll_a950_h600],
     keys=[
         "/AToZHToLLTTbar_MA-950_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2586,7 +2585,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a950_h650",
     id=14637077,
-    processes=["procs.azh_ttll_a950_h650"],
+    processes=[procs.azh_ttll_a950_h650],
     keys=[
         "/AToZHToLLTTbar_MA-950_MH-650_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2596,7 +2595,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a950_h700",
     id=14636448,
-    processes=["procs.azh_ttll_a950_h700"],
+    processes=[procs.azh_ttll_a950_h700],
     keys=[
         "/AToZHToLLTTbar_MA-950_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2606,7 +2605,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a950_h750",
     id=14644979,
-    processes=["procs.azh_ttll_a950_h750"],
+    processes=[procs.azh_ttll_a950_h750],
     keys=[
         "/AToZHToLLTTbar_MA-950_MH-750_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2616,7 +2615,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a950_h800",
     id=14645411,
-    processes=["procs.azh_ttll_a950_h800"],
+    processes=[procs.azh_ttll_a950_h800],
     keys=[
         "/AToZHToLLTTbar_MA-950_MH-800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2626,14 +2625,10 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="azh_ttll_a950_h850",
     id=14636342,
-    processes=["procs.azh_ttll_a950_h850"],
+    processes=[procs.azh_ttll_a950_h850],
     keys=[
         "/AToZHToLLTTbar_MA-950_MH-850_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
     n_files=1,
     n_events=48000,
 )
-
-#
-# AZH->Ztt->nunutt
-#

--- a/cmsdb/campaigns/run2_2017_nano_v9/azh.py
+++ b/cmsdb/campaigns/run2_2017_nano_v9/azh.py
@@ -12,10 +12,11 @@ from cmsdb.campaigns.run2_2017_nano_v9 import campaign_run2_2017_nano_v9 as cpn
 # AZH->Ztt->lltt
 #
 
+
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1000_MH-330",
+    name="azh_ttll_a1000_h330",
     id=14640747,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1000_h330"],
     keys=[
         "/AToZHToLLTTbar_MA-1000_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -23,9 +24,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1000_MH-350",
+    name="azh_ttll_a1000_h350",
     id=14640749,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1000_h350"],
     keys=[
         "/AToZHToLLTTbar_MA-1000_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -33,9 +34,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1000_MH-400",
+    name="azh_ttll_a1000_h400",
     id=14644922,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1000_h400"],
     keys=[
         "/AToZHToLLTTbar_MA-1000_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -43,9 +44,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1000_MH-450",
+    name="azh_ttll_a1000_h450",
     id=14644445,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1000_h450"],
     keys=[
         "/AToZHToLLTTbar_MA-1000_MH-450_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -53,9 +54,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1000_MH-500",
+    name="azh_ttll_a1000_h500",
     id=14644631,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1000_h500"],
     keys=[
         "/AToZHToLLTTbar_MA-1000_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -63,9 +64,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1000_MH-550",
+    name="azh_ttll_a1000_h550",
     id=14637796,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1000_h550"],
     keys=[
         "/AToZHToLLTTbar_MA-1000_MH-550_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -73,9 +74,9 @@ cpn.add_dataset(
     n_events=49000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1000_MH-600",
+    name="azh_ttll_a1000_h600",
     id=14548924,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1000_h600"],
     keys=[
         "/AToZHToLLTTbar_MA-1000_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -83,9 +84,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1000_MH-650",
+    name="azh_ttll_a1000_h650",
     id=14643976,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1000_h650"],
     keys=[
         "/AToZHToLLTTbar_MA-1000_MH-650_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -93,9 +94,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1000_MH-700",
+    name="azh_ttll_a1000_h700",
     id=14536925,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1000_h700"],
     keys=[
         "/AToZHToLLTTbar_MA-1000_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -103,9 +104,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1000_MH-750",
+    name="azh_ttll_a1000_h750",
     id=14636760,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1000_h750"],
     keys=[
         "/AToZHToLLTTbar_MA-1000_MH-750_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -113,9 +114,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1000_MH-800",
+    name="azh_ttll_a1000_h800",
     id=14548527,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1000_h800"],
     keys=[
         "/AToZHToLLTTbar_MA-1000_MH-800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -123,9 +124,9 @@ cpn.add_dataset(
     n_events=49000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1000_MH-850",
+    name="azh_ttll_a1000_h850",
     id=14644480,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1000_h850"],
     keys=[
         "/AToZHToLLTTbar_MA-1000_MH-850_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -133,9 +134,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1000_MH-900",
+    name="azh_ttll_a1000_h900",
     id=14641365,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1000_h900"],
     keys=[
         "/AToZHToLLTTbar_MA-1000_MH-900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -143,9 +144,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1050_MH-330",
+    name="azh_ttll_a1050_h330",
     id=14644650,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1050_h330"],
     keys=[
         "/AToZHToLLTTbar_MA-1050_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -153,9 +154,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1050_MH-350",
+    name="azh_ttll_a1050_h350",
     id=14636601,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1050_h350"],
     keys=[
         "/AToZHToLLTTbar_MA-1050_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -163,9 +164,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1050_MH-400",
+    name="azh_ttll_a1050_h400",
     id=14637383,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1050_h400"],
     keys=[
         "/AToZHToLLTTbar_MA-1050_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -173,9 +174,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1050_MH-450",
+    name="azh_ttll_a1050_h450",
     id=14643202,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1050_h450"],
     keys=[
         "/AToZHToLLTTbar_MA-1050_MH-450_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -183,9 +184,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1050_MH-500",
+    name="azh_ttll_a1050_h500",
     id=14645580,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1050_h500"],
     keys=[
         "/AToZHToLLTTbar_MA-1050_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -193,9 +194,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1050_MH-550",
+    name="azh_ttll_a1050_h550",
     id=14637742,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1050_h550"],
     keys=[
         "/AToZHToLLTTbar_MA-1050_MH-550_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -203,9 +204,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1050_MH-600",
+    name="azh_ttll_a1050_h600",
     id=14637456,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1050_h600"],
     keys=[
         "/AToZHToLLTTbar_MA-1050_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -213,9 +214,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1050_MH-700",
+    name="azh_ttll_a1050_h700",
     id=14638692,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1050_h700"],
     keys=[
         "/AToZHToLLTTbar_MA-1050_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -223,9 +224,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1050_MH-750",
+    name="azh_ttll_a1050_h750",
     id=14637603,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1050_h750"],
     keys=[
         "/AToZHToLLTTbar_MA-1050_MH-750_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -233,9 +234,9 @@ cpn.add_dataset(
     n_events=49000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1050_MH-800",
+    name="azh_ttll_a1050_h800",
     id=14639246,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1050_h800"],
     keys=[
         "/AToZHToLLTTbar_MA-1050_MH-800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -243,9 +244,9 @@ cpn.add_dataset(
     n_events=48000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1050_MH-850",
+    name="azh_ttll_a1050_h850",
     id=14641223,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1050_h850"],
     keys=[
         "/AToZHToLLTTbar_MA-1050_MH-850_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -253,9 +254,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1050_MH-900",
+    name="azh_ttll_a1050_h900",
     id=14645437,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1050_h900"],
     keys=[
         "/AToZHToLLTTbar_MA-1050_MH-900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -263,9 +264,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1050_MH-950",
+    name="azh_ttll_a1050_h950",
     id=14644029,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1050_h950"],
     keys=[
         "/AToZHToLLTTbar_MA-1050_MH-950_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -273,9 +274,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1100_MH-1000",
+    name="azh_ttll_a1100_h1000",
     id=14638003,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1100_h1000"],
     keys=[
         "/AToZHToLLTTbar_MA-1100_MH-1000_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -283,9 +284,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1100_MH-330",
+    name="azh_ttll_a1100_h330",
     id=14643995,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1100_h330"],
     keys=[
         "/AToZHToLLTTbar_MA-1100_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -293,9 +294,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1100_MH-350",
+    name="azh_ttll_a1100_h350",
     id=14643757,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1100_h350"],
     keys=[
         "/AToZHToLLTTbar_MA-1100_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -303,9 +304,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1100_MH-400",
+    name="azh_ttll_a1100_h400",
     id=14644862,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1100_h400"],
     keys=[
         "/AToZHToLLTTbar_MA-1100_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -313,9 +314,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1100_MH-450",
+    name="azh_ttll_a1100_h450",
     id=14641209,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1100_h450"],
     keys=[
         "/AToZHToLLTTbar_MA-1100_MH-450_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -323,9 +324,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1100_MH-500",
+    name="azh_ttll_a1100_h500",
     id=14643951,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1100_h500"],
     keys=[
         "/AToZHToLLTTbar_MA-1100_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -333,9 +334,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1100_MH-550",
+    name="azh_ttll_a1100_h550",
     id=14640899,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1100_h550"],
     keys=[
         "/AToZHToLLTTbar_MA-1100_MH-550_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -343,9 +344,9 @@ cpn.add_dataset(
     n_events=49000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1100_MH-600",
+    name="azh_ttll_a1100_h600",
     id=14640946,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1100_h600"],
     keys=[
         "/AToZHToLLTTbar_MA-1100_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -353,9 +354,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1100_MH-650",
+    name="azh_ttll_a1100_h650",
     id=14640680,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1100_h650"],
     keys=[
         "/AToZHToLLTTbar_MA-1100_MH-650_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -363,9 +364,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1100_MH-700",
+    name="azh_ttll_a1100_h700",
     id=14645549,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1100_h700"],
     keys=[
         "/AToZHToLLTTbar_MA-1100_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -373,9 +374,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1100_MH-750",
+    name="azh_ttll_a1100_h750",
     id=14637895,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1100_h750"],
     keys=[
         "/AToZHToLLTTbar_MA-1100_MH-750_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -383,9 +384,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1100_MH-800",
+    name="azh_ttll_a1100_h800",
     id=14636438,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1100_h800"],
     keys=[
         "/AToZHToLLTTbar_MA-1100_MH-800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -393,9 +394,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1100_MH-850",
+    name="azh_ttll_a1100_h850",
     id=14643264,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1100_h850"],
     keys=[
         "/AToZHToLLTTbar_MA-1100_MH-850_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -403,9 +404,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1100_MH-900",
+    name="azh_ttll_a1100_h900",
     id=14641361,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1100_h900"],
     keys=[
         "/AToZHToLLTTbar_MA-1100_MH-900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -413,9 +414,9 @@ cpn.add_dataset(
     n_events=48000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1100_MH-950",
+    name="azh_ttll_a1100_h950",
     id=14641067,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1100_h950"],
     keys=[
         "/AToZHToLLTTbar_MA-1100_MH-950_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -423,9 +424,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1150_MH-1050",
+    name="azh_ttll_a1150_h1050",
     id=14637047,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1150_h1050"],
     keys=[
         "/AToZHToLLTTbar_MA-1150_MH-1050_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -433,9 +434,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1150_MH-330",
+    name="azh_ttll_a1150_h330",
     id=14645065,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1150_h330"],
     keys=[
         "/AToZHToLLTTbar_MA-1150_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -443,9 +444,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1150_MH-350",
+    name="azh_ttll_a1150_h350",
     id=14641502,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1150_h350"],
     keys=[
         "/AToZHToLLTTbar_MA-1150_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -453,9 +454,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1150_MH-450",
+    name="azh_ttll_a1150_h450",
     id=14638090,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1150_h450"],
     keys=[
         "/AToZHToLLTTbar_MA-1150_MH-450_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -463,9 +464,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1150_MH-550",
+    name="azh_ttll_a1150_h550",
     id=14645380,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1150_h550"],
     keys=[
         "/AToZHToLLTTbar_MA-1150_MH-550_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -473,9 +474,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1150_MH-650",
+    name="azh_ttll_a1150_h650",
     id=14637436,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1150_h650"],
     keys=[
         "/AToZHToLLTTbar_MA-1150_MH-650_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -483,9 +484,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1150_MH-750",
+    name="azh_ttll_a1150_h750",
     id=14644493,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1150_h750"],
     keys=[
         "/AToZHToLLTTbar_MA-1150_MH-750_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -493,9 +494,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1150_MH-850",
+    name="azh_ttll_a1150_h850",
     id=14645060,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1150_h850"],
     keys=[
         "/AToZHToLLTTbar_MA-1150_MH-850_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -503,9 +504,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1150_MH-950",
+    name="azh_ttll_a1150_h950",
     id=14644915,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1150_h950"],
     keys=[
         "/AToZHToLLTTbar_MA-1150_MH-950_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -513,9 +514,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1200_MH-1000",
+    name="azh_ttll_a1200_h1000",
     id=14543193,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1200_h1000"],
     keys=[
         "/AToZHToLLTTbar_MA-1200_MH-1000_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -523,9 +524,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1200_MH-1100",
+    name="azh_ttll_a1200_h1100",
     id=14644025,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1200_h1100"],
     keys=[
         "/AToZHToLLTTbar_MA-1200_MH-1100_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -533,9 +534,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1200_MH-330",
+    name="azh_ttll_a1200_h330",
     id=14637970,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1200_h330"],
     keys=[
         "/AToZHToLLTTbar_MA-1200_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -543,9 +544,9 @@ cpn.add_dataset(
     n_events=48000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1200_MH-350",
+    name="azh_ttll_a1200_h350",
     id=14644005,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1200_h350"],
     keys=[
         "/AToZHToLLTTbar_MA-1200_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -553,9 +554,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1200_MH-400",
+    name="azh_ttll_a1200_h400",
     id=14647612,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1200_h400"],
     keys=[
         "/AToZHToLLTTbar_MA-1200_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -563,9 +564,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1200_MH-500",
+    name="azh_ttll_a1200_h500",
     id=14644884,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1200_h500"],
     keys=[
         "/AToZHToLLTTbar_MA-1200_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -573,9 +574,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1200_MH-600",
+    name="azh_ttll_a1200_h600",
     id=14644415,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1200_h600"],
     keys=[
         "/AToZHToLLTTbar_MA-1200_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -583,9 +584,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1200_MH-700",
+    name="azh_ttll_a1200_h700",
     id=14641569,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1200_h700"],
     keys=[
         "/AToZHToLLTTbar_MA-1200_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -593,9 +594,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1200_MH-800",
+    name="azh_ttll_a1200_h800",
     id=14639844,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1200_h800"],
     keys=[
         "/AToZHToLLTTbar_MA-1200_MH-800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -603,9 +604,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1200_MH-850",
+    name="azh_ttll_a1200_h850",
     id=14549534,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1200_h850"],
     keys=[
         "/AToZHToLLTTbar_MA-1200_MH-850_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -613,9 +614,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1200_MH-900",
+    name="azh_ttll_a1200_h900",
     id=14641099,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1200_h900"],
     keys=[
         "/AToZHToLLTTbar_MA-1200_MH-900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -623,9 +624,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1300_MH-1000",
+    name="azh_ttll_a1300_h1000",
     id=14640819,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1300_h1000"],
     keys=[
         "/AToZHToLLTTbar_MA-1300_MH-1000_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -633,9 +634,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1300_MH-1100",
+    name="azh_ttll_a1300_h1100",
     id=14641489,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1300_h1100"],
     keys=[
         "/AToZHToLLTTbar_MA-1300_MH-1100_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -643,9 +644,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1300_MH-1200",
+    name="azh_ttll_a1300_h1200",
     id=14644883,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1300_h1200"],
     keys=[
         "/AToZHToLLTTbar_MA-1300_MH-1200_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -653,9 +654,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1300_MH-350",
+    name="azh_ttll_a1300_h350",
     id=14645154,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1300_h350"],
     keys=[
         "/AToZHToLLTTbar_MA-1300_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -663,9 +664,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1300_MH-400",
+    name="azh_ttll_a1300_h400",
     id=14639378,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1300_h400"],
     keys=[
         "/AToZHToLLTTbar_MA-1300_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -673,9 +674,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1300_MH-500",
+    name="azh_ttll_a1300_h500",
     id=14640835,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1300_h500"],
     keys=[
         "/AToZHToLLTTbar_MA-1300_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -683,9 +684,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1300_MH-600",
+    name="azh_ttll_a1300_h600",
     id=14645563,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1300_h600"],
     keys=[
         "/AToZHToLLTTbar_MA-1300_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -693,9 +694,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1300_MH-700",
+    name="azh_ttll_a1300_h700",
     id=14637957,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1300_h700"],
     keys=[
         "/AToZHToLLTTbar_MA-1300_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -703,9 +704,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1300_MH-800",
+    name="azh_ttll_a1300_h800",
     id=14644759,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1300_h800"],
     keys=[
         "/AToZHToLLTTbar_MA-1300_MH-800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -713,9 +714,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1300_MH-900",
+    name="azh_ttll_a1300_h900",
     id=14636843,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1300_h900"],
     keys=[
         "/AToZHToLLTTbar_MA-1300_MH-900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -723,9 +724,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1400_MH-1000",
+    name="azh_ttll_a1400_h1000",
     id=14641266,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1400_h1000"],
     keys=[
         "/AToZHToLLTTbar_MA-1400_MH-1000_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -733,9 +734,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1400_MH-1100",
+    name="azh_ttll_a1400_h1100",
     id=14643808,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1400_h1100"],
     keys=[
         "/AToZHToLLTTbar_MA-1400_MH-1100_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -743,9 +744,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1400_MH-1200",
+    name="azh_ttll_a1400_h1200",
     id=14645021,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1400_h1200"],
     keys=[
         "/AToZHToLLTTbar_MA-1400_MH-1200_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -753,9 +754,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1400_MH-1300",
+    name="azh_ttll_a1400_h1300",
     id=14640339,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1400_h1300"],
     keys=[
         "/AToZHToLLTTbar_MA-1400_MH-1300_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -763,9 +764,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1400_MH-350",
+    name="azh_ttll_a1400_h350",
     id=14636494,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1400_h350"],
     keys=[
         "/AToZHToLLTTbar_MA-1400_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -773,9 +774,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1400_MH-400",
+    name="azh_ttll_a1400_h400",
     id=14644419,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1400_h400"],
     keys=[
         "/AToZHToLLTTbar_MA-1400_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -783,9 +784,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1400_MH-500",
+    name="azh_ttll_a1400_h500",
     id=14640681,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1400_h500"],
     keys=[
         "/AToZHToLLTTbar_MA-1400_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -793,9 +794,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1400_MH-600",
+    name="azh_ttll_a1400_h600",
     id=14643451,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1400_h600"],
     keys=[
         "/AToZHToLLTTbar_MA-1400_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -803,9 +804,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1400_MH-700",
+    name="azh_ttll_a1400_h700",
     id=14641327,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1400_h700"],
     keys=[
         "/AToZHToLLTTbar_MA-1400_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -813,9 +814,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1400_MH-800",
+    name="azh_ttll_a1400_h800",
     id=14644989,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1400_h800"],
     keys=[
         "/AToZHToLLTTbar_MA-1400_MH-800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -823,9 +824,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1400_MH-900",
+    name="azh_ttll_a1400_h900",
     id=14645622,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1400_h900"],
     keys=[
         "/AToZHToLLTTbar_MA-1400_MH-900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -833,9 +834,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1500_MH-1000",
+    name="azh_ttll_a1500_h1000",
     id=14647495,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1500_h1000"],
     keys=[
         "/AToZHToLLTTbar_MA-1500_MH-1000_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -843,9 +844,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1500_MH-1100",
+    name="azh_ttll_a1500_h1100",
     id=14641077,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1500_h1100"],
     keys=[
         "/AToZHToLLTTbar_MA-1500_MH-1100_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -853,9 +854,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1500_MH-1200",
+    name="azh_ttll_a1500_h1200",
     id=14644354,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1500_h1200"],
     keys=[
         "/AToZHToLLTTbar_MA-1500_MH-1200_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -863,9 +864,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1500_MH-1300",
+    name="azh_ttll_a1500_h1300",
     id=14638120,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1500_h1300"],
     keys=[
         "/AToZHToLLTTbar_MA-1500_MH-1300_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -873,9 +874,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1500_MH-1400",
+    name="azh_ttll_a1500_h1400",
     id=14647514,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1500_h1400"],
     keys=[
         "/AToZHToLLTTbar_MA-1500_MH-1400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -883,9 +884,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1500_MH-350",
+    name="azh_ttll_a1500_h350",
     id=14645022,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1500_h350"],
     keys=[
         "/AToZHToLLTTbar_MA-1500_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -893,9 +894,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1500_MH-400",
+    name="azh_ttll_a1500_h400",
     id=14548215,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1500_h400"],
     keys=[
         "/AToZHToLLTTbar_MA-1500_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -903,9 +904,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1500_MH-500",
+    name="azh_ttll_a1500_h500",
     id=14641173,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1500_h500"],
     keys=[
         "/AToZHToLLTTbar_MA-1500_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -913,9 +914,9 @@ cpn.add_dataset(
     n_events=49000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1500_MH-600",
+    name="azh_ttll_a1500_h600",
     id=14637940,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1500_h600"],
     keys=[
         "/AToZHToLLTTbar_MA-1500_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -923,9 +924,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1500_MH-700",
+    name="azh_ttll_a1500_h700",
     id=14640888,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1500_h700"],
     keys=[
         "/AToZHToLLTTbar_MA-1500_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -933,9 +934,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1500_MH-900",
+    name="azh_ttll_a1500_h900",
     id=14643452,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1500_h900"],
     keys=[
         "/AToZHToLLTTbar_MA-1500_MH-900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -943,9 +944,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1600_MH-1000",
+    name="azh_ttll_a1600_h1000",
     id=14641468,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1600_h1000"],
     keys=[
         "/AToZHToLLTTbar_MA-1600_MH-1000_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -953,9 +954,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1600_MH-1100",
+    name="azh_ttll_a1600_h1100",
     id=14637407,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1600_h1100"],
     keys=[
         "/AToZHToLLTTbar_MA-1600_MH-1100_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -963,9 +964,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1600_MH-1200",
+    name="azh_ttll_a1600_h1200",
     id=14638121,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1600_h1200"],
     keys=[
         "/AToZHToLLTTbar_MA-1600_MH-1200_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -973,9 +974,9 @@ cpn.add_dataset(
     n_events=49000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1600_MH-1300",
+    name="azh_ttll_a1600_h1300",
     id=14641294,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1600_h1300"],
     keys=[
         "/AToZHToLLTTbar_MA-1600_MH-1300_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -983,9 +984,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1600_MH-1400",
+    name="azh_ttll_a1600_h1400",
     id=14636598,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1600_h1400"],
     keys=[
         "/AToZHToLLTTbar_MA-1600_MH-1400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -993,9 +994,9 @@ cpn.add_dataset(
     n_events=49000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1600_MH-1500",
+    name="azh_ttll_a1600_h1500",
     id=14641495,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1600_h1500"],
     keys=[
         "/AToZHToLLTTbar_MA-1600_MH-1500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1003,9 +1004,9 @@ cpn.add_dataset(
     n_events=49000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1600_MH-350",
+    name="azh_ttll_a1600_h350",
     id=14637598,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1600_h350"],
     keys=[
         "/AToZHToLLTTbar_MA-1600_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1013,9 +1014,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1600_MH-400",
+    name="azh_ttll_a1600_h400",
     id=14644182,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1600_h400"],
     keys=[
         "/AToZHToLLTTbar_MA-1600_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1023,9 +1024,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1600_MH-500",
+    name="azh_ttll_a1600_h500",
     id=14641368,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1600_h500"],
     keys=[
         "/AToZHToLLTTbar_MA-1600_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1033,9 +1034,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1600_MH-600",
+    name="azh_ttll_a1600_h600",
     id=14644439,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1600_h600"],
     keys=[
         "/AToZHToLLTTbar_MA-1600_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1043,9 +1044,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1600_MH-900",
+    name="azh_ttll_a1600_h900",
     id=14640009,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1600_h900"],
     keys=[
         "/AToZHToLLTTbar_MA-1600_MH-900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1053,9 +1054,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1700_MH-1000",
+    name="azh_ttll_a1700_h1000",
     id=14640900,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1700_h1000"],
     keys=[
         "/AToZHToLLTTbar_MA-1700_MH-1000_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1063,9 +1064,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1700_MH-1100",
+    name="azh_ttll_a1700_h1100",
     id=14645008,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1700_h1100"],
     keys=[
         "/AToZHToLLTTbar_MA-1700_MH-1100_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1073,9 +1074,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1700_MH-1200",
+    name="azh_ttll_a1700_h1200",
     id=14644904,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1700_h1200"],
     keys=[
         "/AToZHToLLTTbar_MA-1700_MH-1200_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1083,9 +1084,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1700_MH-1300",
+    name="azh_ttll_a1700_h1300",
     id=14636430,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1700_h1300"],
     keys=[
         "/AToZHToLLTTbar_MA-1700_MH-1300_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1093,9 +1094,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1700_MH-1400",
+    name="azh_ttll_a1700_h1400",
     id=14636571,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1700_h1400"],
     keys=[
         "/AToZHToLLTTbar_MA-1700_MH-1400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1103,9 +1104,9 @@ cpn.add_dataset(
     n_events=48000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1700_MH-1500",
+    name="azh_ttll_a1700_h1500",
     id=14638199,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1700_h1500"],
     keys=[
         "/AToZHToLLTTbar_MA-1700_MH-1500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1113,9 +1114,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1700_MH-1600",
+    name="azh_ttll_a1700_h1600",
     id=14641481,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1700_h1600"],
     keys=[
         "/AToZHToLLTTbar_MA-1700_MH-1600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1123,9 +1124,9 @@ cpn.add_dataset(
     n_events=49000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1700_MH-350",
+    name="azh_ttll_a1700_h350",
     id=14645023,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1700_h350"],
     keys=[
         "/AToZHToLLTTbar_MA-1700_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1133,9 +1134,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1700_MH-400",
+    name="azh_ttll_a1700_h400",
     id=14645452,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1700_h400"],
     keys=[
         "/AToZHToLLTTbar_MA-1700_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1143,9 +1144,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1700_MH-500",
+    name="azh_ttll_a1700_h500",
     id=14636536,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1700_h500"],
     keys=[
         "/AToZHToLLTTbar_MA-1700_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1153,9 +1154,9 @@ cpn.add_dataset(
     n_events=49000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1700_MH-600",
+    name="azh_ttll_a1700_h600",
     id=14644424,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1700_h600"],
     keys=[
         "/AToZHToLLTTbar_MA-1700_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1163,9 +1164,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1700_MH-700",
+    name="azh_ttll_a1700_h700",
     id=14636781,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1700_h700"],
     keys=[
         "/AToZHToLLTTbar_MA-1700_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1173,9 +1174,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1700_MH-800",
+    name="azh_ttll_a1700_h800",
     id=14644001,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1700_h800"],
     keys=[
         "/AToZHToLLTTbar_MA-1700_MH-800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1183,9 +1184,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1700_MH-900",
+    name="azh_ttll_a1700_h900",
     id=14637536,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1700_h900"],
     keys=[
         "/AToZHToLLTTbar_MA-1700_MH-900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1193,9 +1194,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1800_MH-1000",
+    name="azh_ttll_a1800_h1000",
     id=14636446,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1800_h1000"],
     keys=[
         "/AToZHToLLTTbar_MA-1800_MH-1000_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1203,9 +1204,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1800_MH-1100",
+    name="azh_ttll_a1800_h1100",
     id=14645028,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1800_h1100"],
     keys=[
         "/AToZHToLLTTbar_MA-1800_MH-1100_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1213,9 +1214,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1800_MH-1200",
+    name="azh_ttll_a1800_h1200",
     id=14644991,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1800_h1200"],
     keys=[
         "/AToZHToLLTTbar_MA-1800_MH-1200_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1223,9 +1224,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1800_MH-1300",
+    name="azh_ttll_a1800_h1300",
     id=14643136,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1800_h1300"],
     keys=[
         "/AToZHToLLTTbar_MA-1800_MH-1300_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1233,9 +1234,9 @@ cpn.add_dataset(
     n_events=49000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1800_MH-1400",
+    name="azh_ttll_a1800_h1400",
     id=14644377,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1800_h1400"],
     keys=[
         "/AToZHToLLTTbar_MA-1800_MH-1400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1243,9 +1244,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1800_MH-1500",
+    name="azh_ttll_a1800_h1500",
     id=14641545,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1800_h1500"],
     keys=[
         "/AToZHToLLTTbar_MA-1800_MH-1500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1253,9 +1254,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1800_MH-1600",
+    name="azh_ttll_a1800_h1600",
     id=14536346,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1800_h1600"],
     keys=[
         "/AToZHToLLTTbar_MA-1800_MH-1600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1263,9 +1264,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1800_MH-1700",
+    name="azh_ttll_a1800_h1700",
     id=14638264,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1800_h1700"],
     keys=[
         "/AToZHToLLTTbar_MA-1800_MH-1700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1273,9 +1274,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1800_MH-350",
+    name="azh_ttll_a1800_h350",
     id=14645239,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1800_h350"],
     keys=[
         "/AToZHToLLTTbar_MA-1800_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1283,9 +1284,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1800_MH-400",
+    name="azh_ttll_a1800_h400",
     id=14647680,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1800_h400"],
     keys=[
         "/AToZHToLLTTbar_MA-1800_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1293,9 +1294,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1800_MH-500",
+    name="azh_ttll_a1800_h500",
     id=14636041,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1800_h500"],
     keys=[
         "/AToZHToLLTTbar_MA-1800_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1303,9 +1304,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1800_MH-600",
+    name="azh_ttll_a1800_h600",
     id=14638191,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1800_h600"],
     keys=[
         "/AToZHToLLTTbar_MA-1800_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1313,9 +1314,9 @@ cpn.add_dataset(
     n_events=49000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1800_MH-700",
+    name="azh_ttll_a1800_h700",
     id=14641337,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1800_h700"],
     keys=[
         "/AToZHToLLTTbar_MA-1800_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1323,9 +1324,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1800_MH-800",
+    name="azh_ttll_a1800_h800",
     id=14641404,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1800_h800"],
     keys=[
         "/AToZHToLLTTbar_MA-1800_MH-800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1333,9 +1334,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1800_MH-900",
+    name="azh_ttll_a1800_h900",
     id=14644425,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1800_h900"],
     keys=[
         "/AToZHToLLTTbar_MA-1800_MH-900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1343,9 +1344,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1900_MH-1000",
+    name="azh_ttll_a1900_h1000",
     id=14645483,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1900_h1000"],
     keys=[
         "/AToZHToLLTTbar_MA-1900_MH-1000_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1353,9 +1354,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1900_MH-1100",
+    name="azh_ttll_a1900_h1100",
     id=14641381,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1900_h1100"],
     keys=[
         "/AToZHToLLTTbar_MA-1900_MH-1100_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1363,9 +1364,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1900_MH-1200",
+    name="azh_ttll_a1900_h1200",
     id=14644032,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1900_h1200"],
     keys=[
         "/AToZHToLLTTbar_MA-1900_MH-1200_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1373,9 +1374,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1900_MH-1300",
+    name="azh_ttll_a1900_h1300",
     id=14640668,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1900_h1300"],
     keys=[
         "/AToZHToLLTTbar_MA-1900_MH-1300_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1383,9 +1384,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1900_MH-1400",
+    name="azh_ttll_a1900_h1400",
     id=14638513,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1900_h1400"],
     keys=[
         "/AToZHToLLTTbar_MA-1900_MH-1400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1393,9 +1394,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1900_MH-1500",
+    name="azh_ttll_a1900_h1500",
     id=14641448,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1900_h1500"],
     keys=[
         "/AToZHToLLTTbar_MA-1900_MH-1500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1403,9 +1404,9 @@ cpn.add_dataset(
     n_events=48000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1900_MH-1600",
+    name="azh_ttll_a1900_h1600",
     id=14644761,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1900_h1600"],
     keys=[
         "/AToZHToLLTTbar_MA-1900_MH-1600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1413,9 +1414,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1900_MH-1700",
+    name="azh_ttll_a1900_h1700",
     id=14644521,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1900_h1700"],
     keys=[
         "/AToZHToLLTTbar_MA-1900_MH-1700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1423,9 +1424,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1900_MH-1800",
+    name="azh_ttll_a1900_h1800",
     id=14639947,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1900_h1800"],
     keys=[
         "/AToZHToLLTTbar_MA-1900_MH-1800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1433,9 +1434,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1900_MH-350",
+    name="azh_ttll_a1900_h350",
     id=14645606,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1900_h350"],
     keys=[
         "/AToZHToLLTTbar_MA-1900_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1443,9 +1444,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1900_MH-400",
+    name="azh_ttll_a1900_h400",
     id=14640620,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1900_h400"],
     keys=[
         "/AToZHToLLTTbar_MA-1900_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1453,9 +1454,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1900_MH-500",
+    name="azh_ttll_a1900_h500",
     id=14644122,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1900_h500"],
     keys=[
         "/AToZHToLLTTbar_MA-1900_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1463,9 +1464,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1900_MH-600",
+    name="azh_ttll_a1900_h600",
     id=14638778,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1900_h600"],
     keys=[
         "/AToZHToLLTTbar_MA-1900_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1473,9 +1474,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1900_MH-700",
+    name="azh_ttll_a1900_h700",
     id=14643966,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1900_h700"],
     keys=[
         "/AToZHToLLTTbar_MA-1900_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1483,9 +1484,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1900_MH-800",
+    name="azh_ttll_a1900_h800",
     id=14644992,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1900_h800"],
     keys=[
         "/AToZHToLLTTbar_MA-1900_MH-800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1493,9 +1494,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-1900_MH-900",
+    name="azh_ttll_a1900_h900",
     id=14636485,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a1900_h900"],
     keys=[
         "/AToZHToLLTTbar_MA-1900_MH-900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1503,9 +1504,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-2000_MH-1000",
+    name="azh_ttll_a2000_h1000",
     id=14640348,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a2000_h1000"],
     keys=[
         "/AToZHToLLTTbar_MA-2000_MH-1000_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1513,9 +1514,9 @@ cpn.add_dataset(
     n_events=48000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-2000_MH-1100",
+    name="azh_ttll_a2000_h1100",
     id=14644809,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a2000_h1100"],
     keys=[
         "/AToZHToLLTTbar_MA-2000_MH-1100_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1523,9 +1524,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-2000_MH-1200",
+    name="azh_ttll_a2000_h1200",
     id=14637610,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a2000_h1200"],
     keys=[
         "/AToZHToLLTTbar_MA-2000_MH-1200_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1533,9 +1534,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-2000_MH-1300",
+    name="azh_ttll_a2000_h1300",
     id=14636407,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a2000_h1300"],
     keys=[
         "/AToZHToLLTTbar_MA-2000_MH-1300_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1543,9 +1544,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-2000_MH-1400",
+    name="azh_ttll_a2000_h1400",
     id=14641386,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a2000_h1400"],
     keys=[
         "/AToZHToLLTTbar_MA-2000_MH-1400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1553,9 +1554,9 @@ cpn.add_dataset(
     n_events=48000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-2000_MH-1600",
+    name="azh_ttll_a2000_h1600",
     id=14636572,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a2000_h1600"],
     keys=[
         "/AToZHToLLTTbar_MA-2000_MH-1600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1563,9 +1564,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-2000_MH-1700",
+    name="azh_ttll_a2000_h1700",
     id=14645641,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a2000_h1700"],
     keys=[
         "/AToZHToLLTTbar_MA-2000_MH-1700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1573,9 +1574,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-2000_MH-1800",
+    name="azh_ttll_a2000_h1800",
     id=14638745,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a2000_h1800"],
     keys=[
         "/AToZHToLLTTbar_MA-2000_MH-1800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1583,9 +1584,9 @@ cpn.add_dataset(
     n_events=49000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-2000_MH-1900",
+    name="azh_ttll_a2000_h1900",
     id=14640887,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a2000_h1900"],
     keys=[
         "/AToZHToLLTTbar_MA-2000_MH-1900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1593,9 +1594,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-2000_MH-350",
+    name="azh_ttll_a2000_h350",
     id=14645372,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a2000_h350"],
     keys=[
         "/AToZHToLLTTbar_MA-2000_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1603,9 +1604,9 @@ cpn.add_dataset(
     n_events=48000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-2000_MH-400",
+    name="azh_ttll_a2000_h400",
     id=14640824,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a2000_h400"],
     keys=[
         "/AToZHToLLTTbar_MA-2000_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1613,9 +1614,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-2000_MH-500",
+    name="azh_ttll_a2000_h500",
     id=14641466,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a2000_h500"],
     keys=[
         "/AToZHToLLTTbar_MA-2000_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1623,9 +1624,9 @@ cpn.add_dataset(
     n_events=48000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-2000_MH-600",
+    name="azh_ttll_a2000_h600",
     id=14644380,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a2000_h600"],
     keys=[
         "/AToZHToLLTTbar_MA-2000_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1633,9 +1634,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-2000_MH-700",
+    name="azh_ttll_a2000_h700",
     id=14641216,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a2000_h700"],
     keys=[
         "/AToZHToLLTTbar_MA-2000_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1643,9 +1644,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-2000_MH-800",
+    name="azh_ttll_a2000_h800",
     id=14636495,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a2000_h800"],
     keys=[
         "/AToZHToLLTTbar_MA-2000_MH-800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1653,9 +1654,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-2000_MH-900",
+    name="azh_ttll_a2000_h900",
     id=14643988,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a2000_h900"],
     keys=[
         "/AToZHToLLTTbar_MA-2000_MH-900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1663,9 +1664,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-2100_MH-1000",
+    name="azh_ttll_a2100_h1000",
     id=14536369,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a2100_h1000"],
     keys=[
         "/AToZHToLLTTbar_MA-2100_MH-1000_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1673,9 +1674,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-2100_MH-1100",
+    name="azh_ttll_a2100_h1100",
     id=14637855,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a2100_h1100"],
     keys=[
         "/AToZHToLLTTbar_MA-2100_MH-1100_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1683,9 +1684,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-2100_MH-1200",
+    name="azh_ttll_a2100_h1200",
     id=14640710,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a2100_h1200"],
     keys=[
         "/AToZHToLLTTbar_MA-2100_MH-1200_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1693,9 +1694,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-2100_MH-1300",
+    name="azh_ttll_a2100_h1300",
     id=14636479,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a2100_h1300"],
     keys=[
         "/AToZHToLLTTbar_MA-2100_MH-1300_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1703,9 +1704,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-2100_MH-1400",
+    name="azh_ttll_a2100_h1400",
     id=14637248,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a2100_h1400"],
     keys=[
         "/AToZHToLLTTbar_MA-2100_MH-1400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1713,9 +1714,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-2100_MH-1500",
+    name="azh_ttll_a2100_h1500",
     id=14645029,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a2100_h1500"],
     keys=[
         "/AToZHToLLTTbar_MA-2100_MH-1500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1723,9 +1724,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-2100_MH-1700",
+    name="azh_ttll_a2100_h1700",
     id=14637551,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a2100_h1700"],
     keys=[
         "/AToZHToLLTTbar_MA-2100_MH-1700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1733,9 +1734,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-2100_MH-1800",
+    name="azh_ttll_a2100_h1800",
     id=14638095,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a2100_h1800"],
     keys=[
         "/AToZHToLLTTbar_MA-2100_MH-1800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1743,9 +1744,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-2100_MH-1900",
+    name="azh_ttll_a2100_h1900",
     id=14643999,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a2100_h1900"],
     keys=[
         "/AToZHToLLTTbar_MA-2100_MH-1900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1753,9 +1754,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-2100_MH-2000",
+    name="azh_ttll_a2100_h2000",
     id=14536433,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a2100_h2000"],
     keys=[
         "/AToZHToLLTTbar_MA-2100_MH-2000_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1763,9 +1764,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-2100_MH-350",
+    name="azh_ttll_a2100_h350",
     id=14640847,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a2100_h350"],
     keys=[
         "/AToZHToLLTTbar_MA-2100_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1773,9 +1774,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-2100_MH-400",
+    name="azh_ttll_a2100_h400",
     id=14549535,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a2100_h400"],
     keys=[
         "/AToZHToLLTTbar_MA-2100_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1783,9 +1784,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-2100_MH-500",
+    name="azh_ttll_a2100_h500",
     id=14641088,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a2100_h500"],
     keys=[
         "/AToZHToLLTTbar_MA-2100_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1793,9 +1794,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-2100_MH-600",
+    name="azh_ttll_a2100_h600",
     id=14645539,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a2100_h600"],
     keys=[
         "/AToZHToLLTTbar_MA-2100_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1803,9 +1804,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-2100_MH-700",
+    name="azh_ttll_a2100_h700",
     id=14636576,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a2100_h700"],
     keys=[
         "/AToZHToLLTTbar_MA-2100_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1813,9 +1814,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-2100_MH-800",
+    name="azh_ttll_a2100_h800",
     id=14644946,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a2100_h800"],
     keys=[
         "/AToZHToLLTTbar_MA-2100_MH-800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1823,9 +1824,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-2100_MH-900",
+    name="azh_ttll_a2100_h900",
     id=14641004,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a2100_h900"],
     keys=[
         "/AToZHToLLTTbar_MA-2100_MH-900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1833,9 +1834,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-430_MH-330",
+    name="azh_ttll_a430_h330",
     id=14640871,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a430_h330"],
     keys=[
         "/AToZHToLLTTbar_MA-430_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1843,9 +1844,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-450_MH-330",
+    name="azh_ttll_a450_h330",
     id=14641217,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a450_h330"],
     keys=[
         "/AToZHToLLTTbar_MA-450_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1853,9 +1854,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-450_MH-350",
+    name="azh_ttll_a450_h350",
     id=14637724,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a450_h350"],
     keys=[
         "/AToZHToLLTTbar_MA-450_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1863,9 +1864,9 @@ cpn.add_dataset(
     n_events=49000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-500_MH-330",
+    name="azh_ttll_a500_h330",
     id=14645669,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a500_h330"],
     keys=[
         "/AToZHToLLTTbar_MA-500_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1873,9 +1874,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-500_MH-350",
+    name="azh_ttll_a500_h350",
     id=14548216,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a500_h350"],
     keys=[
         "/AToZHToLLTTbar_MA-500_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1883,9 +1884,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-500_MH-370",
+    name="azh_ttll_a500_h370",
     id=14648537,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a500_h370"],
     keys=[
         "/AToZHToLLTTbar_MA-500_MH-370_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1893,9 +1894,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-500_MH-400",
+    name="azh_ttll_a500_h400",
     id=14537163,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a500_h400"],
     keys=[
         "/AToZHToLLTTbar_MA-500_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1903,9 +1904,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-550_MH-330",
+    name="azh_ttll_a550_h330",
     id=14640737,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a550_h330"],
     keys=[
         "/AToZHToLLTTbar_MA-550_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1913,9 +1914,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-550_MH-350",
+    name="azh_ttll_a550_h350",
     id=14641310,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a550_h350"],
     keys=[
         "/AToZHToLLTTbar_MA-550_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1923,9 +1924,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-550_MH-400",
+    name="azh_ttll_a550_h400",
     id=14641298,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a550_h400"],
     keys=[
         "/AToZHToLLTTbar_MA-550_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1933,9 +1934,9 @@ cpn.add_dataset(
     n_events=48000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-550_MH-450",
+    name="azh_ttll_a550_h450",
     id=14644728,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a550_h450"],
     keys=[
         "/AToZHToLLTTbar_MA-550_MH-450_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1943,9 +1944,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-600_MH-330",
+    name="azh_ttll_a600_h330",
     id=14643492,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a600_h330"],
     keys=[
         "/AToZHToLLTTbar_MA-600_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1953,9 +1954,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-600_MH-350",
+    name="azh_ttll_a600_h350",
     id=14644865,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a600_h350"],
     keys=[
         "/AToZHToLLTTbar_MA-600_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1963,9 +1964,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-600_MH-400",
+    name="azh_ttll_a600_h400",
     id=14640637,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a600_h400"],
     keys=[
         "/AToZHToLLTTbar_MA-600_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1973,9 +1974,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-600_MH-450",
+    name="azh_ttll_a600_h450",
     id=14644417,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a600_h450"],
     keys=[
         "/AToZHToLLTTbar_MA-600_MH-450_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1983,9 +1984,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-600_MH-500",
+    name="azh_ttll_a600_h500",
     id=14641414,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a600_h500"],
     keys=[
         "/AToZHToLLTTbar_MA-600_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -1993,9 +1994,9 @@ cpn.add_dataset(
     n_events=48000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-650_MH-330",
+    name="azh_ttll_a650_h330",
     id=14644791,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a650_h330"],
     keys=[
         "/AToZHToLLTTbar_MA-650_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2003,9 +2004,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-650_MH-350",
+    name="azh_ttll_a650_h350",
     id=14636505,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a650_h350"],
     keys=[
         "/AToZHToLLTTbar_MA-650_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2013,9 +2014,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-650_MH-400",
+    name="azh_ttll_a650_h400",
     id=14643912,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a650_h400"],
     keys=[
         "/AToZHToLLTTbar_MA-650_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2023,9 +2024,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-650_MH-450",
+    name="azh_ttll_a650_h450",
     id=14641233,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a650_h450"],
     keys=[
         "/AToZHToLLTTbar_MA-650_MH-450_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2033,9 +2034,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-650_MH-500",
+    name="azh_ttll_a650_h500",
     id=14637773,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a650_h500"],
     keys=[
         "/AToZHToLLTTbar_MA-650_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2043,9 +2044,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-650_MH-550",
+    name="azh_ttll_a650_h550",
     id=14637782,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a650_h550"],
     keys=[
         "/AToZHToLLTTbar_MA-650_MH-550_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2053,9 +2054,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-700_MH-330",
+    name="azh_ttll_a700_h330",
     id=14637877,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a700_h330"],
     keys=[
         "/AToZHToLLTTbar_MA-700_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2063,9 +2064,9 @@ cpn.add_dataset(
     n_events=49000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-700_MH-350",
+    name="azh_ttll_a700_h350",
     id=14549119,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a700_h350"],
     keys=[
         "/AToZHToLLTTbar_MA-700_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2073,9 +2074,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-700_MH-370",
+    name="azh_ttll_a700_h370",
     id=14548653,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a700_h370"],
     keys=[
         "/AToZHToLLTTbar_MA-700_MH-370_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2083,9 +2084,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-700_MH-400",
+    name="azh_ttll_a700_h400",
     id=14550258,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a700_h400"],
     keys=[
         "/AToZHToLLTTbar_MA-700_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2093,9 +2094,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-700_MH-450",
+    name="azh_ttll_a700_h450",
     id=14644343,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a700_h450"],
     keys=[
         "/AToZHToLLTTbar_MA-700_MH-450_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2103,9 +2104,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-700_MH-500",
+    name="azh_ttll_a700_h500",
     id=14645288,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a700_h500"],
     keys=[
         "/AToZHToLLTTbar_MA-700_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2113,9 +2114,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-700_MH-550",
+    name="azh_ttll_a700_h550",
     id=14644477,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a700_h550"],
     keys=[
         "/AToZHToLLTTbar_MA-700_MH-550_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2123,9 +2124,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-750_MH-330",
+    name="azh_ttll_a750_h330",
     id=14641059,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a750_h330"],
     keys=[
         "/AToZHToLLTTbar_MA-750_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2133,9 +2134,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-750_MH-350",
+    name="azh_ttll_a750_h350",
     id=14644713,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a750_h350"],
     keys=[
         "/AToZHToLLTTbar_MA-750_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2143,9 +2144,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-750_MH-400",
+    name="azh_ttll_a750_h400",
     id=14637708,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a750_h400"],
     keys=[
         "/AToZHToLLTTbar_MA-750_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2153,9 +2154,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-750_MH-450",
+    name="azh_ttll_a750_h450",
     id=14640716,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a750_h450"],
     keys=[
         "/AToZHToLLTTbar_MA-750_MH-450_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2163,9 +2164,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-750_MH-500",
+    name="azh_ttll_a750_h500",
     id=14636467,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a750_h500"],
     keys=[
         "/AToZHToLLTTbar_MA-750_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2173,9 +2174,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-750_MH-550",
+    name="azh_ttll_a750_h550",
     id=14644222,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a750_h550"],
     keys=[
         "/AToZHToLLTTbar_MA-750_MH-550_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2183,9 +2184,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-750_MH-600",
+    name="azh_ttll_a750_h600",
     id=14644813,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a750_h600"],
     keys=[
         "/AToZHToLLTTbar_MA-750_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2193,9 +2194,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-750_MH-650",
+    name="azh_ttll_a750_h650",
     id=14644183,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a750_h650"],
     keys=[
         "/AToZHToLLTTbar_MA-750_MH-650_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2203,9 +2204,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-800_MH-330",
+    name="azh_ttll_a800_h330",
     id=14643977,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a800_h330"],
     keys=[
         "/AToZHToLLTTbar_MA-800_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2213,9 +2214,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-800_MH-350",
+    name="azh_ttll_a800_h350",
     id=14638955,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a800_h350"],
     keys=[
         "/AToZHToLLTTbar_MA-800_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2223,9 +2224,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-800_MH-400",
+    name="azh_ttll_a800_h400",
     id=14643987,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a800_h400"],
     keys=[
         "/AToZHToLLTTbar_MA-800_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2233,9 +2234,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-800_MH-450",
+    name="azh_ttll_a800_h450",
     id=14637537,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a800_h450"],
     keys=[
         "/AToZHToLLTTbar_MA-800_MH-450_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2243,9 +2244,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-800_MH-500",
+    name="azh_ttll_a800_h500",
     id=14636808,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a800_h500"],
     keys=[
         "/AToZHToLLTTbar_MA-800_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2253,9 +2254,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-800_MH-550",
+    name="azh_ttll_a800_h550",
     id=14640965,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a800_h550"],
     keys=[
         "/AToZHToLLTTbar_MA-800_MH-550_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2263,9 +2264,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-800_MH-600",
+    name="azh_ttll_a800_h600",
     id=14548217,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a800_h600"],
     keys=[
         "/AToZHToLLTTbar_MA-800_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2273,9 +2274,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-800_MH-650",
+    name="azh_ttll_a800_h650",
     id=14647537,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a800_h650"],
     keys=[
         "/AToZHToLLTTbar_MA-800_MH-650_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2283,9 +2284,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-800_MH-700",
+    name="azh_ttll_a800_h700",
     id=14637545,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a800_h700"],
     keys=[
         "/AToZHToLLTTbar_MA-800_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2293,9 +2294,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-850_MH-330",
+    name="azh_ttll_a850_h330",
     id=14636408,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a850_h330"],
     keys=[
         "/AToZHToLLTTbar_MA-850_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2303,9 +2304,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-850_MH-350",
+    name="azh_ttll_a850_h350",
     id=14640072,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a850_h350"],
     keys=[
         "/AToZHToLLTTbar_MA-850_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2313,9 +2314,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-850_MH-400",
+    name="azh_ttll_a850_h400",
     id=14641161,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a850_h400"],
     keys=[
         "/AToZHToLLTTbar_MA-850_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2323,9 +2324,9 @@ cpn.add_dataset(
     n_events=49000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-850_MH-450",
+    name="azh_ttll_a850_h450",
     id=14644205,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a850_h450"],
     keys=[
         "/AToZHToLLTTbar_MA-850_MH-450_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2333,9 +2334,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-850_MH-500",
+    name="azh_ttll_a850_h500",
     id=14636506,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a850_h500"],
     keys=[
         "/AToZHToLLTTbar_MA-850_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2343,9 +2344,9 @@ cpn.add_dataset(
     n_events=49000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-850_MH-550",
+    name="azh_ttll_a850_h550",
     id=14640940,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a850_h550"],
     keys=[
         "/AToZHToLLTTbar_MA-850_MH-550_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2353,9 +2354,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-850_MH-600",
+    name="azh_ttll_a850_h600",
     id=14637903,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a850_h600"],
     keys=[
         "/AToZHToLLTTbar_MA-850_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2363,9 +2364,9 @@ cpn.add_dataset(
     n_events=48000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-850_MH-650",
+    name="azh_ttll_a850_h650",
     id=14644591,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a850_h650"],
     keys=[
         "/AToZHToLLTTbar_MA-850_MH-650_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2373,9 +2374,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-850_MH-700",
+    name="azh_ttll_a850_h700",
     id=14645081,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a850_h700"],
     keys=[
         "/AToZHToLLTTbar_MA-850_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2383,9 +2384,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-850_MH-750",
+    name="azh_ttll_a850_h750",
     id=14640939,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a850_h750"],
     keys=[
         "/AToZHToLLTTbar_MA-850_MH-750_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2393,9 +2394,9 @@ cpn.add_dataset(
     n_events=49000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-900_MH-330",
+    name="azh_ttll_a900_h330",
     id=14641018,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a900_h330"],
     keys=[
         "/AToZHToLLTTbar_MA-900_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2403,9 +2404,9 @@ cpn.add_dataset(
     n_events=48000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-900_MH-350",
+    name="azh_ttll_a900_h350",
     id=14647696,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a900_h350"],
     keys=[
         "/AToZHToLLTTbar_MA-900_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2413,9 +2414,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-900_MH-370",
+    name="azh_ttll_a900_h370",
     id=14548218,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a900_h370"],
     keys=[
         "/AToZHToLLTTbar_MA-900_MH-370_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2423,9 +2424,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-900_MH-400",
+    name="azh_ttll_a900_h400",
     id=14544289,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a900_h400"],
     keys=[
         "/AToZHToLLTTbar_MA-900_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2433,9 +2434,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-900_MH-450",
+    name="azh_ttll_a900_h450",
     id=14637509,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a900_h450"],
     keys=[
         "/AToZHToLLTTbar_MA-900_MH-450_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2443,9 +2444,9 @@ cpn.add_dataset(
     n_events=49000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-900_MH-550",
+    name="azh_ttll_a900_h550",
     id=14640075,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a900_h550"],
     keys=[
         "/AToZHToLLTTbar_MA-900_MH-550_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2453,9 +2454,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-900_MH-500",
+    name="azh_ttll_a900_h500",
     id=14640067,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a900_h500"],
     keys=[
         "/AToZHToLLTTbar_MA-900_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2463,9 +2464,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-900_MH-600",
+    name="azh_ttll_a900_h600",
     id=14641600,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a900_h600"],
     keys=[
         "/AToZHToLLTTbar_MA-900_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2473,9 +2474,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-900_MH-650",
+    name="azh_ttll_a900_h650",
     id=14645044,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a900_h650"],
     keys=[
         "/AToZHToLLTTbar_MA-900_MH-650_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2483,9 +2484,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-900_MH-700",
+    name="azh_ttll_a900_h700",
     id=14644427,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a900_h700"],
     keys=[
         "/AToZHToLLTTbar_MA-900_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2493,9 +2494,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-900_MH-750",
+    name="azh_ttll_a900_h750",
     id=14641142,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a900_h750"],
     keys=[
         "/AToZHToLLTTbar_MA-900_MH-750_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2503,9 +2504,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-900_MH-800",
+    name="azh_ttll_a900_h800",
     id=14636409,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a900_h800"],
     keys=[
         "/AToZHToLLTTbar_MA-900_MH-800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2513,9 +2514,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-950_MH-330",
+    name="azh_ttll_a950_h330",
     id=14636607,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a950_h330"],
     keys=[
         "/AToZHToLLTTbar_MA-950_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2523,9 +2524,9 @@ cpn.add_dataset(
     n_events=48000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-950_MH-350",
+    name="azh_ttll_a950_h350",
     id=14638010,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a950_h350"],
     keys=[
         "/AToZHToLLTTbar_MA-950_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2533,9 +2534,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-950_MH-400",
+    name="azh_ttll_a950_h400",
     id=14638017,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a950_h400"],
     keys=[
         "/AToZHToLLTTbar_MA-950_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2543,9 +2544,9 @@ cpn.add_dataset(
     n_events=48000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-950_MH-450",
+    name="azh_ttll_a950_h450",
     id=14642920,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a950_h450"],
     keys=[
         "/AToZHToLLTTbar_MA-950_MH-450_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2553,9 +2554,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-950_MH-500",
+    name="azh_ttll_a950_h500",
     id=14637960,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a950_h500"],
     keys=[
         "/AToZHToLLTTbar_MA-950_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2563,9 +2564,9 @@ cpn.add_dataset(
     n_events=49000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-950_MH-550",
+    name="azh_ttll_a950_h550",
     id=14641687,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a950_h550"],
     keys=[
         "/AToZHToLLTTbar_MA-950_MH-550_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2573,9 +2574,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-950_MH-600",
+    name="azh_ttll_a950_h600",
     id=14637720,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a950_h600"],
     keys=[
         "/AToZHToLLTTbar_MA-950_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2583,9 +2584,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-950_MH-650",
+    name="azh_ttll_a950_h650",
     id=14637077,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a950_h650"],
     keys=[
         "/AToZHToLLTTbar_MA-950_MH-650_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2593,9 +2594,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-950_MH-700",
+    name="azh_ttll_a950_h700",
     id=14636448,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a950_h700"],
     keys=[
         "/AToZHToLLTTbar_MA-950_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2603,9 +2604,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-950_MH-750",
+    name="azh_ttll_a950_h750",
     id=14644979,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a950_h750"],
     keys=[
         "/AToZHToLLTTbar_MA-950_MH-750_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2613,9 +2614,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-950_MH-800",
+    name="azh_ttll_a950_h800",
     id=14645411,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a950_h800"],
     keys=[
         "/AToZHToLLTTbar_MA-950_MH-800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],
@@ -2623,9 +2624,9 @@ cpn.add_dataset(
     n_events=50000,
 )
 cpn.add_dataset(
-    name="AToZHToLLTTbar_MA-950_MH-850",
+    name="azh_ttll_a950_h850",
     id=14636342,
-    processes=[procs.AToZHToLLTTbar],
+    processes=["procs.azh_ttll_a950_h850"],
     keys=[
         "/AToZHToLLTTbar_MA-950_MH-850_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
     ],

--- a/cmsdb/campaigns/run2_2017_nano_v9/azh.py
+++ b/cmsdb/campaigns/run2_2017_nano_v9/azh.py
@@ -1,0 +1,2638 @@
+# coding: utf-8
+
+"""
+A->ZH->Ztt datasets for the 2017 data-taking campaign
+"""
+
+import cmsdb.processes as procs
+from cmsdb.campaigns.run2_2017_nano_v9 import campaign_run2_2017_nano_v9 as cpn
+
+
+#
+# AZH->Ztt->lltt
+#
+
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1000_MH-330",
+    id=14640747,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1000_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1000_MH-350",
+    id=14640749,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1000_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1000_MH-400",
+    id=14644922,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1000_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1000_MH-450",
+    id=14644445,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1000_MH-450_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1000_MH-500",
+    id=14644631,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1000_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1000_MH-550",
+    id=14637796,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1000_MH-550_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=49000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1000_MH-600",
+    id=14548924,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1000_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1000_MH-650",
+    id=14643976,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1000_MH-650_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1000_MH-700",
+    id=14536925,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1000_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1000_MH-750",
+    id=14636760,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1000_MH-750_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1000_MH-800",
+    id=14548527,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1000_MH-800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=49000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1000_MH-850",
+    id=14644480,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1000_MH-850_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1000_MH-900",
+    id=14641365,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1000_MH-900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1050_MH-330",
+    id=14644650,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1050_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1050_MH-350",
+    id=14636601,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1050_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1050_MH-400",
+    id=14637383,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1050_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1050_MH-450",
+    id=14643202,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1050_MH-450_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1050_MH-500",
+    id=14645580,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1050_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1050_MH-550",
+    id=14637742,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1050_MH-550_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1050_MH-600",
+    id=14637456,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1050_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1050_MH-700",
+    id=14638692,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1050_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1050_MH-750",
+    id=14637603,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1050_MH-750_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=49000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1050_MH-800",
+    id=14639246,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1050_MH-800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=48000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1050_MH-850",
+    id=14641223,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1050_MH-850_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1050_MH-900",
+    id=14645437,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1050_MH-900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1050_MH-950",
+    id=14644029,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1050_MH-950_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1100_MH-1000",
+    id=14638003,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1100_MH-1000_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1100_MH-330",
+    id=14643995,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1100_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1100_MH-350",
+    id=14643757,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1100_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1100_MH-400",
+    id=14644862,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1100_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1100_MH-450",
+    id=14641209,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1100_MH-450_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1100_MH-500",
+    id=14643951,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1100_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1100_MH-550",
+    id=14640899,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1100_MH-550_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=49000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1100_MH-600",
+    id=14640946,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1100_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1100_MH-650",
+    id=14640680,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1100_MH-650_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1100_MH-700",
+    id=14645549,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1100_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1100_MH-750",
+    id=14637895,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1100_MH-750_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1100_MH-800",
+    id=14636438,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1100_MH-800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1100_MH-850",
+    id=14643264,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1100_MH-850_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1100_MH-900",
+    id=14641361,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1100_MH-900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=48000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1100_MH-950",
+    id=14641067,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1100_MH-950_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1150_MH-1050",
+    id=14637047,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1150_MH-1050_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1150_MH-330",
+    id=14645065,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1150_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1150_MH-350",
+    id=14641502,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1150_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1150_MH-450",
+    id=14638090,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1150_MH-450_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1150_MH-550",
+    id=14645380,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1150_MH-550_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1150_MH-650",
+    id=14637436,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1150_MH-650_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1150_MH-750",
+    id=14644493,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1150_MH-750_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1150_MH-850",
+    id=14645060,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1150_MH-850_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1150_MH-950",
+    id=14644915,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1150_MH-950_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1200_MH-1000",
+    id=14543193,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1200_MH-1000_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1200_MH-1100",
+    id=14644025,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1200_MH-1100_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1200_MH-330",
+    id=14637970,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1200_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=48000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1200_MH-350",
+    id=14644005,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1200_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1200_MH-400",
+    id=14647612,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1200_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1200_MH-500",
+    id=14644884,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1200_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1200_MH-600",
+    id=14644415,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1200_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1200_MH-700",
+    id=14641569,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1200_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1200_MH-800",
+    id=14639844,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1200_MH-800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1200_MH-850",
+    id=14549534,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1200_MH-850_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1200_MH-900",
+    id=14641099,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1200_MH-900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1300_MH-1000",
+    id=14640819,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1300_MH-1000_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1300_MH-1100",
+    id=14641489,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1300_MH-1100_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1300_MH-1200",
+    id=14644883,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1300_MH-1200_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1300_MH-350",
+    id=14645154,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1300_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1300_MH-400",
+    id=14639378,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1300_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1300_MH-500",
+    id=14640835,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1300_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1300_MH-600",
+    id=14645563,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1300_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1300_MH-700",
+    id=14637957,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1300_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1300_MH-800",
+    id=14644759,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1300_MH-800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1300_MH-900",
+    id=14636843,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1300_MH-900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1400_MH-1000",
+    id=14641266,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1400_MH-1000_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1400_MH-1100",
+    id=14643808,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1400_MH-1100_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1400_MH-1200",
+    id=14645021,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1400_MH-1200_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1400_MH-1300",
+    id=14640339,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1400_MH-1300_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1400_MH-350",
+    id=14636494,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1400_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1400_MH-400",
+    id=14644419,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1400_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1400_MH-500",
+    id=14640681,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1400_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1400_MH-600",
+    id=14643451,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1400_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1400_MH-700",
+    id=14641327,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1400_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1400_MH-800",
+    id=14644989,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1400_MH-800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1400_MH-900",
+    id=14645622,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1400_MH-900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1500_MH-1000",
+    id=14647495,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1500_MH-1000_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1500_MH-1100",
+    id=14641077,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1500_MH-1100_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1500_MH-1200",
+    id=14644354,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1500_MH-1200_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1500_MH-1300",
+    id=14638120,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1500_MH-1300_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1500_MH-1400",
+    id=14647514,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1500_MH-1400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1500_MH-350",
+    id=14645022,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1500_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1500_MH-400",
+    id=14548215,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1500_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1500_MH-500",
+    id=14641173,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1500_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=49000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1500_MH-600",
+    id=14637940,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1500_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1500_MH-700",
+    id=14640888,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1500_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1500_MH-900",
+    id=14643452,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1500_MH-900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1600_MH-1000",
+    id=14641468,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1600_MH-1000_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1600_MH-1100",
+    id=14637407,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1600_MH-1100_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1600_MH-1200",
+    id=14638121,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1600_MH-1200_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=49000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1600_MH-1300",
+    id=14641294,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1600_MH-1300_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1600_MH-1400",
+    id=14636598,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1600_MH-1400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=49000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1600_MH-1500",
+    id=14641495,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1600_MH-1500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=49000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1600_MH-350",
+    id=14637598,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1600_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1600_MH-400",
+    id=14644182,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1600_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1600_MH-500",
+    id=14641368,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1600_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1600_MH-600",
+    id=14644439,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1600_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1600_MH-900",
+    id=14640009,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1600_MH-900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1700_MH-1000",
+    id=14640900,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1700_MH-1000_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1700_MH-1100",
+    id=14645008,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1700_MH-1100_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1700_MH-1200",
+    id=14644904,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1700_MH-1200_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1700_MH-1300",
+    id=14636430,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1700_MH-1300_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1700_MH-1400",
+    id=14636571,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1700_MH-1400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=48000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1700_MH-1500",
+    id=14638199,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1700_MH-1500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1700_MH-1600",
+    id=14641481,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1700_MH-1600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=49000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1700_MH-350",
+    id=14645023,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1700_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1700_MH-400",
+    id=14645452,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1700_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1700_MH-500",
+    id=14636536,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1700_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=49000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1700_MH-600",
+    id=14644424,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1700_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1700_MH-700",
+    id=14636781,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1700_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1700_MH-800",
+    id=14644001,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1700_MH-800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1700_MH-900",
+    id=14637536,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1700_MH-900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1800_MH-1000",
+    id=14636446,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1800_MH-1000_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1800_MH-1100",
+    id=14645028,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1800_MH-1100_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1800_MH-1200",
+    id=14644991,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1800_MH-1200_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1800_MH-1300",
+    id=14643136,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1800_MH-1300_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=3,
+    n_events=49000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1800_MH-1400",
+    id=14644377,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1800_MH-1400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1800_MH-1500",
+    id=14641545,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1800_MH-1500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1800_MH-1600",
+    id=14536346,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1800_MH-1600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1800_MH-1700",
+    id=14638264,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1800_MH-1700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1800_MH-350",
+    id=14645239,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1800_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1800_MH-400",
+    id=14647680,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1800_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1800_MH-500",
+    id=14636041,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1800_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1800_MH-600",
+    id=14638191,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1800_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=49000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1800_MH-700",
+    id=14641337,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1800_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1800_MH-800",
+    id=14641404,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1800_MH-800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1800_MH-900",
+    id=14644425,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1800_MH-900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1900_MH-1000",
+    id=14645483,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1900_MH-1000_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1900_MH-1100",
+    id=14641381,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1900_MH-1100_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1900_MH-1200",
+    id=14644032,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1900_MH-1200_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1900_MH-1300",
+    id=14640668,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1900_MH-1300_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1900_MH-1400",
+    id=14638513,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1900_MH-1400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1900_MH-1500",
+    id=14641448,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1900_MH-1500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=48000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1900_MH-1600",
+    id=14644761,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1900_MH-1600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1900_MH-1700",
+    id=14644521,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1900_MH-1700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1900_MH-1800",
+    id=14639947,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1900_MH-1800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1900_MH-350",
+    id=14645606,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1900_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1900_MH-400",
+    id=14640620,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1900_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1900_MH-500",
+    id=14644122,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1900_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1900_MH-600",
+    id=14638778,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1900_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1900_MH-700",
+    id=14643966,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1900_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1900_MH-800",
+    id=14644992,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1900_MH-800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-1900_MH-900",
+    id=14636485,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-1900_MH-900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-2000_MH-1000",
+    id=14640348,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-2000_MH-1000_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=48000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-2000_MH-1100",
+    id=14644809,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-2000_MH-1100_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-2000_MH-1200",
+    id=14637610,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-2000_MH-1200_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-2000_MH-1300",
+    id=14636407,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-2000_MH-1300_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-2000_MH-1400",
+    id=14641386,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-2000_MH-1400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=48000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-2000_MH-1600",
+    id=14636572,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-2000_MH-1600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-2000_MH-1700",
+    id=14645641,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-2000_MH-1700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-2000_MH-1800",
+    id=14638745,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-2000_MH-1800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=49000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-2000_MH-1900",
+    id=14640887,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-2000_MH-1900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-2000_MH-350",
+    id=14645372,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-2000_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=48000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-2000_MH-400",
+    id=14640824,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-2000_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-2000_MH-500",
+    id=14641466,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-2000_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=48000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-2000_MH-600",
+    id=14644380,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-2000_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-2000_MH-700",
+    id=14641216,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-2000_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-2000_MH-800",
+    id=14636495,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-2000_MH-800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-2000_MH-900",
+    id=14643988,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-2000_MH-900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-2100_MH-1000",
+    id=14536369,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-2100_MH-1000_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-2100_MH-1100",
+    id=14637855,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-2100_MH-1100_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-2100_MH-1200",
+    id=14640710,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-2100_MH-1200_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-2100_MH-1300",
+    id=14636479,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-2100_MH-1300_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-2100_MH-1400",
+    id=14637248,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-2100_MH-1400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-2100_MH-1500",
+    id=14645029,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-2100_MH-1500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-2100_MH-1700",
+    id=14637551,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-2100_MH-1700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-2100_MH-1800",
+    id=14638095,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-2100_MH-1800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-2100_MH-1900",
+    id=14643999,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-2100_MH-1900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-2100_MH-2000",
+    id=14536433,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-2100_MH-2000_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-2100_MH-350",
+    id=14640847,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-2100_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-2100_MH-400",
+    id=14549535,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-2100_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-2100_MH-500",
+    id=14641088,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-2100_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-2100_MH-600",
+    id=14645539,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-2100_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-2100_MH-700",
+    id=14636576,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-2100_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-2100_MH-800",
+    id=14644946,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-2100_MH-800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-2100_MH-900",
+    id=14641004,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-2100_MH-900_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-430_MH-330",
+    id=14640871,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-430_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-450_MH-330",
+    id=14641217,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-450_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-450_MH-350",
+    id=14637724,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-450_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=49000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-500_MH-330",
+    id=14645669,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-500_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-500_MH-350",
+    id=14548216,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-500_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-500_MH-370",
+    id=14648537,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-500_MH-370_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-500_MH-400",
+    id=14537163,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-500_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-550_MH-330",
+    id=14640737,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-550_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-550_MH-350",
+    id=14641310,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-550_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-550_MH-400",
+    id=14641298,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-550_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=48000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-550_MH-450",
+    id=14644728,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-550_MH-450_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-600_MH-330",
+    id=14643492,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-600_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-600_MH-350",
+    id=14644865,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-600_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-600_MH-400",
+    id=14640637,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-600_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-600_MH-450",
+    id=14644417,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-600_MH-450_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-600_MH-500",
+    id=14641414,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-600_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=48000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-650_MH-330",
+    id=14644791,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-650_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-650_MH-350",
+    id=14636505,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-650_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-650_MH-400",
+    id=14643912,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-650_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-650_MH-450",
+    id=14641233,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-650_MH-450_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-650_MH-500",
+    id=14637773,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-650_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-650_MH-550",
+    id=14637782,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-650_MH-550_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-700_MH-330",
+    id=14637877,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-700_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=49000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-700_MH-350",
+    id=14549119,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-700_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-700_MH-370",
+    id=14548653,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-700_MH-370_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-700_MH-400",
+    id=14550258,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-700_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-700_MH-450",
+    id=14644343,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-700_MH-450_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-700_MH-500",
+    id=14645288,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-700_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-700_MH-550",
+    id=14644477,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-700_MH-550_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-750_MH-330",
+    id=14641059,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-750_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-750_MH-350",
+    id=14644713,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-750_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-750_MH-400",
+    id=14637708,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-750_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-750_MH-450",
+    id=14640716,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-750_MH-450_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-750_MH-500",
+    id=14636467,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-750_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-750_MH-550",
+    id=14644222,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-750_MH-550_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-750_MH-600",
+    id=14644813,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-750_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-750_MH-650",
+    id=14644183,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-750_MH-650_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-800_MH-330",
+    id=14643977,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-800_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-800_MH-350",
+    id=14638955,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-800_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-800_MH-400",
+    id=14643987,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-800_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-800_MH-450",
+    id=14637537,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-800_MH-450_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-800_MH-500",
+    id=14636808,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-800_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-800_MH-550",
+    id=14640965,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-800_MH-550_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-800_MH-600",
+    id=14548217,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-800_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-800_MH-650",
+    id=14647537,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-800_MH-650_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-800_MH-700",
+    id=14637545,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-800_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-850_MH-330",
+    id=14636408,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-850_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-850_MH-350",
+    id=14640072,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-850_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-850_MH-400",
+    id=14641161,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-850_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=49000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-850_MH-450",
+    id=14644205,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-850_MH-450_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-850_MH-500",
+    id=14636506,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-850_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=49000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-850_MH-550",
+    id=14640940,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-850_MH-550_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-850_MH-600",
+    id=14637903,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-850_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=48000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-850_MH-650",
+    id=14644591,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-850_MH-650_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-850_MH-700",
+    id=14645081,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-850_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-850_MH-750",
+    id=14640939,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-850_MH-750_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=49000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-900_MH-330",
+    id=14641018,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-900_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=48000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-900_MH-350",
+    id=14647696,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-900_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-900_MH-370",
+    id=14548218,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-900_MH-370_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-900_MH-400",
+    id=14544289,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-900_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-900_MH-450",
+    id=14637509,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-900_MH-450_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=49000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-900_MH-550",
+    id=14640075,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-900_MH-550_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-900_MH-500",
+    id=14640067,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-900_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-900_MH-600",
+    id=14641600,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-900_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-900_MH-650",
+    id=14645044,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-900_MH-650_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-900_MH-700",
+    id=14644427,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-900_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-900_MH-750",
+    id=14641142,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-900_MH-750_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-900_MH-800",
+    id=14636409,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-900_MH-800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-950_MH-330",
+    id=14636607,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-950_MH-330_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=48000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-950_MH-350",
+    id=14638010,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-950_MH-350_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-950_MH-400",
+    id=14638017,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-950_MH-400_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=48000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-950_MH-450",
+    id=14642920,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-950_MH-450_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-950_MH-500",
+    id=14637960,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-950_MH-500_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=49000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-950_MH-550",
+    id=14641687,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-950_MH-550_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-950_MH-600",
+    id=14637720,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-950_MH-600_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-950_MH-650",
+    id=14637077,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-950_MH-650_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-950_MH-700",
+    id=14636448,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-950_MH-700_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-950_MH-750",
+    id=14644979,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-950_MH-750_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-950_MH-800",
+    id=14645411,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-950_MH-800_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=50000,
+)
+cpn.add_dataset(
+    name="AToZHToLLTTbar_MA-950_MH-850",
+    id=14636342,
+    processes=[procs.AToZHToLLTTbar],
+    keys=[
+        "/AToZHToLLTTbar_MA-950_MH-850_TuneCP5_13TeV-amcatnlo-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=48000,
+)
+
+#
+# AZH->Ztt->nunutt
+#

--- a/cmsdb/processes/__init__.py
+++ b/cmsdb/processes/__init__.py
@@ -13,3 +13,4 @@ from cmsdb.processes.higgs import *  # noqa
 from cmsdb.processes.hh2bbtautau import *  # noqa
 from cmsdb.processes.hh2bbww import *  # noqa
 from cmsdb.processes.mttbar import *  # noqa
+from cmsdb.processes.azh import *  # noqa

--- a/cmsdb/processes/azh.py
+++ b/cmsdb/processes/azh.py
@@ -5,6 +5,7 @@ azh resonance search signal process definitions
 """
 
 __all__ = [
+    "azh",
     "azh_ttll_a1000_h330",
     "azh_ttll_a1000_h350",
     "azh_ttll_a1000_h400",
@@ -274,7 +275,7 @@ from order import Process
 from scinum import Number
 
 #
-# Z prime
+# A->ZH
 #
 
 azh = Process(

--- a/cmsdb/processes/azh.py
+++ b/cmsdb/processes/azh.py
@@ -1,0 +1,1859 @@
+# coding: utf-8
+
+"""
+azh resonance search signal process definitions
+"""
+
+__all__ = [
+    "azh_ttll_a1000_h330",
+    "azh_ttll_a1000_h350",
+    "azh_ttll_a1000_h400",
+    "azh_ttll_a1000_h450",
+    "azh_ttll_a1000_h500",
+    "azh_ttll_a1000_h550",
+    "azh_ttll_a1000_h600",
+    "azh_ttll_a1000_h650",
+    "azh_ttll_a1000_h700",
+    "azh_ttll_a1000_h750",
+    "azh_ttll_a1000_h800",
+    "azh_ttll_a1000_h850",
+    "azh_ttll_a1000_h900",
+    "azh_ttll_a1050_h330",
+    "azh_ttll_a1050_h350",
+    "azh_ttll_a1050_h400",
+    "azh_ttll_a1050_h450",
+    "azh_ttll_a1050_h500",
+    "azh_ttll_a1050_h550",
+    "azh_ttll_a1050_h600",
+    "azh_ttll_a1050_h700",
+    "azh_ttll_a1050_h750",
+    "azh_ttll_a1050_h800",
+    "azh_ttll_a1050_h850",
+    "azh_ttll_a1050_h900",
+    "azh_ttll_a1050_h950",
+    "azh_ttll_a1100_h1000",
+    "azh_ttll_a1100_h330",
+    "azh_ttll_a1100_h350",
+    "azh_ttll_a1100_h400",
+    "azh_ttll_a1100_h450",
+    "azh_ttll_a1100_h500",
+    "azh_ttll_a1100_h550",
+    "azh_ttll_a1100_h600",
+    "azh_ttll_a1100_h650",
+    "azh_ttll_a1100_h700",
+    "azh_ttll_a1100_h750",
+    "azh_ttll_a1100_h800",
+    "azh_ttll_a1100_h850",
+    "azh_ttll_a1100_h900",
+    "azh_ttll_a1100_h950",
+    "azh_ttll_a1150_h1050",
+    "azh_ttll_a1150_h330",
+    "azh_ttll_a1150_h350",
+    "azh_ttll_a1150_h450",
+    "azh_ttll_a1150_h550",
+    "azh_ttll_a1150_h650",
+    "azh_ttll_a1150_h750",
+    "azh_ttll_a1150_h850",
+    "azh_ttll_a1150_h950",
+    "azh_ttll_a1200_h1000",
+    "azh_ttll_a1200_h1100",
+    "azh_ttll_a1200_h330",
+    "azh_ttll_a1200_h350",
+    "azh_ttll_a1200_h400",
+    "azh_ttll_a1200_h500",
+    "azh_ttll_a1200_h600",
+    "azh_ttll_a1200_h700",
+    "azh_ttll_a1200_h800",
+    "azh_ttll_a1200_h850",
+    "azh_ttll_a1200_h900",
+    "azh_ttll_a1300_h1000",
+    "azh_ttll_a1300_h1100",
+    "azh_ttll_a1300_h1200",
+    "azh_ttll_a1300_h350",
+    "azh_ttll_a1300_h400",
+    "azh_ttll_a1300_h500",
+    "azh_ttll_a1300_h600",
+    "azh_ttll_a1300_h700",
+    "azh_ttll_a1300_h800",
+    "azh_ttll_a1300_h900",
+    "azh_ttll_a1400_h1000",
+    "azh_ttll_a1400_h1100",
+    "azh_ttll_a1400_h1200",
+    "azh_ttll_a1400_h1300",
+    "azh_ttll_a1400_h350",
+    "azh_ttll_a1400_h400",
+    "azh_ttll_a1400_h500",
+    "azh_ttll_a1400_h600",
+    "azh_ttll_a1400_h700",
+    "azh_ttll_a1400_h800",
+    "azh_ttll_a1400_h900",
+    "azh_ttll_a1500_h1000",
+    "azh_ttll_a1500_h1100",
+    "azh_ttll_a1500_h1200",
+    "azh_ttll_a1500_h1300",
+    "azh_ttll_a1500_h1400",
+    "azh_ttll_a1500_h350",
+    "azh_ttll_a1500_h400",
+    "azh_ttll_a1500_h500",
+    "azh_ttll_a1500_h600",
+    "azh_ttll_a1500_h700",
+    "azh_ttll_a1500_h900",
+    "azh_ttll_a1600_h1000",
+    "azh_ttll_a1600_h1100",
+    "azh_ttll_a1600_h1200",
+    "azh_ttll_a1600_h1300",
+    "azh_ttll_a1600_h1400",
+    "azh_ttll_a1600_h1500",
+    "azh_ttll_a1600_h350",
+    "azh_ttll_a1600_h400",
+    "azh_ttll_a1600_h500",
+    "azh_ttll_a1600_h600",
+    "azh_ttll_a1600_h900",
+    "azh_ttll_a1700_h1000",
+    "azh_ttll_a1700_h1100",
+    "azh_ttll_a1700_h1200",
+    "azh_ttll_a1700_h1300",
+    "azh_ttll_a1700_h1400",
+    "azh_ttll_a1700_h1500",
+    "azh_ttll_a1700_h1600",
+    "azh_ttll_a1700_h350",
+    "azh_ttll_a1700_h400",
+    "azh_ttll_a1700_h500",
+    "azh_ttll_a1700_h600",
+    "azh_ttll_a1700_h700",
+    "azh_ttll_a1700_h800",
+    "azh_ttll_a1700_h900",
+    "azh_ttll_a1800_h1000",
+    "azh_ttll_a1800_h1100",
+    "azh_ttll_a1800_h1200",
+    "azh_ttll_a1800_h1300",
+    "azh_ttll_a1800_h1400",
+    "azh_ttll_a1800_h1500",
+    "azh_ttll_a1800_h1600",
+    "azh_ttll_a1800_h1700",
+    "azh_ttll_a1800_h350",
+    "azh_ttll_a1800_h400",
+    "azh_ttll_a1800_h500",
+    "azh_ttll_a1800_h600",
+    "azh_ttll_a1800_h700",
+    "azh_ttll_a1800_h800",
+    "azh_ttll_a1800_h900",
+    "azh_ttll_a1900_h1000",
+    "azh_ttll_a1900_h1100",
+    "azh_ttll_a1900_h1200",
+    "azh_ttll_a1900_h1300",
+    "azh_ttll_a1900_h1400",
+    "azh_ttll_a1900_h1500",
+    "azh_ttll_a1900_h1600",
+    "azh_ttll_a1900_h1700",
+    "azh_ttll_a1900_h1800",
+    "azh_ttll_a1900_h350",
+    "azh_ttll_a1900_h400",
+    "azh_ttll_a1900_h500",
+    "azh_ttll_a1900_h600",
+    "azh_ttll_a1900_h700",
+    "azh_ttll_a1900_h800",
+    "azh_ttll_a1900_h900",
+    "azh_ttll_a2000_h1000",
+    "azh_ttll_a2000_h1100",
+    "azh_ttll_a2000_h1200",
+    "azh_ttll_a2000_h1300",
+    "azh_ttll_a2000_h1400",
+    "azh_ttll_a2000_h1600",
+    "azh_ttll_a2000_h1700",
+    "azh_ttll_a2000_h1800",
+    "azh_ttll_a2000_h1900",
+    "azh_ttll_a2000_h350",
+    "azh_ttll_a2000_h400",
+    "azh_ttll_a2000_h500",
+    "azh_ttll_a2000_h600",
+    "azh_ttll_a2000_h700",
+    "azh_ttll_a2000_h800",
+    "azh_ttll_a2000_h900",
+    "azh_ttll_a2100_h1000",
+    "azh_ttll_a2100_h1100",
+    "azh_ttll_a2100_h1200",
+    "azh_ttll_a2100_h1300",
+    "azh_ttll_a2100_h1400",
+    "azh_ttll_a2100_h1500",
+    "azh_ttll_a2100_h1700",
+    "azh_ttll_a2100_h1800",
+    "azh_ttll_a2100_h1900",
+    "azh_ttll_a2100_h2000",
+    "azh_ttll_a2100_h350",
+    "azh_ttll_a2100_h400",
+    "azh_ttll_a2100_h500",
+    "azh_ttll_a2100_h600",
+    "azh_ttll_a2100_h700",
+    "azh_ttll_a2100_h800",
+    "azh_ttll_a2100_h900",
+    "azh_ttll_a430_h330",
+    "azh_ttll_a450_h330",
+    "azh_ttll_a450_h350",
+    "azh_ttll_a500_h330",
+    "azh_ttll_a500_h350",
+    "azh_ttll_a500_h370",
+    "azh_ttll_a500_h400",
+    "azh_ttll_a550_h330",
+    "azh_ttll_a550_h350",
+    "azh_ttll_a550_h400",
+    "azh_ttll_a550_h450",
+    "azh_ttll_a600_h330",
+    "azh_ttll_a600_h350",
+    "azh_ttll_a600_h400",
+    "azh_ttll_a600_h450",
+    "azh_ttll_a600_h500",
+    "azh_ttll_a650_h330",
+    "azh_ttll_a650_h350",
+    "azh_ttll_a650_h400",
+    "azh_ttll_a650_h450",
+    "azh_ttll_a650_h500",
+    "azh_ttll_a650_h550",
+    "azh_ttll_a700_h330",
+    "azh_ttll_a700_h350",
+    "azh_ttll_a700_h370",
+    "azh_ttll_a700_h400",
+    "azh_ttll_a700_h450",
+    "azh_ttll_a700_h500",
+    "azh_ttll_a700_h550",
+    "azh_ttll_a750_h330",
+    "azh_ttll_a750_h350",
+    "azh_ttll_a750_h400",
+    "azh_ttll_a750_h450",
+    "azh_ttll_a750_h500",
+    "azh_ttll_a750_h550",
+    "azh_ttll_a750_h600",
+    "azh_ttll_a750_h650",
+    "azh_ttll_a800_h330",
+    "azh_ttll_a800_h350",
+    "azh_ttll_a800_h400",
+    "azh_ttll_a800_h450",
+    "azh_ttll_a800_h500",
+    "azh_ttll_a800_h550",
+    "azh_ttll_a800_h600",
+    "azh_ttll_a800_h650",
+    "azh_ttll_a800_h700",
+    "azh_ttll_a850_h330",
+    "azh_ttll_a850_h350",
+    "azh_ttll_a850_h400",
+    "azh_ttll_a850_h450",
+    "azh_ttll_a850_h500",
+    "azh_ttll_a850_h550",
+    "azh_ttll_a850_h600",
+    "azh_ttll_a850_h650",
+    "azh_ttll_a850_h700",
+    "azh_ttll_a850_h750",
+    "azh_ttll_a900_h330",
+    "azh_ttll_a900_h350",
+    "azh_ttll_a900_h370",
+    "azh_ttll_a900_h400",
+    "azh_ttll_a900_h450",
+    "azh_ttll_a900_h550",
+    "azh_ttll_a900_h500",
+    "azh_ttll_a900_h600",
+    "azh_ttll_a900_h650",
+    "azh_ttll_a900_h700",
+    "azh_ttll_a900_h750",
+    "azh_ttll_a900_h800",
+    "azh_ttll_a950_h330",
+    "azh_ttll_a950_h350",
+    "azh_ttll_a950_h400",
+    "azh_ttll_a950_h450",
+    "azh_ttll_a950_h500",
+    "azh_ttll_a950_h550",
+    "azh_ttll_a950_h600",
+    "azh_ttll_a950_h650",
+    "azh_ttll_a950_h700",
+    "azh_ttll_a950_h750",
+    "azh_ttll_a950_h800",
+    "azh_ttll_a950_h850",
+]
+
+
+from order import Process
+from scinum import Number
+
+#
+# Z prime
+#
+
+azh = Process(
+    name="azh",
+    label=r"AtoZH",
+    id=1000000,
+    xsecs={13: Number(0.1)},  # TODO
+)
+
+
+azh_ttll_a1000_h330 = azh.add_process(
+ name="azh_ttll_a1000_h330",
+ label=rf"{azh.label} ($m_A = 1000$ GeV, $m_h = 330$ GeV)",
+ id=1000001,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1000_h350 = azh.add_process(
+ name="azh_ttll_a1000_h350",
+ label=rf"{azh.label} ($m_A = 1000$ GeV, $m_h = 350$ GeV)",
+ id=1000002,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1000_h400 = azh.add_process(
+ name="azh_ttll_a1000_h400",
+ label=rf"{azh.label} ($m_A = 1000$ GeV, $m_h = 400$ GeV)",
+ id=1000003,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1000_h450 = azh.add_process(
+ name="azh_ttll_a1000_h450",
+ label=rf"{azh.label} ($m_A = 1000$ GeV, $m_h = 450$ GeV)",
+ id=1000004,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1000_h500 = azh.add_process(
+ name="azh_ttll_a1000_h500",
+ label=rf"{azh.label} ($m_A = 1000$ GeV, $m_h = 500$ GeV)",
+ id=1000005,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1000_h550 = azh.add_process(
+ name="azh_ttll_a1000_h550",
+ label=rf"{azh.label} ($m_A = 1000$ GeV, $m_h = 550$ GeV)",
+ id=1000006,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1000_h600 = azh.add_process(
+ name="azh_ttll_a1000_h600",
+ label=rf"{azh.label} ($m_A = 1000$ GeV, $m_h = 600$ GeV)",
+ id=1000007,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1000_h650 = azh.add_process(
+ name="azh_ttll_a1000_h650",
+ label=rf"{azh.label} ($m_A = 1000$ GeV, $m_h = 650$ GeV)",
+ id=1000008,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1000_h700 = azh.add_process(
+ name="azh_ttll_a1000_h700",
+ label=rf"{azh.label} ($m_A = 1000$ GeV, $m_h = 700$ GeV)",
+ id=1000009,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1000_h750 = azh.add_process(
+ name="azh_ttll_a1000_h750",
+ label=rf"{azh.label} ($m_A = 1000$ GeV, $m_h = 750$ GeV)",
+ id=1000010,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1000_h800 = azh.add_process(
+ name="azh_ttll_a1000_h800",
+ label=rf"{azh.label} ($m_A = 1000$ GeV, $m_h = 800$ GeV)",
+ id=1000011,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1000_h850 = azh.add_process(
+ name="azh_ttll_a1000_h850",
+ label=rf"{azh.label} ($m_A = 1000$ GeV, $m_h = 850$ GeV)",
+ id=1000012,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1000_h900 = azh.add_process(
+ name="azh_ttll_a1000_h900",
+ label=rf"{azh.label} ($m_A = 1000$ GeV, $m_h = 900$ GeV)",
+ id=1000013,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1050_h330 = azh.add_process(
+ name="azh_ttll_a1050_h330",
+ label=rf"{azh.label} ($m_A = 1050$ GeV, $m_h = 330$ GeV)",
+ id=1000014,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1050_h350 = azh.add_process(
+ name="azh_ttll_a1050_h350",
+ label=rf"{azh.label} ($m_A = 1050$ GeV, $m_h = 350$ GeV)",
+ id=1000015,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1050_h400 = azh.add_process(
+ name="azh_ttll_a1050_h400",
+ label=rf"{azh.label} ($m_A = 1050$ GeV, $m_h = 400$ GeV)",
+ id=1000016,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1050_h450 = azh.add_process(
+ name="azh_ttll_a1050_h450",
+ label=rf"{azh.label} ($m_A = 1050$ GeV, $m_h = 450$ GeV)",
+ id=1000017,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1050_h500 = azh.add_process(
+ name="azh_ttll_a1050_h500",
+ label=rf"{azh.label} ($m_A = 1050$ GeV, $m_h = 500$ GeV)",
+ id=1000018,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1050_h550 = azh.add_process(
+ name="azh_ttll_a1050_h550",
+ label=rf"{azh.label} ($m_A = 1050$ GeV, $m_h = 550$ GeV)",
+ id=1000019,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1050_h600 = azh.add_process(
+ name="azh_ttll_a1050_h600",
+ label=rf"{azh.label} ($m_A = 1050$ GeV, $m_h = 600$ GeV)",
+ id=1000020,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1050_h700 = azh.add_process(
+ name="azh_ttll_a1050_h700",
+ label=rf"{azh.label} ($m_A = 1050$ GeV, $m_h = 700$ GeV)",
+ id=1000021,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1050_h750 = azh.add_process(
+ name="azh_ttll_a1050_h750",
+ label=rf"{azh.label} ($m_A = 1050$ GeV, $m_h = 750$ GeV)",
+ id=1000022,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1050_h800 = azh.add_process(
+ name="azh_ttll_a1050_h800",
+ label=rf"{azh.label} ($m_A = 1050$ GeV, $m_h = 800$ GeV)",
+ id=1000023,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1050_h850 = azh.add_process(
+ name="azh_ttll_a1050_h850",
+ label=rf"{azh.label} ($m_A = 1050$ GeV, $m_h = 850$ GeV)",
+ id=1000024,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1050_h900 = azh.add_process(
+ name="azh_ttll_a1050_h900",
+ label=rf"{azh.label} ($m_A = 1050$ GeV, $m_h = 900$ GeV)",
+ id=1000025,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1050_h950 = azh.add_process(
+ name="azh_ttll_a1050_h950",
+ label=rf"{azh.label} ($m_A = 1050$ GeV, $m_h = 950$ GeV)",
+ id=1000026,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1100_h1000 = azh.add_process(
+ name="azh_ttll_a1100_h1000",
+ label=rf"{azh.label} ($m_A = 1100$ GeV, $m_h = 1000$ GeV)",
+ id=1000027,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1100_h330 = azh.add_process(
+ name="azh_ttll_a1100_h330",
+ label=rf"{azh.label} ($m_A = 1100$ GeV, $m_h = 330$ GeV)",
+ id=1000028,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1100_h350 = azh.add_process(
+ name="azh_ttll_a1100_h350",
+ label=rf"{azh.label} ($m_A = 1100$ GeV, $m_h = 350$ GeV)",
+ id=1000029,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1100_h400 = azh.add_process(
+ name="azh_ttll_a1100_h400",
+ label=rf"{azh.label} ($m_A = 1100$ GeV, $m_h = 400$ GeV)",
+ id=1000030,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1100_h450 = azh.add_process(
+ name="azh_ttll_a1100_h450",
+ label=rf"{azh.label} ($m_A = 1100$ GeV, $m_h = 450$ GeV)",
+ id=1000031,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1100_h500 = azh.add_process(
+ name="azh_ttll_a1100_h500",
+ label=rf"{azh.label} ($m_A = 1100$ GeV, $m_h = 500$ GeV)",
+ id=1000032,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1100_h550 = azh.add_process(
+ name="azh_ttll_a1100_h550",
+ label=rf"{azh.label} ($m_A = 1100$ GeV, $m_h = 550$ GeV)",
+ id=1000033,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1100_h600 = azh.add_process(
+ name="azh_ttll_a1100_h600",
+ label=rf"{azh.label} ($m_A = 1100$ GeV, $m_h = 600$ GeV)",
+ id=1000034,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1100_h650 = azh.add_process(
+ name="azh_ttll_a1100_h650",
+ label=rf"{azh.label} ($m_A = 1100$ GeV, $m_h = 650$ GeV)",
+ id=1000035,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1100_h700 = azh.add_process(
+ name="azh_ttll_a1100_h700",
+ label=rf"{azh.label} ($m_A = 1100$ GeV, $m_h = 700$ GeV)",
+ id=1000036,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1100_h750 = azh.add_process(
+ name="azh_ttll_a1100_h750",
+ label=rf"{azh.label} ($m_A = 1100$ GeV, $m_h = 750$ GeV)",
+ id=1000037,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1100_h800 = azh.add_process(
+ name="azh_ttll_a1100_h800",
+ label=rf"{azh.label} ($m_A = 1100$ GeV, $m_h = 800$ GeV)",
+ id=1000038,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1100_h850 = azh.add_process(
+ name="azh_ttll_a1100_h850",
+ label=rf"{azh.label} ($m_A = 1100$ GeV, $m_h = 850$ GeV)",
+ id=1000039,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1100_h900 = azh.add_process(
+ name="azh_ttll_a1100_h900",
+ label=rf"{azh.label} ($m_A = 1100$ GeV, $m_h = 900$ GeV)",
+ id=1000040,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1100_h950 = azh.add_process(
+ name="azh_ttll_a1100_h950",
+ label=rf"{azh.label} ($m_A = 1100$ GeV, $m_h = 950$ GeV)",
+ id=1000041,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1150_h1050 = azh.add_process(
+ name="azh_ttll_a1150_h1050",
+ label=rf"{azh.label} ($m_A = 1150$ GeV, $m_h = 1050$ GeV)",
+ id=1000042,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1150_h330 = azh.add_process(
+ name="azh_ttll_a1150_h330",
+ label=rf"{azh.label} ($m_A = 1150$ GeV, $m_h = 330$ GeV)",
+ id=1000043,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1150_h350 = azh.add_process(
+ name="azh_ttll_a1150_h350",
+ label=rf"{azh.label} ($m_A = 1150$ GeV, $m_h = 350$ GeV)",
+ id=1000044,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1150_h450 = azh.add_process(
+ name="azh_ttll_a1150_h450",
+ label=rf"{azh.label} ($m_A = 1150$ GeV, $m_h = 450$ GeV)",
+ id=1000045,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1150_h550 = azh.add_process(
+ name="azh_ttll_a1150_h550",
+ label=rf"{azh.label} ($m_A = 1150$ GeV, $m_h = 550$ GeV)",
+ id=1000046,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1150_h650 = azh.add_process(
+ name="azh_ttll_a1150_h650",
+ label=rf"{azh.label} ($m_A = 1150$ GeV, $m_h = 650$ GeV)",
+ id=1000047,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1150_h750 = azh.add_process(
+ name="azh_ttll_a1150_h750",
+ label=rf"{azh.label} ($m_A = 1150$ GeV, $m_h = 750$ GeV)",
+ id=1000048,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1150_h850 = azh.add_process(
+ name="azh_ttll_a1150_h850",
+ label=rf"{azh.label} ($m_A = 1150$ GeV, $m_h = 850$ GeV)",
+ id=1000049,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1150_h950 = azh.add_process(
+ name="azh_ttll_a1150_h950",
+ label=rf"{azh.label} ($m_A = 1150$ GeV, $m_h = 950$ GeV)",
+ id=1000050,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1200_h1000 = azh.add_process(
+ name="azh_ttll_a1200_h1000",
+ label=rf"{azh.label} ($m_A = 1200$ GeV, $m_h = 1000$ GeV)",
+ id=1000051,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1200_h1100 = azh.add_process(
+ name="azh_ttll_a1200_h1100",
+ label=rf"{azh.label} ($m_A = 1200$ GeV, $m_h = 1100$ GeV)",
+ id=1000052,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1200_h330 = azh.add_process(
+ name="azh_ttll_a1200_h330",
+ label=rf"{azh.label} ($m_A = 1200$ GeV, $m_h = 330$ GeV)",
+ id=1000053,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1200_h350 = azh.add_process(
+ name="azh_ttll_a1200_h350",
+ label=rf"{azh.label} ($m_A = 1200$ GeV, $m_h = 350$ GeV)",
+ id=1000054,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1200_h400 = azh.add_process(
+ name="azh_ttll_a1200_h400",
+ label=rf"{azh.label} ($m_A = 1200$ GeV, $m_h = 400$ GeV)",
+ id=1000055,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1200_h500 = azh.add_process(
+ name="azh_ttll_a1200_h500",
+ label=rf"{azh.label} ($m_A = 1200$ GeV, $m_h = 500$ GeV)",
+ id=1000056,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1200_h600 = azh.add_process(
+ name="azh_ttll_a1200_h600",
+ label=rf"{azh.label} ($m_A = 1200$ GeV, $m_h = 600$ GeV)",
+ id=1000057,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1200_h700 = azh.add_process(
+ name="azh_ttll_a1200_h700",
+ label=rf"{azh.label} ($m_A = 1200$ GeV, $m_h = 700$ GeV)",
+ id=1000058,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1200_h800 = azh.add_process(
+ name="azh_ttll_a1200_h800",
+ label=rf"{azh.label} ($m_A = 1200$ GeV, $m_h = 800$ GeV)",
+ id=1000059,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1200_h850 = azh.add_process(
+ name="azh_ttll_a1200_h850",
+ label=rf"{azh.label} ($m_A = 1200$ GeV, $m_h = 850$ GeV)",
+ id=1000060,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1200_h900 = azh.add_process(
+ name="azh_ttll_a1200_h900",
+ label=rf"{azh.label} ($m_A = 1200$ GeV, $m_h = 900$ GeV)",
+ id=1000061,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1300_h1000 = azh.add_process(
+ name="azh_ttll_a1300_h1000",
+ label=rf"{azh.label} ($m_A = 1300$ GeV, $m_h = 1000$ GeV)",
+ id=1000062,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1300_h1100 = azh.add_process(
+ name="azh_ttll_a1300_h1100",
+ label=rf"{azh.label} ($m_A = 1300$ GeV, $m_h = 1100$ GeV)",
+ id=1000063,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1300_h1200 = azh.add_process(
+ name="azh_ttll_a1300_h1200",
+ label=rf"{azh.label} ($m_A = 1300$ GeV, $m_h = 1200$ GeV)",
+ id=1000064,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1300_h350 = azh.add_process(
+ name="azh_ttll_a1300_h350",
+ label=rf"{azh.label} ($m_A = 1300$ GeV, $m_h = 350$ GeV)",
+ id=1000065,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1300_h400 = azh.add_process(
+ name="azh_ttll_a1300_h400",
+ label=rf"{azh.label} ($m_A = 1300$ GeV, $m_h = 400$ GeV)",
+ id=1000066,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1300_h500 = azh.add_process(
+ name="azh_ttll_a1300_h500",
+ label=rf"{azh.label} ($m_A = 1300$ GeV, $m_h = 500$ GeV)",
+ id=1000067,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1300_h600 = azh.add_process(
+ name="azh_ttll_a1300_h600",
+ label=rf"{azh.label} ($m_A = 1300$ GeV, $m_h = 600$ GeV)",
+ id=1000068,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1300_h700 = azh.add_process(
+ name="azh_ttll_a1300_h700",
+ label=rf"{azh.label} ($m_A = 1300$ GeV, $m_h = 700$ GeV)",
+ id=1000069,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1300_h800 = azh.add_process(
+ name="azh_ttll_a1300_h800",
+ label=rf"{azh.label} ($m_A = 1300$ GeV, $m_h = 800$ GeV)",
+ id=1000070,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1300_h900 = azh.add_process(
+ name="azh_ttll_a1300_h900",
+ label=rf"{azh.label} ($m_A = 1300$ GeV, $m_h = 900$ GeV)",
+ id=1000071,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1400_h1000 = azh.add_process(
+ name="azh_ttll_a1400_h1000",
+ label=rf"{azh.label} ($m_A = 1400$ GeV, $m_h = 1000$ GeV)",
+ id=1000072,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1400_h1100 = azh.add_process(
+ name="azh_ttll_a1400_h1100",
+ label=rf"{azh.label} ($m_A = 1400$ GeV, $m_h = 1100$ GeV)",
+ id=1000073,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1400_h1200 = azh.add_process(
+ name="azh_ttll_a1400_h1200",
+ label=rf"{azh.label} ($m_A = 1400$ GeV, $m_h = 1200$ GeV)",
+ id=1000074,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1400_h1300 = azh.add_process(
+ name="azh_ttll_a1400_h1300",
+ label=rf"{azh.label} ($m_A = 1400$ GeV, $m_h = 1300$ GeV)",
+ id=1000075,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1400_h350 = azh.add_process(
+ name="azh_ttll_a1400_h350",
+ label=rf"{azh.label} ($m_A = 1400$ GeV, $m_h = 350$ GeV)",
+ id=1000076,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1400_h400 = azh.add_process(
+ name="azh_ttll_a1400_h400",
+ label=rf"{azh.label} ($m_A = 1400$ GeV, $m_h = 400$ GeV)",
+ id=1000077,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1400_h500 = azh.add_process(
+ name="azh_ttll_a1400_h500",
+ label=rf"{azh.label} ($m_A = 1400$ GeV, $m_h = 500$ GeV)",
+ id=1000078,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1400_h600 = azh.add_process(
+ name="azh_ttll_a1400_h600",
+ label=rf"{azh.label} ($m_A = 1400$ GeV, $m_h = 600$ GeV)",
+ id=1000079,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1400_h700 = azh.add_process(
+ name="azh_ttll_a1400_h700",
+ label=rf"{azh.label} ($m_A = 1400$ GeV, $m_h = 700$ GeV)",
+ id=1000080,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1400_h800 = azh.add_process(
+ name="azh_ttll_a1400_h800",
+ label=rf"{azh.label} ($m_A = 1400$ GeV, $m_h = 800$ GeV)",
+ id=1000081,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1400_h900 = azh.add_process(
+ name="azh_ttll_a1400_h900",
+ label=rf"{azh.label} ($m_A = 1400$ GeV, $m_h = 900$ GeV)",
+ id=1000082,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1500_h1000 = azh.add_process(
+ name="azh_ttll_a1500_h1000",
+ label=rf"{azh.label} ($m_A = 1500$ GeV, $m_h = 1000$ GeV)",
+ id=1000083,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1500_h1100 = azh.add_process(
+ name="azh_ttll_a1500_h1100",
+ label=rf"{azh.label} ($m_A = 1500$ GeV, $m_h = 1100$ GeV)",
+ id=1000084,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1500_h1200 = azh.add_process(
+ name="azh_ttll_a1500_h1200",
+ label=rf"{azh.label} ($m_A = 1500$ GeV, $m_h = 1200$ GeV)",
+ id=1000085,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1500_h1300 = azh.add_process(
+ name="azh_ttll_a1500_h1300",
+ label=rf"{azh.label} ($m_A = 1500$ GeV, $m_h = 1300$ GeV)",
+ id=1000086,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1500_h1400 = azh.add_process(
+ name="azh_ttll_a1500_h1400",
+ label=rf"{azh.label} ($m_A = 1500$ GeV, $m_h = 1400$ GeV)",
+ id=1000087,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1500_h350 = azh.add_process(
+ name="azh_ttll_a1500_h350",
+ label=rf"{azh.label} ($m_A = 1500$ GeV, $m_h = 350$ GeV)",
+ id=1000088,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1500_h400 = azh.add_process(
+ name="azh_ttll_a1500_h400",
+ label=rf"{azh.label} ($m_A = 1500$ GeV, $m_h = 400$ GeV)",
+ id=1000089,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1500_h500 = azh.add_process(
+ name="azh_ttll_a1500_h500",
+ label=rf"{azh.label} ($m_A = 1500$ GeV, $m_h = 500$ GeV)",
+ id=1000090,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1500_h600 = azh.add_process(
+ name="azh_ttll_a1500_h600",
+ label=rf"{azh.label} ($m_A = 1500$ GeV, $m_h = 600$ GeV)",
+ id=1000091,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1500_h700 = azh.add_process(
+ name="azh_ttll_a1500_h700",
+ label=rf"{azh.label} ($m_A = 1500$ GeV, $m_h = 700$ GeV)",
+ id=1000092,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1500_h900 = azh.add_process(
+ name="azh_ttll_a1500_h900",
+ label=rf"{azh.label} ($m_A = 1500$ GeV, $m_h = 900$ GeV)",
+ id=1000093,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1600_h1000 = azh.add_process(
+ name="azh_ttll_a1600_h1000",
+ label=rf"{azh.label} ($m_A = 1600$ GeV, $m_h = 1000$ GeV)",
+ id=1000094,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1600_h1100 = azh.add_process(
+ name="azh_ttll_a1600_h1100",
+ label=rf"{azh.label} ($m_A = 1600$ GeV, $m_h = 1100$ GeV)",
+ id=1000095,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1600_h1200 = azh.add_process(
+ name="azh_ttll_a1600_h1200",
+ label=rf"{azh.label} ($m_A = 1600$ GeV, $m_h = 1200$ GeV)",
+ id=1000096,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1600_h1300 = azh.add_process(
+ name="azh_ttll_a1600_h1300",
+ label=rf"{azh.label} ($m_A = 1600$ GeV, $m_h = 1300$ GeV)",
+ id=1000097,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1600_h1400 = azh.add_process(
+ name="azh_ttll_a1600_h1400",
+ label=rf"{azh.label} ($m_A = 1600$ GeV, $m_h = 1400$ GeV)",
+ id=1000098,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1600_h1500 = azh.add_process(
+ name="azh_ttll_a1600_h1500",
+ label=rf"{azh.label} ($m_A = 1600$ GeV, $m_h = 1500$ GeV)",
+ id=1000099,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1600_h350 = azh.add_process(
+ name="azh_ttll_a1600_h350",
+ label=rf"{azh.label} ($m_A = 1600$ GeV, $m_h = 350$ GeV)",
+ id=1000100,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1600_h400 = azh.add_process(
+ name="azh_ttll_a1600_h400",
+ label=rf"{azh.label} ($m_A = 1600$ GeV, $m_h = 400$ GeV)",
+ id=1000101,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1600_h500 = azh.add_process(
+ name="azh_ttll_a1600_h500",
+ label=rf"{azh.label} ($m_A = 1600$ GeV, $m_h = 500$ GeV)",
+ id=1000102,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1600_h600 = azh.add_process(
+ name="azh_ttll_a1600_h600",
+ label=rf"{azh.label} ($m_A = 1600$ GeV, $m_h = 600$ GeV)",
+ id=1000103,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1600_h900 = azh.add_process(
+ name="azh_ttll_a1600_h900",
+ label=rf"{azh.label} ($m_A = 1600$ GeV, $m_h = 900$ GeV)",
+ id=1000104,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1700_h1000 = azh.add_process(
+ name="azh_ttll_a1700_h1000",
+ label=rf"{azh.label} ($m_A = 1700$ GeV, $m_h = 1000$ GeV)",
+ id=1000105,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1700_h1100 = azh.add_process(
+ name="azh_ttll_a1700_h1100",
+ label=rf"{azh.label} ($m_A = 1700$ GeV, $m_h = 1100$ GeV)",
+ id=1000106,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1700_h1200 = azh.add_process(
+ name="azh_ttll_a1700_h1200",
+ label=rf"{azh.label} ($m_A = 1700$ GeV, $m_h = 1200$ GeV)",
+ id=1000107,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1700_h1300 = azh.add_process(
+ name="azh_ttll_a1700_h1300",
+ label=rf"{azh.label} ($m_A = 1700$ GeV, $m_h = 1300$ GeV)",
+ id=1000108,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1700_h1400 = azh.add_process(
+ name="azh_ttll_a1700_h1400",
+ label=rf"{azh.label} ($m_A = 1700$ GeV, $m_h = 1400$ GeV)",
+ id=1000109,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1700_h1500 = azh.add_process(
+ name="azh_ttll_a1700_h1500",
+ label=rf"{azh.label} ($m_A = 1700$ GeV, $m_h = 1500$ GeV)",
+ id=1000110,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1700_h1600 = azh.add_process(
+ name="azh_ttll_a1700_h1600",
+ label=rf"{azh.label} ($m_A = 1700$ GeV, $m_h = 1600$ GeV)",
+ id=1000111,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1700_h350 = azh.add_process(
+ name="azh_ttll_a1700_h350",
+ label=rf"{azh.label} ($m_A = 1700$ GeV, $m_h = 350$ GeV)",
+ id=1000112,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1700_h400 = azh.add_process(
+ name="azh_ttll_a1700_h400",
+ label=rf"{azh.label} ($m_A = 1700$ GeV, $m_h = 400$ GeV)",
+ id=1000113,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1700_h500 = azh.add_process(
+ name="azh_ttll_a1700_h500",
+ label=rf"{azh.label} ($m_A = 1700$ GeV, $m_h = 500$ GeV)",
+ id=1000114,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1700_h600 = azh.add_process(
+ name="azh_ttll_a1700_h600",
+ label=rf"{azh.label} ($m_A = 1700$ GeV, $m_h = 600$ GeV)",
+ id=1000115,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1700_h700 = azh.add_process(
+ name="azh_ttll_a1700_h700",
+ label=rf"{azh.label} ($m_A = 1700$ GeV, $m_h = 700$ GeV)",
+ id=1000116,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1700_h800 = azh.add_process(
+ name="azh_ttll_a1700_h800",
+ label=rf"{azh.label} ($m_A = 1700$ GeV, $m_h = 800$ GeV)",
+ id=1000117,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1700_h900 = azh.add_process(
+ name="azh_ttll_a1700_h900",
+ label=rf"{azh.label} ($m_A = 1700$ GeV, $m_h = 900$ GeV)",
+ id=1000118,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1800_h1000 = azh.add_process(
+ name="azh_ttll_a1800_h1000",
+ label=rf"{azh.label} ($m_A = 1800$ GeV, $m_h = 1000$ GeV)",
+ id=1000119,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1800_h1100 = azh.add_process(
+ name="azh_ttll_a1800_h1100",
+ label=rf"{azh.label} ($m_A = 1800$ GeV, $m_h = 1100$ GeV)",
+ id=1000120,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1800_h1200 = azh.add_process(
+ name="azh_ttll_a1800_h1200",
+ label=rf"{azh.label} ($m_A = 1800$ GeV, $m_h = 1200$ GeV)",
+ id=1000121,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1800_h1300 = azh.add_process(
+ name="azh_ttll_a1800_h1300",
+ label=rf"{azh.label} ($m_A = 1800$ GeV, $m_h = 1300$ GeV)",
+ id=1000122,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1800_h1400 = azh.add_process(
+ name="azh_ttll_a1800_h1400",
+ label=rf"{azh.label} ($m_A = 1800$ GeV, $m_h = 1400$ GeV)",
+ id=1000123,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1800_h1500 = azh.add_process(
+ name="azh_ttll_a1800_h1500",
+ label=rf"{azh.label} ($m_A = 1800$ GeV, $m_h = 1500$ GeV)",
+ id=1000124,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1800_h1600 = azh.add_process(
+ name="azh_ttll_a1800_h1600",
+ label=rf"{azh.label} ($m_A = 1800$ GeV, $m_h = 1600$ GeV)",
+ id=1000125,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1800_h1700 = azh.add_process(
+ name="azh_ttll_a1800_h1700",
+ label=rf"{azh.label} ($m_A = 1800$ GeV, $m_h = 1700$ GeV)",
+ id=1000126,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1800_h350 = azh.add_process(
+ name="azh_ttll_a1800_h350",
+ label=rf"{azh.label} ($m_A = 1800$ GeV, $m_h = 350$ GeV)",
+ id=1000127,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1800_h400 = azh.add_process(
+ name="azh_ttll_a1800_h400",
+ label=rf"{azh.label} ($m_A = 1800$ GeV, $m_h = 400$ GeV)",
+ id=1000128,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1800_h500 = azh.add_process(
+ name="azh_ttll_a1800_h500",
+ label=rf"{azh.label} ($m_A = 1800$ GeV, $m_h = 500$ GeV)",
+ id=1000129,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1800_h600 = azh.add_process(
+ name="azh_ttll_a1800_h600",
+ label=rf"{azh.label} ($m_A = 1800$ GeV, $m_h = 600$ GeV)",
+ id=1000130,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1800_h700 = azh.add_process(
+ name="azh_ttll_a1800_h700",
+ label=rf"{azh.label} ($m_A = 1800$ GeV, $m_h = 700$ GeV)",
+ id=1000131,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1800_h800 = azh.add_process(
+ name="azh_ttll_a1800_h800",
+ label=rf"{azh.label} ($m_A = 1800$ GeV, $m_h = 800$ GeV)",
+ id=1000132,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1800_h900 = azh.add_process(
+ name="azh_ttll_a1800_h900",
+ label=rf"{azh.label} ($m_A = 1800$ GeV, $m_h = 900$ GeV)",
+ id=1000133,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1900_h1000 = azh.add_process(
+ name="azh_ttll_a1900_h1000",
+ label=rf"{azh.label} ($m_A = 1900$ GeV, $m_h = 1000$ GeV)",
+ id=1000134,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1900_h1100 = azh.add_process(
+ name="azh_ttll_a1900_h1100",
+ label=rf"{azh.label} ($m_A = 1900$ GeV, $m_h = 1100$ GeV)",
+ id=1000135,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1900_h1200 = azh.add_process(
+ name="azh_ttll_a1900_h1200",
+ label=rf"{azh.label} ($m_A = 1900$ GeV, $m_h = 1200$ GeV)",
+ id=1000136,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1900_h1300 = azh.add_process(
+ name="azh_ttll_a1900_h1300",
+ label=rf"{azh.label} ($m_A = 1900$ GeV, $m_h = 1300$ GeV)",
+ id=1000137,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1900_h1400 = azh.add_process(
+ name="azh_ttll_a1900_h1400",
+ label=rf"{azh.label} ($m_A = 1900$ GeV, $m_h = 1400$ GeV)",
+ id=1000138,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1900_h1500 = azh.add_process(
+ name="azh_ttll_a1900_h1500",
+ label=rf"{azh.label} ($m_A = 1900$ GeV, $m_h = 1500$ GeV)",
+ id=1000139,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1900_h1600 = azh.add_process(
+ name="azh_ttll_a1900_h1600",
+ label=rf"{azh.label} ($m_A = 1900$ GeV, $m_h = 1600$ GeV)",
+ id=1000140,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1900_h1700 = azh.add_process(
+ name="azh_ttll_a1900_h1700",
+ label=rf"{azh.label} ($m_A = 1900$ GeV, $m_h = 1700$ GeV)",
+ id=1000141,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1900_h1800 = azh.add_process(
+ name="azh_ttll_a1900_h1800",
+ label=rf"{azh.label} ($m_A = 1900$ GeV, $m_h = 1800$ GeV)",
+ id=1000142,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1900_h350 = azh.add_process(
+ name="azh_ttll_a1900_h350",
+ label=rf"{azh.label} ($m_A = 1900$ GeV, $m_h = 350$ GeV)",
+ id=1000143,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1900_h400 = azh.add_process(
+ name="azh_ttll_a1900_h400",
+ label=rf"{azh.label} ($m_A = 1900$ GeV, $m_h = 400$ GeV)",
+ id=1000144,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1900_h500 = azh.add_process(
+ name="azh_ttll_a1900_h500",
+ label=rf"{azh.label} ($m_A = 1900$ GeV, $m_h = 500$ GeV)",
+ id=1000145,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1900_h600 = azh.add_process(
+ name="azh_ttll_a1900_h600",
+ label=rf"{azh.label} ($m_A = 1900$ GeV, $m_h = 600$ GeV)",
+ id=1000146,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1900_h700 = azh.add_process(
+ name="azh_ttll_a1900_h700",
+ label=rf"{azh.label} ($m_A = 1900$ GeV, $m_h = 700$ GeV)",
+ id=1000147,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1900_h800 = azh.add_process(
+ name="azh_ttll_a1900_h800",
+ label=rf"{azh.label} ($m_A = 1900$ GeV, $m_h = 800$ GeV)",
+ id=1000148,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a1900_h900 = azh.add_process(
+ name="azh_ttll_a1900_h900",
+ label=rf"{azh.label} ($m_A = 1900$ GeV, $m_h = 900$ GeV)",
+ id=1000149,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a2000_h1000 = azh.add_process(
+ name="azh_ttll_a2000_h1000",
+ label=rf"{azh.label} ($m_A = 2000$ GeV, $m_h = 1000$ GeV)",
+ id=1000150,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a2000_h1100 = azh.add_process(
+ name="azh_ttll_a2000_h1100",
+ label=rf"{azh.label} ($m_A = 2000$ GeV, $m_h = 1100$ GeV)",
+ id=1000151,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a2000_h1200 = azh.add_process(
+ name="azh_ttll_a2000_h1200",
+ label=rf"{azh.label} ($m_A = 2000$ GeV, $m_h = 1200$ GeV)",
+ id=1000152,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a2000_h1300 = azh.add_process(
+ name="azh_ttll_a2000_h1300",
+ label=rf"{azh.label} ($m_A = 2000$ GeV, $m_h = 1300$ GeV)",
+ id=1000153,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a2000_h1400 = azh.add_process(
+ name="azh_ttll_a2000_h1400",
+ label=rf"{azh.label} ($m_A = 2000$ GeV, $m_h = 1400$ GeV)",
+ id=1000154,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a2000_h1600 = azh.add_process(
+ name="azh_ttll_a2000_h1600",
+ label=rf"{azh.label} ($m_A = 2000$ GeV, $m_h = 1600$ GeV)",
+ id=1000155,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a2000_h1700 = azh.add_process(
+ name="azh_ttll_a2000_h1700",
+ label=rf"{azh.label} ($m_A = 2000$ GeV, $m_h = 1700$ GeV)",
+ id=1000156,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a2000_h1800 = azh.add_process(
+ name="azh_ttll_a2000_h1800",
+ label=rf"{azh.label} ($m_A = 2000$ GeV, $m_h = 1800$ GeV)",
+ id=1000157,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a2000_h1900 = azh.add_process(
+ name="azh_ttll_a2000_h1900",
+ label=rf"{azh.label} ($m_A = 2000$ GeV, $m_h = 1900$ GeV)",
+ id=1000158,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a2000_h350 = azh.add_process(
+ name="azh_ttll_a2000_h350",
+ label=rf"{azh.label} ($m_A = 2000$ GeV, $m_h = 350$ GeV)",
+ id=1000159,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a2000_h400 = azh.add_process(
+ name="azh_ttll_a2000_h400",
+ label=rf"{azh.label} ($m_A = 2000$ GeV, $m_h = 400$ GeV)",
+ id=1000160,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a2000_h500 = azh.add_process(
+ name="azh_ttll_a2000_h500",
+ label=rf"{azh.label} ($m_A = 2000$ GeV, $m_h = 500$ GeV)",
+ id=1000161,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a2000_h600 = azh.add_process(
+ name="azh_ttll_a2000_h600",
+ label=rf"{azh.label} ($m_A = 2000$ GeV, $m_h = 600$ GeV)",
+ id=1000162,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a2000_h700 = azh.add_process(
+ name="azh_ttll_a2000_h700",
+ label=rf"{azh.label} ($m_A = 2000$ GeV, $m_h = 700$ GeV)",
+ id=1000163,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a2000_h800 = azh.add_process(
+ name="azh_ttll_a2000_h800",
+ label=rf"{azh.label} ($m_A = 2000$ GeV, $m_h = 800$ GeV)",
+ id=1000164,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a2000_h900 = azh.add_process(
+ name="azh_ttll_a2000_h900",
+ label=rf"{azh.label} ($m_A = 2000$ GeV, $m_h = 900$ GeV)",
+ id=1000165,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a2100_h1000 = azh.add_process(
+ name="azh_ttll_a2100_h1000",
+ label=rf"{azh.label} ($m_A = 2100$ GeV, $m_h = 1000$ GeV)",
+ id=1000166,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a2100_h1100 = azh.add_process(
+ name="azh_ttll_a2100_h1100",
+ label=rf"{azh.label} ($m_A = 2100$ GeV, $m_h = 1100$ GeV)",
+ id=1000167,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a2100_h1200 = azh.add_process(
+ name="azh_ttll_a2100_h1200",
+ label=rf"{azh.label} ($m_A = 2100$ GeV, $m_h = 1200$ GeV)",
+ id=1000168,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a2100_h1300 = azh.add_process(
+ name="azh_ttll_a2100_h1300",
+ label=rf"{azh.label} ($m_A = 2100$ GeV, $m_h = 1300$ GeV)",
+ id=1000169,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a2100_h1400 = azh.add_process(
+ name="azh_ttll_a2100_h1400",
+ label=rf"{azh.label} ($m_A = 2100$ GeV, $m_h = 1400$ GeV)",
+ id=1000170,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a2100_h1500 = azh.add_process(
+ name="azh_ttll_a2100_h1500",
+ label=rf"{azh.label} ($m_A = 2100$ GeV, $m_h = 1500$ GeV)",
+ id=1000171,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a2100_h1700 = azh.add_process(
+ name="azh_ttll_a2100_h1700",
+ label=rf"{azh.label} ($m_A = 2100$ GeV, $m_h = 1700$ GeV)",
+ id=1000172,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a2100_h1800 = azh.add_process(
+ name="azh_ttll_a2100_h1800",
+ label=rf"{azh.label} ($m_A = 2100$ GeV, $m_h = 1800$ GeV)",
+ id=1000173,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a2100_h1900 = azh.add_process(
+ name="azh_ttll_a2100_h1900",
+ label=rf"{azh.label} ($m_A = 2100$ GeV, $m_h = 1900$ GeV)",
+ id=1000174,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a2100_h2000 = azh.add_process(
+ name="azh_ttll_a2100_h2000",
+ label=rf"{azh.label} ($m_A = 2100$ GeV, $m_h = 2000$ GeV)",
+ id=1000175,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a2100_h350 = azh.add_process(
+ name="azh_ttll_a2100_h350",
+ label=rf"{azh.label} ($m_A = 2100$ GeV, $m_h = 350$ GeV)",
+ id=1000176,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a2100_h400 = azh.add_process(
+ name="azh_ttll_a2100_h400",
+ label=rf"{azh.label} ($m_A = 2100$ GeV, $m_h = 400$ GeV)",
+ id=1000177,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a2100_h500 = azh.add_process(
+ name="azh_ttll_a2100_h500",
+ label=rf"{azh.label} ($m_A = 2100$ GeV, $m_h = 500$ GeV)",
+ id=1000178,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a2100_h600 = azh.add_process(
+ name="azh_ttll_a2100_h600",
+ label=rf"{azh.label} ($m_A = 2100$ GeV, $m_h = 600$ GeV)",
+ id=1000179,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a2100_h700 = azh.add_process(
+ name="azh_ttll_a2100_h700",
+ label=rf"{azh.label} ($m_A = 2100$ GeV, $m_h = 700$ GeV)",
+ id=1000180,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a2100_h800 = azh.add_process(
+ name="azh_ttll_a2100_h800",
+ label=rf"{azh.label} ($m_A = 2100$ GeV, $m_h = 800$ GeV)",
+ id=1000181,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a2100_h900 = azh.add_process(
+ name="azh_ttll_a2100_h900",
+ label=rf"{azh.label} ($m_A = 2100$ GeV, $m_h = 900$ GeV)",
+ id=1000182,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a430_h330 = azh.add_process(
+ name="azh_ttll_a430_h330",
+ label=rf"{azh.label} ($m_A = 430$ GeV, $m_h = 330$ GeV)",
+ id=1000183,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a450_h330 = azh.add_process(
+ name="azh_ttll_a450_h330",
+ label=rf"{azh.label} ($m_A = 450$ GeV, $m_h = 330$ GeV)",
+ id=1000184,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a450_h350 = azh.add_process(
+ name="azh_ttll_a450_h350",
+ label=rf"{azh.label} ($m_A = 450$ GeV, $m_h = 350$ GeV)",
+ id=1000185,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a500_h330 = azh.add_process(
+ name="azh_ttll_a500_h330",
+ label=rf"{azh.label} ($m_A = 500$ GeV, $m_h = 330$ GeV)",
+ id=1000186,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a500_h350 = azh.add_process(
+ name="azh_ttll_a500_h350",
+ label=rf"{azh.label} ($m_A = 500$ GeV, $m_h = 350$ GeV)",
+ id=1000187,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a500_h370 = azh.add_process(
+ name="azh_ttll_a500_h370",
+ label=rf"{azh.label} ($m_A = 500$ GeV, $m_h = 370$ GeV)",
+ id=1000188,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a500_h400 = azh.add_process(
+ name="azh_ttll_a500_h400",
+ label=rf"{azh.label} ($m_A = 500$ GeV, $m_h = 400$ GeV)",
+ id=1000189,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a550_h330 = azh.add_process(
+ name="azh_ttll_a550_h330",
+ label=rf"{azh.label} ($m_A = 550$ GeV, $m_h = 330$ GeV)",
+ id=1000190,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a550_h350 = azh.add_process(
+ name="azh_ttll_a550_h350",
+ label=rf"{azh.label} ($m_A = 550$ GeV, $m_h = 350$ GeV)",
+ id=1000191,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a550_h400 = azh.add_process(
+ name="azh_ttll_a550_h400",
+ label=rf"{azh.label} ($m_A = 550$ GeV, $m_h = 400$ GeV)",
+ id=1000192,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a550_h450 = azh.add_process(
+ name="azh_ttll_a550_h450",
+ label=rf"{azh.label} ($m_A = 550$ GeV, $m_h = 450$ GeV)",
+ id=1000193,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a600_h330 = azh.add_process(
+ name="azh_ttll_a600_h330",
+ label=rf"{azh.label} ($m_A = 600$ GeV, $m_h = 330$ GeV)",
+ id=1000194,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a600_h350 = azh.add_process(
+ name="azh_ttll_a600_h350",
+ label=rf"{azh.label} ($m_A = 600$ GeV, $m_h = 350$ GeV)",
+ id=1000195,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a600_h400 = azh.add_process(
+ name="azh_ttll_a600_h400",
+ label=rf"{azh.label} ($m_A = 600$ GeV, $m_h = 400$ GeV)",
+ id=1000196,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a600_h450 = azh.add_process(
+ name="azh_ttll_a600_h450",
+ label=rf"{azh.label} ($m_A = 600$ GeV, $m_h = 450$ GeV)",
+ id=1000197,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a600_h500 = azh.add_process(
+ name="azh_ttll_a600_h500",
+ label=rf"{azh.label} ($m_A = 600$ GeV, $m_h = 500$ GeV)",
+ id=1000198,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a650_h330 = azh.add_process(
+ name="azh_ttll_a650_h330",
+ label=rf"{azh.label} ($m_A = 650$ GeV, $m_h = 330$ GeV)",
+ id=1000199,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a650_h350 = azh.add_process(
+ name="azh_ttll_a650_h350",
+ label=rf"{azh.label} ($m_A = 650$ GeV, $m_h = 350$ GeV)",
+ id=1000200,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a650_h400 = azh.add_process(
+ name="azh_ttll_a650_h400",
+ label=rf"{azh.label} ($m_A = 650$ GeV, $m_h = 400$ GeV)",
+ id=1000201,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a650_h450 = azh.add_process(
+ name="azh_ttll_a650_h450",
+ label=rf"{azh.label} ($m_A = 650$ GeV, $m_h = 450$ GeV)",
+ id=1000202,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a650_h500 = azh.add_process(
+ name="azh_ttll_a650_h500",
+ label=rf"{azh.label} ($m_A = 650$ GeV, $m_h = 500$ GeV)",
+ id=1000203,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a650_h550 = azh.add_process(
+ name="azh_ttll_a650_h550",
+ label=rf"{azh.label} ($m_A = 650$ GeV, $m_h = 550$ GeV)",
+ id=1000204,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a700_h330 = azh.add_process(
+ name="azh_ttll_a700_h330",
+ label=rf"{azh.label} ($m_A = 700$ GeV, $m_h = 330$ GeV)",
+ id=1000205,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a700_h350 = azh.add_process(
+ name="azh_ttll_a700_h350",
+ label=rf"{azh.label} ($m_A = 700$ GeV, $m_h = 350$ GeV)",
+ id=1000206,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a700_h370 = azh.add_process(
+ name="azh_ttll_a700_h370",
+ label=rf"{azh.label} ($m_A = 700$ GeV, $m_h = 370$ GeV)",
+ id=1000207,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a700_h400 = azh.add_process(
+ name="azh_ttll_a700_h400",
+ label=rf"{azh.label} ($m_A = 700$ GeV, $m_h = 400$ GeV)",
+ id=1000208,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a700_h450 = azh.add_process(
+ name="azh_ttll_a700_h450",
+ label=rf"{azh.label} ($m_A = 700$ GeV, $m_h = 450$ GeV)",
+ id=1000209,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a700_h500 = azh.add_process(
+ name="azh_ttll_a700_h500",
+ label=rf"{azh.label} ($m_A = 700$ GeV, $m_h = 500$ GeV)",
+ id=1000210,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a700_h550 = azh.add_process(
+ name="azh_ttll_a700_h550",
+ label=rf"{azh.label} ($m_A = 700$ GeV, $m_h = 550$ GeV)",
+ id=1000211,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a750_h330 = azh.add_process(
+ name="azh_ttll_a750_h330",
+ label=rf"{azh.label} ($m_A = 750$ GeV, $m_h = 330$ GeV)",
+ id=1000212,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a750_h350 = azh.add_process(
+ name="azh_ttll_a750_h350",
+ label=rf"{azh.label} ($m_A = 750$ GeV, $m_h = 350$ GeV)",
+ id=1000213,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a750_h400 = azh.add_process(
+ name="azh_ttll_a750_h400",
+ label=rf"{azh.label} ($m_A = 750$ GeV, $m_h = 400$ GeV)",
+ id=1000214,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a750_h450 = azh.add_process(
+ name="azh_ttll_a750_h450",
+ label=rf"{azh.label} ($m_A = 750$ GeV, $m_h = 450$ GeV)",
+ id=1000215,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a750_h500 = azh.add_process(
+ name="azh_ttll_a750_h500",
+ label=rf"{azh.label} ($m_A = 750$ GeV, $m_h = 500$ GeV)",
+ id=1000216,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a750_h550 = azh.add_process(
+ name="azh_ttll_a750_h550",
+ label=rf"{azh.label} ($m_A = 750$ GeV, $m_h = 550$ GeV)",
+ id=1000217,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a750_h600 = azh.add_process(
+ name="azh_ttll_a750_h600",
+ label=rf"{azh.label} ($m_A = 750$ GeV, $m_h = 600$ GeV)",
+ id=1000218,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a750_h650 = azh.add_process(
+ name="azh_ttll_a750_h650",
+ label=rf"{azh.label} ($m_A = 750$ GeV, $m_h = 650$ GeV)",
+ id=1000219,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a800_h330 = azh.add_process(
+ name="azh_ttll_a800_h330",
+ label=rf"{azh.label} ($m_A = 800$ GeV, $m_h = 330$ GeV)",
+ id=1000220,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a800_h350 = azh.add_process(
+ name="azh_ttll_a800_h350",
+ label=rf"{azh.label} ($m_A = 800$ GeV, $m_h = 350$ GeV)",
+ id=1000221,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a800_h400 = azh.add_process(
+ name="azh_ttll_a800_h400",
+ label=rf"{azh.label} ($m_A = 800$ GeV, $m_h = 400$ GeV)",
+ id=1000222,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a800_h450 = azh.add_process(
+ name="azh_ttll_a800_h450",
+ label=rf"{azh.label} ($m_A = 800$ GeV, $m_h = 450$ GeV)",
+ id=1000223,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a800_h500 = azh.add_process(
+ name="azh_ttll_a800_h500",
+ label=rf"{azh.label} ($m_A = 800$ GeV, $m_h = 500$ GeV)",
+ id=1000224,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a800_h550 = azh.add_process(
+ name="azh_ttll_a800_h550",
+ label=rf"{azh.label} ($m_A = 800$ GeV, $m_h = 550$ GeV)",
+ id=1000225,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a800_h600 = azh.add_process(
+ name="azh_ttll_a800_h600",
+ label=rf"{azh.label} ($m_A = 800$ GeV, $m_h = 600$ GeV)",
+ id=1000226,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a800_h650 = azh.add_process(
+ name="azh_ttll_a800_h650",
+ label=rf"{azh.label} ($m_A = 800$ GeV, $m_h = 650$ GeV)",
+ id=1000227,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a800_h700 = azh.add_process(
+ name="azh_ttll_a800_h700",
+ label=rf"{azh.label} ($m_A = 800$ GeV, $m_h = 700$ GeV)",
+ id=1000228,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a850_h330 = azh.add_process(
+ name="azh_ttll_a850_h330",
+ label=rf"{azh.label} ($m_A = 850$ GeV, $m_h = 330$ GeV)",
+ id=1000229,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a850_h350 = azh.add_process(
+ name="azh_ttll_a850_h350",
+ label=rf"{azh.label} ($m_A = 850$ GeV, $m_h = 350$ GeV)",
+ id=1000230,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a850_h400 = azh.add_process(
+ name="azh_ttll_a850_h400",
+ label=rf"{azh.label} ($m_A = 850$ GeV, $m_h = 400$ GeV)",
+ id=1000231,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a850_h450 = azh.add_process(
+ name="azh_ttll_a850_h450",
+ label=rf"{azh.label} ($m_A = 850$ GeV, $m_h = 450$ GeV)",
+ id=1000232,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a850_h500 = azh.add_process(
+ name="azh_ttll_a850_h500",
+ label=rf"{azh.label} ($m_A = 850$ GeV, $m_h = 500$ GeV)",
+ id=1000233,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a850_h550 = azh.add_process(
+ name="azh_ttll_a850_h550",
+ label=rf"{azh.label} ($m_A = 850$ GeV, $m_h = 550$ GeV)",
+ id=1000234,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a850_h600 = azh.add_process(
+ name="azh_ttll_a850_h600",
+ label=rf"{azh.label} ($m_A = 850$ GeV, $m_h = 600$ GeV)",
+ id=1000235,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a850_h650 = azh.add_process(
+ name="azh_ttll_a850_h650",
+ label=rf"{azh.label} ($m_A = 850$ GeV, $m_h = 650$ GeV)",
+ id=1000236,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a850_h700 = azh.add_process(
+ name="azh_ttll_a850_h700",
+ label=rf"{azh.label} ($m_A = 850$ GeV, $m_h = 700$ GeV)",
+ id=1000237,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a850_h750 = azh.add_process(
+ name="azh_ttll_a850_h750",
+ label=rf"{azh.label} ($m_A = 850$ GeV, $m_h = 750$ GeV)",
+ id=1000238,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a900_h330 = azh.add_process(
+ name="azh_ttll_a900_h330",
+ label=rf"{azh.label} ($m_A = 900$ GeV, $m_h = 330$ GeV)",
+ id=1000239,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a900_h350 = azh.add_process(
+ name="azh_ttll_a900_h350",
+ label=rf"{azh.label} ($m_A = 900$ GeV, $m_h = 350$ GeV)",
+ id=1000240,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a900_h370 = azh.add_process(
+ name="azh_ttll_a900_h370",
+ label=rf"{azh.label} ($m_A = 900$ GeV, $m_h = 370$ GeV)",
+ id=1000241,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a900_h400 = azh.add_process(
+ name="azh_ttll_a900_h400",
+ label=rf"{azh.label} ($m_A = 900$ GeV, $m_h = 400$ GeV)",
+ id=1000242,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a900_h450 = azh.add_process(
+ name="azh_ttll_a900_h450",
+ label=rf"{azh.label} ($m_A = 900$ GeV, $m_h = 450$ GeV)",
+ id=1000243,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a900_h550 = azh.add_process(
+ name="azh_ttll_a900_h550",
+ label=rf"{azh.label} ($m_A = 900$ GeV, $m_h = 550$ GeV)",
+ id=1000244,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a900_h500 = azh.add_process(
+ name="azh_ttll_a900_h500",
+ label=rf"{azh.label} ($m_A = 900$ GeV, $m_h = 500$ GeV)",
+ id=1000245,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a900_h600 = azh.add_process(
+ name="azh_ttll_a900_h600",
+ label=rf"{azh.label} ($m_A = 900$ GeV, $m_h = 600$ GeV)",
+ id=1000246,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a900_h650 = azh.add_process(
+ name="azh_ttll_a900_h650",
+ label=rf"{azh.label} ($m_A = 900$ GeV, $m_h = 650$ GeV)",
+ id=1000247,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a900_h700 = azh.add_process(
+ name="azh_ttll_a900_h700",
+ label=rf"{azh.label} ($m_A = 900$ GeV, $m_h = 700$ GeV)",
+ id=1000248,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a900_h750 = azh.add_process(
+ name="azh_ttll_a900_h750",
+ label=rf"{azh.label} ($m_A = 900$ GeV, $m_h = 750$ GeV)",
+ id=1000249,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a900_h800 = azh.add_process(
+ name="azh_ttll_a900_h800",
+ label=rf"{azh.label} ($m_A = 900$ GeV, $m_h = 800$ GeV)",
+ id=1000250,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a950_h330 = azh.add_process(
+ name="azh_ttll_a950_h330",
+ label=rf"{azh.label} ($m_A = 950$ GeV, $m_h = 330$ GeV)",
+ id=1000251,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a950_h350 = azh.add_process(
+ name="azh_ttll_a950_h350",
+ label=rf"{azh.label} ($m_A = 950$ GeV, $m_h = 350$ GeV)",
+ id=1000252,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a950_h400 = azh.add_process(
+ name="azh_ttll_a950_h400",
+ label=rf"{azh.label} ($m_A = 950$ GeV, $m_h = 400$ GeV)",
+ id=1000253,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a950_h450 = azh.add_process(
+ name="azh_ttll_a950_h450",
+ label=rf"{azh.label} ($m_A = 950$ GeV, $m_h = 450$ GeV)",
+ id=1000254,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a950_h500 = azh.add_process(
+ name="azh_ttll_a950_h500",
+ label=rf"{azh.label} ($m_A = 950$ GeV, $m_h = 500$ GeV)",
+ id=1000255,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a950_h550 = azh.add_process(
+ name="azh_ttll_a950_h550",
+ label=rf"{azh.label} ($m_A = 950$ GeV, $m_h = 550$ GeV)",
+ id=1000256,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a950_h600 = azh.add_process(
+ name="azh_ttll_a950_h600",
+ label=rf"{azh.label} ($m_A = 950$ GeV, $m_h = 600$ GeV)",
+ id=1000257,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a950_h650 = azh.add_process(
+ name="azh_ttll_a950_h650",
+ label=rf"{azh.label} ($m_A = 950$ GeV, $m_h = 650$ GeV)",
+ id=1000258,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a950_h700 = azh.add_process(
+ name="azh_ttll_a950_h700",
+ label=rf"{azh.label} ($m_A = 950$ GeV, $m_h = 700$ GeV)",
+ id=1000259,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a950_h750 = azh.add_process(
+ name="azh_ttll_a950_h750",
+ label=rf"{azh.label} ($m_A = 950$ GeV, $m_h = 750$ GeV)",
+ id=1000260,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a950_h800 = azh.add_process(
+ name="azh_ttll_a950_h800",
+ label=rf"{azh.label} ($m_A = 950$ GeV, $m_h = 800$ GeV)",
+ id=1000261,
+ xsecs={13: Number(0.1)}, # TODO
+ )
+azh_ttll_a950_h850 = azh.add_process(
+ name="azh_ttll_a950_h850",
+ label=rf"{azh.label} ($m_A = 950$ GeV, $m_h = 850$ GeV)",
+ id=1000262,
+ xsecs={13: Number(0.1)}, # TODO
+ )


### PR DESCRIPTION
I added the A->ZH signal samples used in our analysis to the CMSDB (run2 2017 campaign, processes) 