### PR TITLE
Datasets/2022 dy higgs ttv

### DIFF
--- a/cmsdb/campaigns/run3_2022_postEE_nano_v12/ewk.py
+++ b/cmsdb/campaigns/run3_2022_postEE_nano_v12/ewk.py
@@ -9,14 +9,15 @@ from order import DatasetInfo
 import cmsdb.processes as procs
 from cmsdb.campaigns.run3_2022_postEE_nano_v12 import campaign_run3_2022_postEE_nano_v12 as cpn
 
-
+####################################################################################################
 #
 # Drell-Yan
 #
+####################################################################################################
 
-
+# inclusive, LO, forPog
 cpn.add_dataset(
-    name="dy_lep_m50_madgraph",
+    name="dy_lep_m50_for_pog_madgraph",
     id=14791423,
     processes=[procs.dy_lep_m50],
     keys=[
@@ -26,6 +27,324 @@ cpn.add_dataset(
     n_events=94947242,
 )
 
+# inclusive, LO
+cpn.add_dataset(
+    name="dy_lep_m10to50_madgraph",
+    id=14873228,
+    processes=[procs.dy_lep_m10to50],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/DYto2L-4Jets_MLL-10to50_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=2274,
+            n_events=500642946,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="dy_lep_m50_madgraph",
+    id=14810676,
+    processes=[procs.dy_lep_m50],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/DYto2L-4Jets_MLL-50_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=236,
+            n_events=240872023,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/DYto2L-4Jets_MLL-50_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6_ext1-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=1587,
+            n_events=254295366,
+        ),
+    ),
+)
+
+# jet-binned, LO
+cpn.add_dataset(
+    name="dy_lep_m50_1j_madgraph",
+    id=14790810,
+    processes=[procs.dy_lep_m50_1j],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/DYto2L-4Jets_MLL-50_1J_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=187,
+            n_events=57771603,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="dy_lep_m50_2j_madgraph",
+    id=14794042,
+    processes=[procs.dy_lep_m50_2j],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/DYto2L-4Jets_MLL-50_2J_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=147,
+            n_events=50007544,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="dy_lep_m50_3j_madgraph",
+    id=14791238,
+    processes=[procs.dy_lep_m50_3j],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/DYto2L-4Jets_MLL-50_3J_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=109,
+            n_events=28997825,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="dy_lep_m50_4j_madgraph",
+    id=14794840,
+    processes=[procs.dy_lep_m50_4j],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/DYto2L-4Jets_MLL-50_4J_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=140,
+            n_events=9490226,
+        ),
+    ),
+)
+
+# TODO: implement corresponding processes + xsecs
+# # ptll-binned, LO
+# cpn.add_dataset(
+#     name="dy_lep_m50_ptll100to200_madgraph",
+#     id=14948737,
+#     processes=[procs.dy_lep_m50_ptll100to200],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/DYto2L-4Jets_MLL-50_PTLL-100to200_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+#             ],
+#             n_files=497,
+#             n_events=69961256,
+#         ),
+#     ),
+# )
+# cpn.add_dataset(
+#     name="dy_lep_m50_ptll200to400_madgraph",
+#     id=14949443,
+#     processes=[procs.dy_lep_m50_ptll200to400],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/DYto2L-4Jets_MLL-50_PTLL-200to400_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+#             ],
+#             n_files=155,
+#             n_events=6931476,
+#         ),
+#     ),
+# )
+# cpn.add_dataset(
+#     name="dy_lep_m50_ptll400to600_madgraph",
+#     id=14949288,
+#     processes=[procs.dy_lep_m50_ptll400to600],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/DYto2L-4Jets_MLL-50_PTLL-400to600_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+#             ],
+#             n_files=81,
+#             n_events=3355496,
+#         ),
+#     ),
+# )
+# cpn.add_dataset(
+#     name="dy_lep_m50_ptll600toinf_madgraph",
+#     id=14948747,
+#     processes=[procs.dy_lep_m50_ptll600toinf],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/DYto2L-4Jets_MLL-50_PTLL-600_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+#             ],
+#             n_files=117,
+#             n_events=3470735,
+#         ),
+#     ),
+# )
+
+# # ht-binned, LO
+# cpn.add_dataset(
+#     name="dy_lep_m4to50_ht40to70_madgraph",
+#     id=14950532,
+#     processes=[procs.dy_lep_m4to50_ht40to70],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/DYto2L-4Jets_MLL-4to50_HT-40to70_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+#             ],
+#             n_files=1706,
+#             n_events=332696345,
+#         ),
+#     ),
+# )
+# cpn.add_dataset(
+#     name="dy_lep_m4to50_ht70to100_madgraph",
+#     id=14949534,
+#     processes=[procs.dy_lep_m4to50_ht70to100],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/DYto2L-4Jets_MLL-4to50_HT-70to100_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+#             ],
+#             n_files=1099,
+#             n_events=201751012,
+#         ),
+#     ),
+# )
+# cpn.add_dataset(
+#     name="dy_lep_m4to50_ht400to800_madgraph",
+#     id=14949799,
+#     processes=[procs.dy_lep_m4to50_ht400to800],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/DYto2L-4Jets_MLL-4to50_HT-400to800_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+#             ],
+#             n_files=77,
+#             n_events=4520981,
+#         ),
+#     ),
+# )
+# cpn.add_dataset(
+#     name="dy_lep_m4to50_ht800to1500_madgraph",
+#     id=14948706,
+#     processes=[procs.dy_lep_m4to50_ht800to1500],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/DYto2L-4Jets_MLL-4to50_HT-800to1500_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+#             ],
+#             n_files=189,
+#             n_events=3901947,
+#         ),
+#     ),
+# )
+# cpn.add_dataset(
+#     name="dy_lep_m4to50_ht1500to2500_madgraph",
+#     id=14951014,
+#     processes=[procs.dy_lep_m4to50_ht1500to2500],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/DYto2L-4Jets_MLL-4to50_HT-1500to2500_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+#             ],
+#             n_files=54,
+#             n_events=3203979,
+#         ),
+#     ),
+# )
+# cpn.add_dataset(
+#     name="dy_lep_m4to50_ht2500toinf_madgraph",
+#     id=14952243,
+#     processes=[procs.dy_lep_m4to50_ht2500toinf],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/DYto2L-4Jets_MLL-4to50_HT-2500_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v1/NANOAODSIM",  # noqa
+#             ],
+#             n_files=147,
+#             n_events=3660177,
+#         ),
+#     ),
+# )
+# cpn.add_dataset(
+#     name="dy_lep_m50to120_ht40to70_madgraph",
+#     id=14817089,
+#     processes=[procs.dy_lep_m50to120_ht40to70],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/DYto2L-4Jets_MLL-50to120_HT-40to70_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v1/NANOAODSIM",  # noqa
+#             ],
+#             n_files=422,
+#             n_events=133980512,
+#         ),
+#     ),
+# )
+# cpn.add_dataset(
+#     name="dy_lep_m50to120_ht70to100_madgraph",
+#     id=14847021,
+#     processes=[procs.dy_lep_m50to120_ht70to100],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/DYto2L-4Jets_MLL-50to120_HT-70to100_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v3/NANOAODSIM",  # noqa
+#             ],
+#             n_files=648,
+#             n_events=98847366,
+#         ),
+#     ),
+# )
+# cpn.add_dataset(
+#     name="dy_lep_m50to120_ht100to400_madgraph",
+#     id=14813464,
+#     processes=[procs.dy_lep_m50to120_ht100to400],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/DYto2L-4Jets_MLL-50to120_HT-100to400_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v1/NANOAODSIM",  # noqa
+#             ],
+#             n_files=307,
+#             n_events=142936007,
+#         ),
+#     ),
+# )
+# cpn.add_dataset(
+#     name="dy_lep_m50to120_ht400to800_madgraph",
+#     id=14878614,
+#     processes=[procs.dy_lep_m50to120_ht400to800],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/DYto2L-4Jets_MLL-50to120_HT-400to800_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+#             ],
+#             n_files=52,
+#             n_events=3935310,
+#         ),
+#     ),
+# )
+
+# inclusive, NLO
+cpn.add_dataset(
+    name="dy_lep_m4to10_amcatnlo",
+    id=14940403,
+    processes=[procs.dy_lep_m4to10],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/DYto2L-2Jets_MLL-4to10_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=1037,
+            n_events=197465370,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/DYto2L-2Jets_MLL-4to10_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6_ext1-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=838,
+            n_events=147147055,
+        ),
+    ),
+)
 cpn.add_dataset(
     name="dy_lep_m10to50_amcatnlo",
     id=14803206,
@@ -47,12 +366,222 @@ cpn.add_dataset(
         ),
     ),
 )
+cpn.add_dataset(
+    name="dy_lep_m50_amcatnlo",
+    id=14791972,
+    processes=[procs.dy_lep_m50],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/DYto2L-2Jets_MLL-50_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=286,
+            n_events=213436879,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/DYto2L-2Jets_MLL-50_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6_ext1-v1/NANOAODSIM",  # noqa
+            ],
+            n_files=407,
+            n_events=319825084,
+        ),
+    ),
+)
+
+# jet-binned, NLO
+cpn.add_dataset(
+    name="dy_lep_m50_0j_amcatnlo",
+    id=14791116,
+    processes=[procs.dy_lep_m50_0j],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/DYto2L-2Jets_MLL-50_0J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=452,
+            n_events=346950546,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="dy_lep_m50_1j_amcatnlo",
+    id=14790681,
+    processes=[procs.dy_lep_m50_1j],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/DYto2L-2Jets_MLL-50_1J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=454,
+            n_events=322623183,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="dy_lep_m50_2j_amcatnlo",
+    id=14801013,
+    processes=[procs.dy_lep_m50_2j],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/DYto2L-2Jets_MLL-50_2J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=386,
+            n_events=277437970,
+        ),
+    ),
+)
+
+# TODO: implement corresponding processes + xsecs
+# # jet-binned, ptll-binned, NLO
+# cpn.add_dataset(
+#     name="dy_lep_m501j__ptll40to100_amcatnlo",
+#     id=14825993,
+#     processes=[procs.dy_lep_m501j__ptll40to100],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/DYto2L-2Jets_MLL-50_PTLL-40to100_1J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v1/NANOAODSIM",  # noqa
+#             ],
+#             n_files=287,
+#             n_events=163904854,
+#         ),
+#     ),
+# )
+# cpn.add_dataset(
+#     name="dy_lep_m50_1j_ptll600toinf_amcatnlo",
+#     id=14870369,
+#     processes=[procs.dy_lep_m50_1j_ptll600toinf],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/DYto2L-2Jets_MLL-50_PTLL-600_1J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v3/NANOAODSIM",  # noqa
+#             ],
+#             n_files=33,
+#             n_events=1862921,
+#         ),
+#     ),
+# )
+# cpn.add_dataset(
+#     name="dy_lep_m50_1j_ptll100to200_amcatnlo",
+#     id=14826169,
+#     processes=[procs.dy_lep_m50_1j_ptll100to200],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/DYto2L-2Jets_MLL-50_PTLL-100to200_1J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v1/NANOAODSIM",  # noqa
+#             ],
+#             n_files=183,
+#             n_events=64510280,
+#         ),
+#     ),
+# )
+# cpn.add_dataset(
+#     name="dy_lep_m50_1j_ptll200to400_amcatnlo",
+#     id=14824736,
+#     processes=[procs.dy_lep_m50_1j_ptll200to400],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/DYto2L-2Jets_MLL-50_PTLL-200to400_1J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v1/NANOAODSIM",  # noqa
+#             ],
+#             n_files=61,
+#             n_events=6583092,
+#         ),
+#     ),
+# )
+# cpn.add_dataset(
+#     name="dy_lep_m50_1j_ptll400to600_amcatnlo",
+#     id=14826052,
+#     processes=[procs.dy_lep_m50_1j_ptll400to600],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/DYto2L-2Jets_MLL-50_PTLL-400to600_1J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v1/NANOAODSIM",  # noqa
+#             ],
+#             n_files=38,
+#             n_events=1722633,
+#         ),
+#     ),
+# )
+
+# cpn.add_dataset(
+#     name="dy_lep_m502j__ptll40to100_amcatnlo",
+#     id=14868304,
+#     processes=[procs.dy_lep_m502j__ptll40to100],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/DYto2L-2Jets_MLL-50_PTLL-40to100_2J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v3/NANOAODSIM",  # noqa
+#             ],
+#             n_files=406,
+#             n_events=66554879,
+#         ),
+#     ),
+# )
+# cpn.add_dataset(
+#     name="dy_lep_m50_2j_ptll100to200_amcatnlo",
+#     id=14870830,
+#     processes=[procs.dy_lep_m50_2j_ptll100to200],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/DYto2L-2Jets_MLL-50_PTLL-100to200_2J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v3/NANOAODSIM",  # noqa
+#             ],
+#             n_files=356,
+#             n_events=70249250,
+#         ),
+#     ),
+# )
+# cpn.add_dataset(
+#     name="dy_lep_m50_2j_ptll200to400_amcatnlo",
+#     id=14853119,
+#     processes=[procs.dy_lep_m50_2j_ptll200to400],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/DYto2L-2Jets_MLL-50_PTLL-200to400_2J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v3/NANOAODSIM",  # noqa
+#             ],
+#             n_files=93,
+#             n_events=12661552,
+#         ),
+#     ),
+# )
+# cpn.add_dataset(
+#     name="dy_lep_m50_2j_ptll400to600_amcatnlo",
+#     id=14827368,
+#     processes=[procs.dy_lep_m50_2j_ptll400to600],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/DYto2L-2Jets_MLL-50_PTLL-400to600_2J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+#             ],
+#             n_files=48,
+#             n_events=1739647,
+#         ),
+#     ),
+# )
+# cpn.add_dataset(
+#     name="dy_lep_m50_2j_ptll600toinf_amcatnlo",
+#     id=14824689,
+#     processes=[procs.dy_lep_m50_2j_ptll600toinf],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/DYto2L-2Jets_MLL-50_PTLL-600_2J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v1/NANOAODSIM",  # noqa
+#             ],
+#             n_files=25,
+#             n_events=1682240,
+#         ),
+#     ),
+# )
 
 
+####################################################################################################
 #
 # W boson production
 #
-
+####################################################################################################
 
 cpn.add_dataset(
     name="w_lnu_amcatnlo",

--- a/cmsdb/campaigns/run3_2022_postEE_nano_v12/higgs.py
+++ b/cmsdb/campaigns/run3_2022_postEE_nano_v12/higgs.py
@@ -1,0 +1,1221 @@
+# coding: utf-8
+
+"""
+Higgs datasets for the 2022postEE data-taking campaign
+"""
+
+from order import DatasetInfo
+
+import cmsdb.processes as procs
+from cmsdb.campaigns.run3_2022_postEE_nano_v12 import campaign_run3_2022_postEE_nano_v12 as cpn
+
+
+#
+# Single Higgs
+#
+
+####################################################################################################
+#
+# ggH
+#
+####################################################################################################
+
+# cpn.add_dataset(
+#     name="h_ggf_hbb_pt200toinf_powheg",
+#     id=14805810,
+#     processes=[procs.h_ggf_hbb_pt200toinf],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/GluGluHto2B_PT-200_M-125_TuneCP5_13p6TeV_powheg-minlo-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+#             ],
+#             n_files=32,
+#             n_events=207945,
+#         ),
+#         extension=DatasetInfo(
+#             keys=[
+#                 "/GluGluHto2B_PT-200_M-125_TuneCP5_13p6TeV_powheg-minlo-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6_ext1-v2/NANOAODSIM",  # noqa
+#             ],
+#             n_files=355,
+#             n_events=15058774,
+#     ),
+# )
+# cpn.add_dataset(
+#     name="h_ggf_hcc_pt200toinf_powheg",
+#     id=14798441,
+#     processes=[procs.h_ggf_hcc_pt200toinf],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/GluGluHtoCC_PT-200_M-125_TuneCP5_13p6TeV_powheg-minlo-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+#             ],
+#             n_files=36,
+#             n_events=359490,
+#         ),
+#     ),
+# )
+cpn.add_dataset(
+    name="h_ggf_hgg_amcatnlo",
+    id=14796528,
+    processes=[procs.h_ggf_hgg],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/GluGluHtoGG_M-125_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=27,
+            n_events=3174151,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="h_ggf_hzz4l_powheg",
+    id=14793399,
+    processes=[procs.h_ggf_hzz4l],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/GluGluHtoZZto4L_M-125_TuneCP5_13p6TeV_powheg2-JHUGenV752-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=19,
+            n_events=1666666,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="h_ggf_hzg_zll_powheg",
+    id=14796430,
+    processes=[procs.h_ggf_hzg_zll],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/GluGluHtoZG_Zto2L_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=26,
+            n_events=199278,
+        ),
+        tune_down=DatasetInfo(
+            keys=[
+                "/GluGluHtoZG_Zto2L_M-125_CP5TuneDown_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=25,
+            n_events=196495,
+        ),
+        tune_up=DatasetInfo(
+            keys=[
+                "/GluGluHtoZG_Zto2L_M-125_CP5TuneUp_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=16,
+            n_events=199301,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="h_ggf_hbb_powheg",
+    id=14876616,
+    processes=[procs.h_ggf_hbb],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/GluGluHto2B_M-125_TuneCP5_13p6TeV_powheg-minlo-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=135,
+            n_events=15489920,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="h_ggf_hww2l2nu_powheg",
+    id=14849369,
+    processes=[procs.h_ggf_hww2l2nu],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/GluGluHto2Wto2L2Nu_M-125_TuneCP5_13p6TeV_powheg-jhugen752-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=93,
+            n_events=4980263,
+        ),
+        tune_down=DatasetInfo(
+            keys=[
+                "/GluGluHto2Wto2L2Nu_M-125_TuneCP5Down_13p6TeV_powheg-jhugen752-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=95,
+            n_events=4987292,
+        ),
+        tune_up=DatasetInfo(
+            keys=[
+                "/GluGluHto2Wto2L2Nu_M-125_TuneCP5Up_13p6TeV_powheg-jhugen752-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=92,
+            n_events=4982312,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="h_ggf_hzz4nu_pt150toinf_powheg",
+    id=14849364,
+    processes=[procs.h_ggf_hzz4nu_pt150toinf],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/GluGluHto2Zto4Nu_PT-150_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=90,
+            n_events=3734036,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="h_ggf_hcc_powheg",
+    id=14872560,
+    processes=[procs.h_ggf_hcc],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/GluGluHto2C_M-125_TuneCP5_13p6TeV_powheg-minlo-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=134,
+            n_events=15481839,
+        ),
+    ),
+)
+# NOTE: there are also htt samples with *UncorrelatedDecay* in the DAS name. They are not considered here.
+cpn.add_dataset(
+    name="h_ggf_htt_amcatnlo",
+    id=14849353,
+    processes=[procs.h_ggf_htt],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/GluGluHto2Tau_M-125_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=89,
+            n_events=3533459,
+        ),
+    ),
+)
+# cpn.add_dataset(
+#     name="h_ggf_hcc_pt200toinf_powheg",
+#     id=14851872,
+#     processes=[procs.h_ggf_hcc_pt200toinf],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/GluGluHto2C_PT-200_M-125_TuneCP5_13p6TeV_powheg-minlo-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+#             ],
+#             n_files=696,
+#             n_events=15117536,
+#         ),
+#     ),
+# )
+# cpn.add_dataset(
+#     name="h_ggf_hee_amcatnlo",
+#     id=14948781,
+#     processes=[procs.h_ggf_hee],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/GluGluHto2E_M-125_TuneCP5_13p6TeV_amcatnloFxFx-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+#             ],
+#             n_files=115,
+#             n_events=3055389,
+#         ),
+#     ),
+# )
+cpn.add_dataset(
+    name="h_ggf_hmm_powheg",
+    id=14850119,
+    processes=[procs.h_ggf_hmm],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/GluGluHto2Mu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v1/NANOAODSIM",  # noqa
+            ],
+            n_files=1,
+            n_events=691000,
+        ),
+    ),
+)
+
+####################################################################################################
+#
+# qqH
+#
+####################################################################################################
+
+# NOTE: this sample includes the *UncorrelatedDecay* tag. No htt dataset without this tag has been found on 07.06.2024
+cpn.add_dataset(
+    name="h_vbf_htt_powheg",
+    id=14927452,
+    processes=[procs.h_vbf_htt],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/VBFHTo2TauUncorrelatedDecay_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=33,
+            n_events=397268,
+        ),
+    ),
+)
+
+cpn.add_dataset(
+    name="h_vbf_hbb_powheg",
+    id=14857769,
+    processes=[procs.h_vbf_hbb],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/VBFHto2B_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=131,
+            n_events=12246336,
+        ),
+        dipole_recoil_on=DatasetInfo(
+            keys=[
+                "/VBFHto2B_M-125_dipoleRecoilOn_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=36,
+            n_events=3180348,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="h_vbf_hcc_powheg",
+    id=14870678,
+    processes=[procs.h_vbf_hcc],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/VBFHto2C_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=140,
+            n_events=15542540,
+        ),
+    ),
+)
+
+cpn.add_dataset(
+    name="h_vbf_hww2l2nu_powheg",
+    id=14849309,
+    processes=[procs.h_vbf_hww2l2nu],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/VBFHto2Wto2L2Nu_M-125_TuneCP5_13p6TeV_powheg-jhugen752-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=96,
+            n_events=4987403,
+        ),
+        tune_down=DatasetInfo(
+            keys=[
+                "/VBFHto2Wto2L2Nu_M-125_TuneCP5Down_13p6TeV_powheg-jhugen752-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=94,
+            n_events=4984705,
+        ),
+        tune_up=DatasetInfo(
+            keys=[
+                "/VBFHto2Wto2L2Nu_M-125_TuneCP5Up_13p6TeV_powheg-jhugen752-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=99,
+            n_events=4978912,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="h_vbf_hzz4nu_powheg",
+    id=14849347,
+    processes=[procs.h_vbf_hzz4nu],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/VBFHto2Zto4Nu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=57,
+            n_events=1743925,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="h_vbf_hgg_amcatnlo",
+    id=14802334,
+    processes=[procs.h_vbf_hgg],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/VBFHtoGG_M-125_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=43,
+            n_events=1799500,
+        ),
+        tune_down=DatasetInfo(
+            keys=[
+                "/VBFHtoZG_Zto2L_M-125_CP5TuneDown_withDipoleRecoil_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=8,
+            n_events=350000,
+        ),
+        tune_up=DatasetInfo(
+            keys=[
+                "/VBFHtoZG_Zto2L_M-125_CP5TuneUp_withDipoleRecoil_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=7,
+            n_events=349296,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="h_vbf_hzg_zll_powheg",
+    id=14800564,
+    processes=[procs.h_vbf_hzg_zll],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/VBFHtoZG_Zto2L_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=6,
+            n_events=50000,
+        ),
+        with_dipole_recoil=DatasetInfo(
+            keys=[
+                "/VBFHtoZG_Zto2L_M-125_TuneCP5_withDipoleRecoil_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=8,
+            n_events=345734,
+        ),
+    ),
+)
+
+####################################################################################################
+#
+# ZH
+#
+####################################################################################################
+
+cpn.add_dataset(
+    name="zh_zqq_hbb_powheg",
+    id=14790777,
+    processes=[procs.zh_zqq_hbb],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ZH_Hto2B_Zto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=17,
+            n_events=4090842,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/ZH_Hto2B_Zto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6_ext1-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=136,
+            n_events=11353020,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="zh_hzg_powheg",
+    id=14796033,
+    processes=[procs.zh_hzg],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ZH_HtoZG_ZtoAll_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=30,
+            n_events=424143,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="zh_zll_hbb_powheg",
+    id=14802579,
+    processes=[procs.zh_zll_hbb],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ZH_Hto2B_Zto2L_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=37,
+            n_events=2062940,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/ZH_Hto2B_Zto2L_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6_ext1-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=236,
+            n_events=12923375,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="zh_zll_hcc_powheg",
+    id=14792528,
+    processes=[procs.zh_zll_hcc],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ZH_Hto2C_Zto2L_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=31,
+            n_events=2955696,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="zh_zqq_hll4nu_powheg",
+    id=14849385,
+    processes=[procs.zh_zqq_hll4nu],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ZHto2Zto4Nu_Zto2Q_M-125_TuneCP5_13p6TeV_powheg-minlo-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=94,
+            n_events=1746525,
+        ),
+    ),
+)
+
+cpn.add_dataset(
+    name="zh_hww2l2nu_powheg",
+    id=14918165,
+    processes=[procs.zh_hww2l2nu],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ZH_ZtoAll_Hto2Wto2L2Nu_M-125_TuneCP5_13p6TeV_powheg-minlo-HZJ-jhugenv752-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=23,
+            n_events=3499224,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="zh_hzg_zll_powheg",
+    id=14885107,
+    processes=[procs.zh_hzg_zll],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ZH_ZtoAll_HtoZGto2LG_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=104,
+            n_events=424006,
+        ),
+        tune_up=DatasetInfo(
+            keys=[
+                "/ZH_ZtoAll_HtoZGto2LG_M-125_CP5TuneUp_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=134,
+            n_events=422599,
+        ),
+        tune_down=DatasetInfo(
+            keys=[
+                "/ZH_ZtoAll_HtoZGto2LG_M-125_CP5TuneDown_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=142,
+            n_events=420688,
+        ),
+    ),
+)
+
+cpn.add_dataset(
+    name="zh_zqq_hcc_powheg",
+    id=14868436,
+    processes=[procs.zh_zqq_hcc],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ZH_Hto2C_Zto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=155,
+            n_events=15467517,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/ZH_Hto2C_Zto2L_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6_ext1-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=248,
+            n_events=11811488,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="zh_hmm_powheg",
+    id=14861719,
+    processes=[procs.zh_hmm],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ZH_Hto2Mu_ZtoAll_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=110,
+            n_events=690584,
+        ),
+    ),
+)
+# NOTE: this sample includes the *UncorrelatedDecay* tag. No htt dataset without this tag has been found on 07.06.2024
+cpn.add_dataset(
+    name="zh_htt_powheg",
+    id=14927555,
+    processes=[procs.zh_htt],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ZHto2TauUncorrelatedDecay_M-125_CP5_13p6TeV_powheg-minnlo-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=22,
+            n_events=69650,
+        ),
+    ),
+)
+
+####################################################################################################
+#
+# zh_gg
+#
+####################################################################################################
+
+cpn.add_dataset(
+    name="zh_gg_zll_hbb_powheg",
+    id=14800335,
+    processes=[procs.zh_gg_zll_hbb],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ggZH_Hto2B_Zto2L_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=36,
+            n_events=2068050,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/ggZH_Hto2B_Zto2L_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6_ext1-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=153,
+            n_events=13417872,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="zh_gg_znunu_hbb_powheg",
+    id=14805763,
+    processes=[procs.zh_gg_znunu_hbb],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ggZH_Hto2B_Zto2Nu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=36,
+            n_events=2012538,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/ggZH_Hto2B_Zto2Nu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6_ext1-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=144,
+            n_events=13450930,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="zh_gg_zqq_hbb_powheg",
+    id=14798128,
+    processes=[procs.zh_gg_zqq_hbb],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ggZH_Hto2B_Zto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=28,
+            n_events=1995576,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/ggZH_Hto2B_Zto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6_ext1-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=251,
+            n_events=13393120,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="zh_gg_zll_hcc_powheg",
+    id=14793916,
+    processes=[procs.zh_gg_zll_hcc],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ggZH_Hto2C_Zto2L_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=53,
+            n_events=2901759,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/ggZH_Hto2C_Zto2L_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6_ext1-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=124,
+            n_events=12308985,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="zh_gg_znunu_hcc_powheg",
+    id=14802049,
+    processes=[procs.zh_gg_znunu_hcc],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ggZH_Hto2C_Zto2Nu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=70,
+            n_events=2934525,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/ggZH_Hto2C_Zto2Nu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6_ext1-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=93,
+            n_events=12576235,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="zh_gg_zqq_hcc_powheg",
+    id=14870624,
+    processes=[procs.zh_gg_zqq_hcc],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ggZH_Hto2C_Zto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=135,
+            n_events=15549976,
+        ),
+    ),
+)
+
+####################################################################################################
+#
+# WplusH
+#
+####################################################################################################
+
+# NOTE: this sample includes the *UncorrelatedDecay* tag. No htt dataset without this tag has been found on 07.06.2024
+cpn.add_dataset(
+    name="wph_htt_powheg",
+    id=14925742,
+    processes=[procs.wph_htt],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WplusHTo2TauUncorrelatedDecay_M-125_TuneCP5_13p6TeV_powheg-minnlo-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=14,
+            n_events=70000,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wph_zqq_hbb_powheg",
+    id=14810685,
+    processes=[procs.wph_zqq_hbb],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WplusH_Hto2B_Wto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=21,
+            n_events=4085059,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/WplusH_Hto2B_Wto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6_ext1-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=481,
+            n_events=11334593,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wph_wlnu_hbb_powheg",
+    id=14805180,
+    processes=[procs.wph_wlnu_hbb],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WplusH_Hto2B_WtoLNu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=38,
+            n_events=2120400,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/WplusH_Hto2B_WtoLNu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6_ext1-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=306,
+            n_events=12788758,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wph_wqq_hcc_powheg",
+    id=14852306,
+    processes=[procs.wph_wqq_hcc],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WplusH_Hto2C_Wto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=531,
+            n_events=15514030,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wph_wlnu_hcc_powheg",
+    id=14792459,
+    processes=[procs.wph_wlnu_hcc],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WplusH_Hto2C_WtoLNu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=92,
+            n_events=2926870,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/WplusH_Hto2C_WtoLNu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6_ext1-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=365,
+            n_events=11934720,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wph_hmm_powheg",
+    id=14872544,
+    processes=[procs.wph_hmm],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WplusH_Hto2Mu_WtoAll_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=28,
+            n_events=417345,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wph_hzz4l_powheg",
+    id=14793772,
+    processes=[procs.wph_hzz4l],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WplusH_Hto2Zto4L_M-125_TuneCP5_13p6TeV_powheg2-minlo-HWJ-JHUGenV752-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=44,
+            n_events=1691511,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wph_hzg_powheg",
+    id=14802027,
+    processes=[procs.wph_hzg],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WplusH_HtoZG_WtoAll_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=26,
+            n_events=138428,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wph_hzg_zll_powheg",
+    id=14844999,
+    processes=[procs.wph_hzg_zll],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WplusH_HtoZG_WtoAll_Zto2L_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=11,
+            n_events=537606,
+        ),
+        tune_down=DatasetInfo(
+            keys=[
+                "/WplusH_HtoZG_WtoAll_Zto2L_M-125_CP5TuneDown_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=28,
+            n_events=139061,
+        ),
+        tune_up=DatasetInfo(
+            keys=[
+                "/WplusH_HtoZG_WtoAll_Zto2L_M-125_CP5TuneUp_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=28,
+            n_events=139225,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wph_wqq_hzz4nu_powheg",
+    id=14849411,
+    processes=[procs.wph_wqq_hzz4nu],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WplusHto2Zto4Nu_Wto2Q_M-125_TuneCP5_13p6TeV_powheg-minlo-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=59,
+            n_events=1742996,
+        ),
+    ),
+)
+
+####################################################################################################
+#
+# WminusH
+#
+####################################################################################################
+
+cpn.add_dataset(
+    name="wmh_hzz4l_powheg",
+    id=14796284,
+    processes=[procs.wmh_hzz4l],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WminusH_Hto2Zto4L_M-125_TuneCP5_13p6TeV_powheg2-minlo-HWJ-JHUGenV752-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=42,
+            n_events=1688428,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wmh_wlnhbb_u_powheg",
+    id=14799662,
+    processes=[procs.wmh_wlnhbb_u],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WminusH_Hto2B_WtoLNu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=60,
+            n_events=2027956,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/WminusH_Hto2B_WtoLNu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6_ext1-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=340,
+            n_events=12999904,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wmh_wqq_hbb_powheg",
+    id=14801501,
+    processes=[procs.wmh_wqq_hbb],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WminusH_Hto2B_Wto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=43,
+            n_events=4003343,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/WminusH_Hto2B_Wto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6_ext1-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=309,
+            n_events=11304506,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wmh_hzz4l_powheg",
+    id=14799041,
+    processes=[procs.wmh_hzz4l],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WminusH_Hto2Zto4L_M-125p5_TuneCP5_13p6TeV_powheg2-minlo-HWJ-JHUGenV752-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=37,
+            n_events=1730541,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wmh_hzg_zll_powheg",
+    id=14793565,
+    processes=[procs.wmh_hzg_zll],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WminusH_HtoZG_WtoAll_Zto2L_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=22,
+            n_events=235813,
+        ),
+        tune_up=DatasetInfo(
+            keys=[
+                "/WminusH_HtoZG_WtoAll_Zto2L_M-125_CP5TuneUp_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=58,
+            n_events=238880,
+        ),
+        tune_down=DatasetInfo(
+            keys=[
+                "/WminusH_HtoZG_WtoAll_Zto2L_M-125_CP5TuneDown_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=91,
+            n_events=238177,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wmh_wlnu_hcc_powheg",
+    id=14798000,
+    processes=[procs.wmh_wlnu_hcc],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WminusH_Hto2C_WtoLNu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=121,
+            n_events=2993794,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/WminusH_Hto2C_WtoLNu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6_ext1-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=557,
+            n_events=11901295,
+        ),
+    ),
+)
+# NOTE: this sample includes the *UncorrelatedDecay* tag. No htt dataset without this tag has been found on 07.06.2024
+cpn.add_dataset(
+    name="wmh_htt_powheg",
+    id=14925240,
+    processes=[procs.wmh_htt],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WminusHTo2TauUncorrelatedDecay_M-125_TuneCP5_13p6TeV_powheg-minnlo-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=7,
+            n_events=67580,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wmh_wqq_hcc_powheg",
+    id=14852324,
+    processes=[procs.wmh_wqq_hcc],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WminusH_Hto2C_Wto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=529,
+            n_events=15485820,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wmh_wqq_powheg",
+    id=14958828,
+    processes=[procs.wmh_wqq],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WminusHto2Zto4Nu_Wto2Q_M-125_TuneCP5_13p6TeV_powheg-minlo-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=36,
+            n_events=1746566,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wmh_hmm_powheg",
+    id=14868377,
+    processes=[procs.wmh_hmm],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WminusH_Hto2Mu_WtoAll_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=8,
+            n_events=420000,
+        ),
+    ),
+)
+
+
+####################################################################################################
+#
+# ttH
+#
+####################################################################################################
+
+# cpn.add_dataset(
+#     name="tth_hbb_powheg",
+#     id=14870747,
+#     processes=[procs.tth_hbb],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/TTH_Hto2B_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v3/NANOAODSIM",  # noqa
+#             ],
+#             n_files=85,
+#             n_events=10478951,
+#         ),
+#     ),
+# )
+cpn.add_dataset(
+    name="tth_hbb_powheg",
+    id=14868530,
+    processes=[procs.tth_hbb],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/TTHto2B_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=134,
+            n_events=11099294,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="tth_hmm_powheg",
+    id=14867977,
+    processes=[procs.tth_hmm],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/TTH_Hto2Mu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=19,
+            n_events=699316,
+        ),
+    ),
+)
+# cpn.add_dataset(
+#     name="tth_hzz_powheg",
+#     id=14951667,
+#     processes=[procs.tth_hzz],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/TTH_Hto2Z_4LFilter_M-125_TuneCP5_13p6TeV_powheg-jhugenv752-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+#             ],
+#             n_files=30,
+#             n_events=298293,
+#         ),
+#     ),
+# )
+cpn.add_dataset(
+    name="tth_hzz_powheg",
+    id=14793353,
+    processes=[procs.tth_hzz],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/TTH_Hto2Z_M-125_4LFilter_TuneCP5_13p6TeV_powheg2-JHUGenV752-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=17,
+            n_events=341864,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="tth_hcc_powheg",
+    id=14870594,
+    processes=[procs.tth_hcc],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/TTHto2C_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=113,
+            n_events=11355120,
+        ),
+    ),
+)
+# cpn.add_dataset(
+#     name="tth_hnonbb_1j_amcatnlo",
+#     id=14852415,
+#     processes=[procs.tth_hnonbb_1j],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/TTHtoNon2B-1Jets_M-125_TuneCP5_13p6TeV_amcatnloFXFX-madspin-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+#             ],
+#             n_files=320,
+#             n_events=22107915,
+#         ),
+#     ),
+# )
+cpn.add_dataset(
+    name="tth_hnonbb_powheg",
+    id=14845759,
+    processes=[procs.tth_hnonbb],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/TTHtoNon2B_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=122,
+            n_events=13955780,
+        ),
+    ),
+)
+
+####################################################################################################
+#
+# ttVH
+#
+####################################################################################################
+
+cpn.add_dataset(
+    name="ttzh_madgraph",
+    id=14861698,
+    processes=[procs.ttzh],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/TTZH_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=104,
+            n_events=2785771,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="ttwh_madgraph",
+    id=14855650,
+    processes=[procs.ttwh],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/TTWH_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=79,
+            n_events=2800000,
+        ),
+    ),
+)

--- a/cmsdb/campaigns/run3_2022_postEE_nano_v12/top.py
+++ b/cmsdb/campaigns/run3_2022_postEE_nano_v12/top.py
@@ -1022,3 +1022,53 @@ cpn.add_dataset(
         # ),
     ),
 )
+
+####################################################################################################
+#
+# ttV, ttVV
+#
+####################################################################################################
+
+# TODO: add corresponding process
+# cpn.add_dataset(
+#     name="ttz_zqq_1j_amcatnlo",
+#     id=14795953,
+#     processes=[procs.ttz_zqq_1j],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/TTZ-ZtoQQ-1Jets_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+#             ],
+#             n_files=52,
+#             n_events=1334574,
+#         ),
+#     ),
+# )
+cpn.add_dataset(
+    name="ttzz_madgraph",
+    id=14826688,
+    processes=[procs.ttzz],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/TTZZ_TuneCP5_13p6TeV_madgraph-madspin-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=17,
+            n_events=1054000,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="ttww_madgraph",
+    id=14800877,
+    processes=[procs.ttww],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/TTWW_TuneCP5_13p6TeV_madgraph-madspin-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=52,
+            n_events=1536000,
+        ),
+    ),
+)

--- a/cmsdb/campaigns/run3_2022_preEE_nano_v12/ewk.py
+++ b/cmsdb/campaigns/run3_2022_preEE_nano_v12/ewk.py
@@ -9,13 +9,15 @@ from order import DatasetInfo
 import cmsdb.processes as procs
 from cmsdb.campaigns.run3_2022_preEE_nano_v12 import campaign_run3_2022_preEE_nano_v12 as cpn
 
+####################################################################################################
 #
 # Drell-Yan
 #
+####################################################################################################
 
-# inclusive (madgraph)
+# inclusive, LO, forPog
 cpn.add_dataset(
-    name="dy_lep_m50_madgraph",
+    name="dy_lep_m50_for_pog_madgraph",
     id=14802794,
     processes=[procs.dy_lep_m50],
     keys=[
@@ -25,31 +27,546 @@ cpn.add_dataset(
     n_events=27096229,
 )
 
+# inclusive, LO
 cpn.add_dataset(
-    name="dy_lep_m10to50_amcatnlo",
-    id=14803891,
+    name="dy_lep_m10to50_madgraph",
+    id=14873228,
     processes=[procs.dy_lep_m10to50],
     info=dict(
         nominal=DatasetInfo(
             keys=[
-                "/DYto2L-2Jets_MLL-10to50_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+                "/DYto2L-4Jets_MLL-10to50_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v3/NANOAODSIM",  # noqa
             ],
-            n_files=141,
-            n_events=67681922,
+            n_files=2274,
+            n_events=500642946,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="dy_lep_m50_madgraph",
+    id=14810676,
+    processes=[procs.dy_lep_m50],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/DYto2L-4Jets_MLL-50_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=236,
+            n_events=240872023,
         ),
         extension=DatasetInfo(
             keys=[
-                "/DYto2L-2Jets_MLL-10to50_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v1/NANOAODSIM",  # noqa
+                "/DYto2L-4Jets_MLL-50_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6_ext1-v2/NANOAODSIM",  # noqa
             ],
-            n_files=73,
-            n_events=47494002,
+            n_files=1587,
+            n_events=254295366,
         ),
     ),
 )
 
+# jet-binned, LO
+cpn.add_dataset(
+    name="dy_lep_m50_1j_madgraph",
+    id=14790810,
+    processes=[procs.dy_lep_m50_1j],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/DYto2L-4Jets_MLL-50_1J_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=187,
+            n_events=57771603,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="dy_lep_m50_2j_madgraph",
+    id=14794042,
+    processes=[procs.dy_lep_m50_2j],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/DYto2L-4Jets_MLL-50_2J_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=147,
+            n_events=50007544,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="dy_lep_m50_3j_madgraph",
+    id=14791238,
+    processes=[procs.dy_lep_m50_3j],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/DYto2L-4Jets_MLL-50_3J_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=109,
+            n_events=28997825,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="dy_lep_m50_4j_madgraph",
+    id=14794840,
+    processes=[procs.dy_lep_m50_4j],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/DYto2L-4Jets_MLL-50_4J_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=140,
+            n_events=9490226,
+        ),
+    ),
+)
+
+# TODO: implement corresponding processes + xsecs
+# # ptll-binned, LO
+# cpn.add_dataset(
+#     name="dy_lep_m50_ptll100to200_madgraph",
+#     id=14948737,
+#     processes=[procs.dy_lep_m50_ptll100to200],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/DYto2L-4Jets_MLL-50_PTLL-100to200_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+#             ],
+#             n_files=497,
+#             n_events=69961256,
+#         ),
+#     ),
+# )
+# cpn.add_dataset(
+#     name="dy_lep_m50_ptll200to400_madgraph",
+#     id=14949443,
+#     processes=[procs.dy_lep_m50_ptll200to400],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/DYto2L-4Jets_MLL-50_PTLL-200to400_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+#             ],
+#             n_files=155,
+#             n_events=6931476,
+#         ),
+#     ),
+# )
+# cpn.add_dataset(
+#     name="dy_lep_m50_ptll400to600_madgraph",
+#     id=14949288,
+#     processes=[procs.dy_lep_m50_ptll400to600],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/DYto2L-4Jets_MLL-50_PTLL-400to600_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+#             ],
+#             n_files=81,
+#             n_events=3355496,
+#         ),
+#     ),
+# )
+# cpn.add_dataset(
+#     name="dy_lep_m50_ptll600toinf_madgraph",
+#     id=14948747,
+#     processes=[procs.dy_lep_m50_ptll600toinf],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/DYto2L-4Jets_MLL-50_PTLL-600_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+#             ],
+#             n_files=117,
+#             n_events=3470735,
+#         ),
+#     ),
+# )
+
+# # ht-binned, LO
+# cpn.add_dataset(
+#     name="dy_lep_m4to50_ht40to70_madgraph",
+#     id=14950532,
+#     processes=[procs.dy_lep_m4to50_ht40to70],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/DYto2L-4Jets_MLL-4to50_HT-40to70_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+#             ],
+#             n_files=1706,
+#             n_events=332696345,
+#         ),
+#     ),
+# )
+# cpn.add_dataset(
+#     name="dy_lep_m4to50_ht70to100_madgraph",
+#     id=14949534,
+#     processes=[procs.dy_lep_m4to50_ht70to100],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/DYto2L-4Jets_MLL-4to50_HT-70to100_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+#             ],
+#             n_files=1099,
+#             n_events=201751012,
+#         ),
+#     ),
+# )
+# cpn.add_dataset(
+#     name="dy_lep_m4to50_ht400to800_madgraph",
+#     id=14949799,
+#     processes=[procs.dy_lep_m4to50_ht400to800],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/DYto2L-4Jets_MLL-4to50_HT-400to800_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+#             ],
+#             n_files=77,
+#             n_events=4520981,
+#         ),
+#     ),
+# )
+# cpn.add_dataset(
+#     name="dy_lep_m4to50_ht800to1500_madgraph",
+#     id=14948706,
+#     processes=[procs.dy_lep_m4to50_ht800to1500],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/DYto2L-4Jets_MLL-4to50_HT-800to1500_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+#             ],
+#             n_files=189,
+#             n_events=3901947,
+#         ),
+#     ),
+# )
+# cpn.add_dataset(
+#     name="dy_lep_m4to50_ht1500to2500_madgraph",
+#     id=14951014,
+#     processes=[procs.dy_lep_m4to50_ht1500to2500],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/DYto2L-4Jets_MLL-4to50_HT-1500to2500_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+#             ],
+#             n_files=54,
+#             n_events=3203979,
+#         ),
+#     ),
+# )
+# cpn.add_dataset(
+#     name="dy_lep_m4to50_ht2500toinf_madgraph",
+#     id=14952243,
+#     processes=[procs.dy_lep_m4to50_ht2500toinf],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/DYto2L-4Jets_MLL-4to50_HT-2500_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v1/NANOAODSIM",  # noqa
+#             ],
+#             n_files=147,
+#             n_events=3660177,
+#         ),
+#     ),
+# )
+# cpn.add_dataset(
+#     name="dy_lep_m50to120_ht40to70_madgraph",
+#     id=14817089,
+#     processes=[procs.dy_lep_m50to120_ht40to70],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/DYto2L-4Jets_MLL-50to120_HT-40to70_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v1/NANOAODSIM",  # noqa
+#             ],
+#             n_files=422,
+#             n_events=133980512,
+#         ),
+#     ),
+# )
+# cpn.add_dataset(
+#     name="dy_lep_m50to120_ht70to100_madgraph",
+#     id=14847021,
+#     processes=[procs.dy_lep_m50to120_ht70to100],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/DYto2L-4Jets_MLL-50to120_HT-70to100_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v3/NANOAODSIM",  # noqa
+#             ],
+#             n_files=648,
+#             n_events=98847366,
+#         ),
+#     ),
+# )
+# cpn.add_dataset(
+#     name="dy_lep_m50to120_ht100to400_madgraph",
+#     id=14813464,
+#     processes=[procs.dy_lep_m50to120_ht100to400],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/DYto2L-4Jets_MLL-50to120_HT-100to400_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v1/NANOAODSIM",  # noqa
+#             ],
+#             n_files=307,
+#             n_events=142936007,
+#         ),
+#     ),
+# )
+
+# inclusive, NLO
+cpn.add_dataset(
+    name="dy_lep_m4to10_amcatnlo",
+    id=14940403,
+    processes=[procs.dy_lep_m4to10],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/DYto2L-2Jets_MLL-4to10_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=1037,
+            n_events=197465370,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/DYto2L-2Jets_MLL-4to10_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6_ext1-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=838,
+            n_events=147147055,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="dy_lep_m10to50_amcatnlo",
+    id=14803206,
+    processes=[procs.dy_lep_m10to50],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/DYto2L-2Jets_MLL-10to50_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=322,
+            n_events=215532589,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/DYto2L-2Jets_MLL-10to50_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6_ext1-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=1123,
+            n_events=171220296,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="dy_lep_m50_amcatnlo",
+    id=14791972,
+    processes=[procs.dy_lep_m50],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/DYto2L-2Jets_MLL-50_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=286,
+            n_events=213436879,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/DYto2L-2Jets_MLL-50_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6_ext1-v1/NANOAODSIM",  # noqa
+            ],
+            n_files=407,
+            n_events=319825084,
+        ),
+    ),
+)
+
+# jet-binned, NLO
+cpn.add_dataset(
+    name="dy_lep_m50_0j_amcatnlo",
+    id=14791116,
+    processes=[procs.dy_lep_m50_0j],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/DYto2L-2Jets_MLL-50_0J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=452,
+            n_events=346950546,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="dy_lep_m50_1j_amcatnlo",
+    id=14790681,
+    processes=[procs.dy_lep_m50_1j],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/DYto2L-2Jets_MLL-50_1J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=454,
+            n_events=322623183,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="dy_lep_m50_2j_amcatnlo",
+    id=14801013,
+    processes=[procs.dy_lep_m50_2j],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/DYto2L-2Jets_MLL-50_2J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=386,
+            n_events=277437970,
+        ),
+    ),
+)
+
+# TODO: implement corresponding processes + xsecs
+# # ptll and jet-binned, NLO
+# cpn.add_dataset(
+#     name="dy_lep_m50_1j_ptll40to100_amcatnlo",
+#     id=14825993,
+#     processes=[procs.dy_lep_m50_1j_ptll40to100],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/DYto2L-2Jets_MLL-50_PTLL-40to100_1J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v1/NANOAODSIM",  # noqa
+#             ],
+#             n_files=287,
+#             n_events=163904854,
+#         ),
+#     ),
+# )
+# cpn.add_dataset(
+#     name="dy_lep_m50_1j_ptll100to200_amcatnlo",
+#     id=14826169,
+#     processes=[procs.dy_lep_m50_1j_ptll100to200],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/DYto2L-2Jets_MLL-50_PTLL-100to200_1J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v1/NANOAODSIM",  # noqa
+#             ],
+#             n_files=183,
+#             n_events=64510280,
+#         ),
+#     ),
+# )
+# cpn.add_dataset(
+#     name="dy_lep_m50_1j_ptll200to400_amcatnlo",
+#     id=14824736,
+#     processes=[procs.dy_lep_m50_1j_ptll200to400],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/DYto2L-2Jets_MLL-50_PTLL-200to400_1J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v1/NANOAODSIM",  # noqa
+#             ],
+#             n_files=61,
+#             n_events=6583092,
+#         ),
+#     ),
+# )
+# cpn.add_dataset(
+#     name="dy_lep_m50_1j_ptll400to600_amcatnlo",
+#     id=14826052,
+#     processes=[procs.dy_lep_m50_1j_ptll400to600],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/DYto2L-2Jets_MLL-50_PTLL-400to600_1J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v1/NANOAODSIM",  # noqa
+#             ],
+#             n_files=38,
+#             n_events=1722633,
+#         ),
+#     ),
+# )
+# cpn.add_dataset(
+#     name="dy_lep_m50_1j_ptll600toinf_amcatnlo",
+#     id=14870369,
+#     processes=[procs.dy_lep_m50_1j_ptll600toinf],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/DYto2L-2Jets_MLL-50_PTLL-600_1J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v3/NANOAODSIM",  # noqa
+#             ],
+#             n_files=33,
+#             n_events=1862921,
+#         ),
+#     ),
+# )
+# cpn.add_dataset(
+#     name="dy_lep_m50_2j_ptll40to100_amcatnlo",
+#     id=14868304,
+#     processes=[procs.dy_lep_m50_2j_ptll40to100],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/DYto2L-2Jets_MLL-50_PTLL-40to100_2J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v3/NANOAODSIM",  # noqa
+#             ],
+#             n_files=406,
+#             n_events=66554879,
+#         ),
+#     ),
+# )
+# cpn.add_dataset(
+#     name="dy_lep_m50_2j_ptll100to200_amcatnlo",
+#     id=14870830,
+#     processes=[procs.dy_lep_m50_2j_ptll100to200],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/DYto2L-2Jets_MLL-50_PTLL-100to200_2J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v3/NANOAODSIM",  # noqa
+#             ],
+#             n_files=356,
+#             n_events=70249250,
+#         ),
+#     ),
+# )
+# cpn.add_dataset(
+#     name="dy_lep_m50_2j_ptll200to400_amcatnlo",
+#     id=14853119,
+#     processes=[procs.dy_lep_m50_2j_ptll200to400],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/DYto2L-2Jets_MLL-50_PTLL-200to400_2J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v3/NANOAODSIM",  # noqa
+#             ],
+#             n_files=93,
+#             n_events=12661552,
+#         ),
+#     ),
+# )
+# cpn.add_dataset(
+#     name="dy_lep_m50_2j_ptll400to600_amcatnlo",
+#     id=14827368,
+#     processes=[procs.dy_lep_m50_2j_ptll400to600],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/DYto2L-2Jets_MLL-50_PTLL-400to600_2J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+#             ],
+#             n_files=48,
+#             n_events=1739647,
+#         ),
+#     ),
+# )
+# cpn.add_dataset(
+#     name="dy_lep_m50_2j_ptll600toinf_amcatnlo",
+#     id=14824689,
+#     processes=[procs.dy_lep_m50_2j_ptll600toinf],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/DYto2L-2Jets_MLL-50_PTLL-600_2J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22EENanoAODv12-130X_mcRun3_2022_realistic_postEE_v6-v1/NANOAODSIM",  # noqa
+#             ],
+#             n_files=25,
+#             n_events=1682240,
+#         ),
+#     ),
+# )
+
+
+####################################################################################################
 #
 # W boson production
 #
+####################################################################################################
 
 cpn.add_dataset(
     name="w_lnu_amcatnlo",

--- a/cmsdb/campaigns/run3_2022_preEE_nano_v12/higgs.py
+++ b/cmsdb/campaigns/run3_2022_preEE_nano_v12/higgs.py
@@ -1,0 +1,1246 @@
+# coding: utf-8
+
+"""
+Higgs datasets for the 2022preEE data-taking campaign
+"""
+
+from order import DatasetInfo
+
+import cmsdb.processes as procs
+from cmsdb.campaigns.run3_2022_preEE_nano_v12 import campaign_run3_2022_preEE_nano_v12 as cpn
+
+
+#
+# Single Higgs
+#
+
+####################################################################################################
+#
+# h_ggf
+#
+####################################################################################################
+
+cpn.add_dataset(
+    name="h_ggf_hbb_pt200toinf_powheg",
+    id=14801316,
+    processes=[procs.h_ggf_hbb_pt200toinf],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/GluGluHto2B_PT-200_M-125_TuneCP5_13p6TeV_powheg-minlo-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=29,
+            n_events=59480,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/GluGluHto2B_PT-200_M-125_TuneCP5_13p6TeV_powheg-minlo-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=291,
+            n_events=4324232,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="h_ggf_hcc_pt200toinf_powheg",
+    id=14797543,
+    processes=[procs.h_ggf_hcc_pt200toinf],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/GluGluHtoCC_PT-200_M-125_TuneCP5_13p6TeV_powheg-minlo-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=20,
+            n_events=122144,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="h_ggf_hgg_amcatnlo",
+    id=14805985,
+    processes=[procs.h_ggf_hgg],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/GluGluHtoGG_M-125_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=27,
+            n_events=933797,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="h_ggf_hzz4l_powheg",
+    id=14796087,
+    processes=[procs.h_ggf_hzz4l],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/GluGluHtoZZto4L_M-125_TuneCP5_13p6TeV_powheg2-JHUGenV752-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=24,
+            n_events=486643,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="h_ggf_hzg_zll_powheg",
+    id=14797462,
+    processes=[procs.h_ggf_hzg_zll],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/GluGluHtoZG_Zto2L_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=19,
+            n_events=55000,
+        ),
+        tune_down=DatasetInfo(
+            keys=[
+                "/GluGluHtoZG_Zto2L_M-125_CP5TuneDown_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=2,
+            n_events=55000,
+        ),
+        tune_up=DatasetInfo(
+            keys=[
+                "/GluGluHtoZG_Zto2L_M-125_CP5TuneUp_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=21,
+            n_events=54999,
+        ),
+    ),
+)
+# NOTE: there are also htt samples with *UncorrelatedDecay* in the DAS name. They are not considered here.
+cpn.add_dataset(
+    name="h_ggf_htt_powheg",
+    id=14805667,
+    processes=[procs.h_ggf_htt],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/GluGluHToTauTau_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=14,
+            n_events=295722,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="h_ggf_hbb_powheg",
+    id=14876200,
+    processes=[procs.h_ggf_hbb],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/GluGluHto2B_M-125_TuneCP5_13p6TeV_powheg-minlo-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=53,
+            n_events=4353624,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="h_ggf_hww2l2nu_powheg",
+    id=14849365,
+    processes=[procs.h_ggf_hww2l2nu],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/GluGluHto2Wto2L2Nu_M-125_TuneCP5_13p6TeV_powheg-jhugen752-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=60,
+            n_events=1494981,
+        ),
+        tune_down=DatasetInfo(
+            keys=[
+                "/GluGluHto2Wto2L2Nu_M-125_TuneCP5Down_13p6TeV_powheg-jhugen752-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=55,
+            n_events=1494981,
+        ),
+        tune_up=DatasetInfo(
+            keys=[
+                "/GluGluHto2Wto2L2Nu_M-125_TuneCP5Up_13p6TeV_powheg-jhugen752-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=59,
+            n_events=1497196,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="h_ggf_hzz4nu_powheg",
+    id=14849342,
+    processes=[procs.h_ggf_hzz4nu],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/GluGluHto2Zto4Nu_PT-150_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=34,
+            n_events=1014208,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="h_ggf_hcc_powheg",
+    id=14877479,
+    processes=[procs.h_ggf_hcc],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/GluGluHto2C_M-125_TuneCP5_13p6TeV_powheg-minlo-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=61,
+            n_events=4371062,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="h_ggf_htt_amcatnlo",
+    id=14849328,
+    processes=[procs.h_ggf_htt],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/GluGluHto2Tau_M-125_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=29,
+            n_events=1038456,
+        ),
+    ),
+)
+# cpn.add_dataset(
+#     name="h_ggf_hcc_pt200toinf_powheg",
+#     id=14852276,
+#     processes=[procs.h_ggf_hcc_pt200toinf],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/GluGluHto2C_PT-200_M-125_TuneCP5_13p6TeV_powheg-minlo-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+#             ],
+#             n_files=319,
+#             n_events=4322480,
+#         ),
+#     ),
+# )
+# cpn.add_dataset(
+#     name="h_ggf_hee_amcatnlo",
+#     id=14947996,
+#     processes=[procs.h_ggf_hee],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/GluGluHto2E_M-125_TuneCP5_13p6TeV_amcatnloFxFx-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+#             ],
+#             n_files=65,
+#             n_events=881432,
+#         ),
+#     ),
+# )
+# cpn.add_dataset(
+#     name="h_ggf_hzz4l_ew0_powheg",
+#     id=14950668,
+#     processes=[procs.h_ggf_hzz4l_ew0],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/GluGluHtoZZto4L_ew0_M-125_TuneCP5_13p6TeV_powheg-jhugen-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+#             ],
+#             n_files=20,
+#             n_events=100000,
+#         ),
+#     ),
+# )
+cpn.add_dataset(
+    name="h_ggf_hmm_powheg",
+    id=14868421,
+    processes=[procs.h_ggf_hmm],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/GluGluHto2Mu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=21,
+            n_events=200000,
+        ),
+    ),
+)
+
+####################################################################################################
+#
+# h_vbf
+#
+####################################################################################################
+
+cpn.add_dataset(
+    name="h_vbf_hzg_zll_powheg",
+    id=14798046,
+    processes=[procs.h_vbf_hzg_zll],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/VBFHtoZG_Zto2L_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=5,
+            n_events=12000,
+        ),
+        with_dipole_recoil=DatasetInfo(
+            keys=[
+                "/VBFHtoZG_Zto2L_M-125_TuneCP5_withDipoleRecoil_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=4,
+            n_events=96465,
+        ),
+        tune_up=DatasetInfo(
+            keys=[
+                "/VBFHtoZG_Zto2L_M-125_CP5TuneUp_withDipoleRecoil_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=5,
+            n_events=98582,
+        ),
+        tune_down=DatasetInfo(
+            keys=[
+                "/VBFHtoZG_Zto2L_M-125_CP5TuneDown_withDipoleRecoil_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=5,
+            n_events=96480,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="h_vbf_hww2l2nu_powheg",
+    id=14849334,
+    processes=[procs.h_vbf_hww2l2nu],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/VBFHto2Wto2L2Nu_M-125_TuneCP5_13p6TeV_powheg-jhugen752-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=43,
+            n_events=1497840,
+        ),
+        tune_up=DatasetInfo(
+            keys=[
+                "/VBFHto2Wto2L2Nu_M-125_TuneCP5Up_13p6TeV_powheg-jhugen752-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=56,
+            n_events=1498588,
+        ),
+        tune_down=DatasetInfo(
+            keys=[
+                "/VBFHto2Wto2L2Nu_M-125_TuneCP5Down_13p6TeV_powheg-jhugen752-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=58,
+            n_events=1497840,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="h_vbf_hzz4nu_powheg",
+    id=14849329,
+    processes=[procs.h_vbf_hzz4nu],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/VBFHto2Zto4Nu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=30,
+            n_events=500000,
+        ),
+    ),
+)
+# NOTE: this sample includes the *UncorrelatedDecay* tag. No htt dataset without this tag has been found on 07.06.2024
+cpn.add_dataset(
+    name="h_vbf_htt_powheg",
+    id=14926213,
+    processes=[procs.h_vbf_htt],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/VBFHTo2TauUncorrelatedDecay_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=13,
+            n_events=100000,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="h_vbf_hgg_amcatnlo",
+    id=14885189,
+    processes=[procs.h_vbf_hgg],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/VBFHtoGG_M-125_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=15,
+            n_events=314360,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="h_vbf_hcc_powheg",
+    id=14853086,
+    processes=[procs.h_vbf_hcc],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/VBFHto2C_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=119,
+            n_events=4348092,
+        ),
+    ),
+)
+# cpn.add_dataset(
+#     name="h_vbf_hcc_powheg",
+#     id=14788422,
+#     processes=[procs.h_vbf_hcc],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/VBFHToCC_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-FlatPU0to70_130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+#             ],
+#             n_files=1,
+#             n_events=300000,
+#         ),
+#     ),
+# )
+cpn.add_dataset(
+    name="h_vbf_hbb_powheg",
+    id=14870810,
+    processes=[procs.h_vbf_hbb],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/VBFHto2B_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=33,
+            n_events=3330700,
+        ),
+        dipole_recoil_on=DatasetInfo(
+            keys=[
+                "/VBFHto2B_M-125_dipoleRecoilOn_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=31,
+            n_events=948700,
+        ),
+    ),
+)
+
+####################################################################################################
+#
+# zh
+#
+####################################################################################################
+
+cpn.add_dataset(
+    name="zh_zqq_hbb_powheg",
+    id=14805167,
+    processes=[procs.zh_zqq_hbb],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ZH_Hto2B_Zto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=19,
+            n_events=1144560,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/ZH_Hto2B_Zto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=65,
+            n_events=3177722,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="zh_hzg_powheg",
+    id=14794187,
+    processes=[procs.zh_hzg],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ZH_HtoZG_ZtoAll_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=46,
+            n_events=124384,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="zh_zll_hbb_powheg",
+    id=14805378,
+    processes=[procs.zh_zll_hbb],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ZH_Hto2B_Zto2L_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=34,
+            n_events=599100,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/ZH_Hto2B_Zto2L_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=57,
+            n_events=4339792,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="zh_zll_hcc_powheg",
+    id=14800392,
+    processes=[procs.zh_zll_hcc],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ZH_Hto2C_Zto2L_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=27,
+            n_events=799380,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/ZH_Hto2C_Zto2L_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=45,
+            n_events=4153800,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="zh_zqq_powheg",
+    id=14849422,
+    processes=[procs.zh_zqq],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ZHto2Zto4Nu_Zto2Q_M-125_TuneCP5_13p6TeV_powheg-minlo-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=70,
+            n_events=497369,
+        ),
+    ),
+)
+# NOTE: this sample includes the *UncorrelatedDecay* tag. No htt dataset without this tag has been found on 07.06.2024
+cpn.add_dataset(
+    name="zh_htt_powheg",
+    id=14927154,
+    processes=[procs.zh_htt],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ZHto2TauUncorrelatedDecay_M-125_CP5_13p6TeV_powheg-minnlo-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=22,
+            n_events=28752,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="zh_hww2l2nu_powheg",
+    id=14918311,
+    processes=[procs.zh_hww2l2nu],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ZH_ZtoAll_Hto2Wto2L2Nu_M-125_TuneCP5_13p6TeV_powheg-minlo-HZJ-jhugenv752-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=53,
+            n_events=963869,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="zh_hzg_zll_powheg",
+    id=14885110,
+    processes=[procs.zh_hzg_zll],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ZH_ZtoAll_HtoZGto2LG_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=52,
+            n_events=124660,
+        ),
+        tune_up=DatasetInfo(
+            keys=[
+                "/ZH_ZtoAll_HtoZGto2LG_M-125_CP5TuneUp_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=51,
+            n_events=124656,
+        ),
+        tune_down=DatasetInfo(
+            keys=[
+                "/ZH_ZtoAll_HtoZGto2LG_M-125_CP5TuneDown_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=38,
+            n_events=124659,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="zh_zqq_hcc_powheg",
+    id=14868489,
+    processes=[procs.zh_zqq_hcc],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ZH_Hto2C_Zto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=64,
+            n_events=3101694,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="zh_hmm_powheg",
+    id=14863423,
+    processes=[procs.zh_hmm],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ZH_Hto2Mu_ZtoAll_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=35,
+            n_events=196974,
+        ),
+    ),
+)
+
+####################################################################################################
+#
+# zh_gg
+#
+####################################################################################################
+
+cpn.add_dataset(
+    name="zh_gg_zqq_hbb_powheg",
+    id=14804331,
+    processes=[procs.zh_gg_zqq_hbb],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ggZH_Hto2B_Zto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=21,
+            n_events=578672,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/ggZH_Hto2B_Zto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=59,
+            n_events=3782022,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="zh_gg_zll_hbb_powheg",
+    id=14803231,
+    processes=[procs.zh_gg_zll_hbb],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ggZH_Hto2B_Zto2L_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=23,
+            n_events=582250,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/ggZH_Hto2B_Zto2L_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=41,
+            n_events=3780820,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="zh_gg_znunu_hbb_powheg",
+    id=14805533,
+    processes=[procs.zh_gg_znunu_hbb],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ggZH_Hto2B_Zto2Nu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=16,
+            n_events=581016,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/ggZH_Hto2B_Zto2Nu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=39,
+            n_events=3784521,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="zh_gg_zll_hcc_powheg",
+    id=14803676,
+    processes=[procs.zh_gg_zll_hcc],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ggZH_Hto2C_Zto2L_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=41,
+            n_events=773402,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/ggZH_Hto2C_Zto2Nu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=38,
+            n_events=3588800,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="zh_gg_znunu_hcc_powheg",
+    id=14846449,
+    processes=[procs.zh_gg_znunu_hcc],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ggZH_Hto2C_Zto2Nu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=29,
+            n_events=797924,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/ggZH_Hto2C_Zto2L_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=39,
+            n_events=3593320,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="zh_gg_zqq_hcc_powheg",
+    id=14853067,
+    processes=[procs.zh_gg_zqq_hcc],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/ggZH_Hto2C_Zto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=114,
+            n_events=4391804,
+        ),
+    ),
+)
+
+####################################################################################################
+#
+# WminusH
+#
+####################################################################################################
+
+cpn.add_dataset(
+    name="wmh_hzz4l_powheg",
+    id=14793663,
+    processes=[procs.wmh_hzz4l],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WminusH_Hto2Zto4L_M-125_TuneCP5_13p6TeV_powheg2-minlo-HWJ-JHUGenV752-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=19,
+            n_events=491969,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wmh_wlnu_hbb_powheg",
+    id=14805882,
+    processes=[procs.wmh_wlnu_hbb],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WminusH_Hto2B_WtoLNu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=21,
+            n_events=590044,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/WminusH_Hto2B_WtoLNu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=169,
+            n_events=4399854,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wmh_wqq_hbb_powheg",
+    id=14801338,
+    processes=[procs.wmh_wqq_hbb],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WminusH_Hto2B_Wto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=22,
+            n_events=1147965,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/WminusH_Hto2B_Wto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=223,
+            n_events=3153199,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wmh_wln_hccu_powheg",
+    id=14804815,
+    processes=[procs.wmh_wln_hccu],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WminusH_Hto2C_WtoLNu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=33,
+            n_events=732400,
+        ),
+    ),
+)
+# NOTE: this sample includes the *UncorrelatedDecay* tag. No htt dataset without this tag has been found on 07.06.2024
+cpn.add_dataset(
+    name="wmh_powheg",
+    id=14926126,
+    processes=[procs.wmh],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WminusHTo2TauUncorrelatedDecay_M-125_TuneCP5_13p6TeV_powheg-minnlo-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=12,
+            n_events=30000,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wmh_wqq_hcc_powheg",
+    id=14852474,
+    processes=[procs.wmh_wqq_hcc],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WminusH_Hto2C_Wto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=321,
+            n_events=4357249,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/WminusH_Hto2C_WtoLNu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=147,
+            n_events=4200000,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wmh_wqq_hzz4nu_powheg",
+    id=14849469,
+    processes=[procs.wmh_wqq_hzz4nu],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WminusHto2Zto4Nu_Wto2Q_M-125_TuneCP5_13p6TeV_powheg-minlo-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=26,
+            n_events=497364,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wmh_hzg_zll_powheg",
+    id=14826664,
+    processes=[procs.wmh_hzg_zll],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WminusH_HtoZG_WtoAll_Zto2L_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=18,
+            n_events=53961,
+        ),
+        tune_up=DatasetInfo(
+            keys=[
+                "/WminusH_HtoZG_WtoAll_Zto2L_M-125_CP5TuneUp_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=12,
+            n_events=70000,
+        ),
+        tune_down=DatasetInfo(
+            keys=[
+                "/WminusH_HtoZG_WtoAll_Zto2L_M-125_CP5TuneDown_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=16,
+            n_events=69801,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wmh_hmm_powheg",
+    id=14856644,
+    processes=[procs.wmh_hmm],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WminusH_Hto2Mu_WtoAll_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=5,
+            n_events=120000,
+        ),
+    ),
+)
+
+####################################################################################################
+#
+# WplusH
+#
+####################################################################################################
+
+cpn.add_dataset(
+    name="wph_htt_powheg",
+    id=14925460,
+    processes=[procs.wph_htt],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WplusHTo2TauUncorrelatedDecay_M-125_TuneCP5_13p6TeV_powheg-minnlo-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=14,
+            n_events=30000,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wph_zqq_hbb_powheg",
+    id=14810156,
+    processes=[procs.wph_zqq_hbb],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WplusH_Hto2B_Wto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=18,
+            n_events=1199214,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/WplusH_Hto2B_Wto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=147,
+            n_events=3179822,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wph_wlnu_hbb_powheg",
+    id=14804043,
+    processes=[procs.wph_wlnu_hbb],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WplusH_Hto2B_WtoLNu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=22,
+            n_events=565746,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/WplusH_Hto2B_WtoLNu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=159,
+            n_events=4206261,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wph_wqq_hcc_powheg",
+    id=14852349,
+    processes=[procs.wph_wqq_hcc],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WplusH_Hto2C_Wto2Q_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=271,
+            n_events=4369883,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wph_wlnu_hcc_powheg",
+    id=14795238,
+    processes=[procs.wph_wlnu_hcc],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WplusH_Hto2C_WtoLNu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=62,
+            n_events=754430,
+        ),
+        extension=DatasetInfo(
+            keys=[
+                "/WplusH_Hto2C_WtoLNu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5_ext1-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=155,
+            n_events=4200000,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wph_hmm_powheg",
+    id=14868497,
+    processes=[procs.wph_hmm],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WplusH_Hto2Mu_WtoAll_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=26,
+            n_events=118804,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wph_hzz4l_powheg",
+    id=14810120,
+    processes=[procs.wph_hzz4l],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WplusH_Hto2Zto4L_M-125_TuneCP5_13p6TeV_powheg2-minlo-HWJ-JHUGenV752-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=17,
+            n_events=492605,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wph_hzg_powheg",
+    id=14798660,
+    processes=[procs.wph_hzg],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WplusH_HtoZG_WtoAll_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=17,
+            n_events=38162,
+        ),
+        tune_down=DatasetInfo(
+            keys=[
+                "/WplusH_HtoZG_WtoAll_Zto2L_M-125_CP5TuneDown_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=24,
+            n_events=39616,
+        ),
+        tune_up=DatasetInfo(
+            keys=[
+                "/WplusH_HtoZG_WtoAll_Zto2L_M-125_CP5TuneUp_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=19,
+            n_events=39997,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wph_hzg_zll_powheg",
+    id=14792521,
+    processes=[procs.wph_hzg_zll],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WplusH_HtoZG_WtoAll_Zto2L_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=16,
+            n_events=156824,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="wph_wqq_hzz4nu_powheg",
+    id=14849415,
+    processes=[procs.wph_wqq_hzz4nu],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/WplusHto2Zto4Nu_Wto2Q_M-125_TuneCP5_13p6TeV_powheg-minlo-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=28,
+            n_events=495938,
+        ),
+    ),
+)
+
+
+####################################################################################################
+#
+# ttH
+#
+####################################################################################################
+
+# cpn.add_dataset(
+#     name="tth_hzz_powheg",
+#     id=14793299,
+#     processes=[procs.tth_hzz],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/TTH_Hto2Z_M-125_4LFilter_TuneCP5_13p6TeV_powheg2-JHUGenV752-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+#             ],
+#             n_files=20,
+#             n_events=96720,
+#         ),
+#     ),
+# )
+cpn.add_dataset(
+    name="tth_hzz_powheg",
+    id=14952169,
+    processes=[procs.tth_hzz],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/TTH_Hto2Z_4LFilter_M-125_TuneCP5_13p6TeV_powheg-jhugenv752-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=7,
+            n_events=95869,
+        ),
+    ),
+)
+# cpn.add_dataset(
+#     name="tth_hnonbb_1j_amcatnlo",
+#     id=14852673,
+#     processes=[procs.tth_hnonbb_1j],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/TTHtoNon2B-1Jets_M-125_TuneCP5_13p6TeV_amcatnloFXFX-madspin-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+#             ],
+#             n_files=165,
+#             n_events=6303497,
+#         ),
+#     ),
+# )
+cpn.add_dataset(
+    name="tth_hnonbb_powheg",
+    id=14849153,
+    processes=[procs.tth_hnonbb],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/TTHtoNon2B_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v4/NANOAODSIM",  # noqa
+            ],
+            n_files=46,
+            n_events=3846525,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="tth_hcc_powheg",
+    id=14870558,
+    processes=[procs.tth_hcc],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/TTHto2C_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=37,
+            n_events=3184328,
+        ),
+    ),
+)
+cpn.add_dataset(
+    name="tth_hbb_powheg",
+    id=14857767,
+    processes=[procs.tth_hbb],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/TTHto2B_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=45,
+            n_events=3177628,
+        ),
+    ),
+)
+# cpn.add_dataset(
+#     name="tth_hbb_powheg",
+#     id=14870504,
+#     processes=[procs.tth_hbb],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/TTH_Hto2B_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v3/NANOAODSIM",  # noqa
+#             ],
+#             n_files=43,
+#             n_events=2989710,
+#         ),
+#     ),
+# )
+cpn.add_dataset(
+    name="tth_hmm_powheg",
+    id=14868415,
+    processes=[procs.tth_hmm],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/TTH_Hto2Mu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v3/NANOAODSIM",  # noqa
+            ],
+            n_files=28,
+            n_events=197248,
+        ),
+    ),
+)
+
+####################################################################################################
+#
+# ttVH
+#
+####################################################################################################
+
+cpn.add_dataset(
+    name="ttzh_madgraph",
+    id=14861662,
+    processes=[procs.ttz],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/TTZH_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=43,
+            n_events=798996,
+        ),
+    ),
+)
+
+cpn.add_dataset(
+    name="ttwh_madgraph",
+    id=14860507,
+    processes=[procs.ttwh],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/TTWH_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=25,
+            n_events=790196,
+        ),
+    ),
+)

--- a/cmsdb/campaigns/run3_2022_preEE_nano_v12/top.py
+++ b/cmsdb/campaigns/run3_2022_preEE_nano_v12/top.py
@@ -1078,3 +1078,55 @@ cpn.add_dataset(
         # ),
     ),
 )
+
+
+####################################################################################################
+#
+# ttV, ttVV
+#
+####################################################################################################
+
+# TODO: add corresponding process
+# cpn.add_dataset(
+#     name="ttz_amcatnlo",
+#     id=14796050,
+#     processes=[procs.ttz],
+#     info=dict(
+#         nominal=DatasetInfo(
+#             keys=[
+#                 "/TTZ-ZtoQQ-1Jets_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+#             ],
+#             n_files=24,
+#             n_events=376687,
+#         ),
+#     ),
+# )
+cpn.add_dataset(
+    name="ttzz_madgraph",
+    id=14800072,
+    processes=[procs.ttzz],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/TTZZ_TuneCP5_13p6TeV_madgraph-madspin-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=22,
+            n_events=443238,
+        ),
+    ),
+)
+
+cpn.add_dataset(
+    name="ttww_madgraph",
+    id=14797430,
+    processes=[procs.ttww],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/TTWW_TuneCP5_13p6TeV_madgraph-madspin-pythia8/Run3Summer22NanoAODv12-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+            ],
+            n_files=23,
+            n_events=448443,
+        ),
+    ),
+)

--- a/cmsdb/processes/ewk.py
+++ b/cmsdb/processes/ewk.py
@@ -7,8 +7,9 @@ EWK-related process definitions.
 __all__ = [
     "dy",
     "dy_lep",
+    "dy_lep_m4to10",
     "dy_lep_m10to50",
-    "dy_lep_m50", "dy_lep_m50_1j", "dy_lep_m50_2j", "dy_lep_m50_3j", "dy_lep_m50_4j",
+    "dy_lep_m50", "dy_lep_m50_0j", "dy_lep_m50_1j", "dy_lep_m50_2j", "dy_lep_m50_3j", "dy_lep_m50_4j",
     "dy_lep_0j", "dy_lep_1j", "dy_lep_2j",
     "dy_lep_m50_ht70to100", "dy_lep_m50_ht100to200", "dy_lep_m50_ht200to400",
     "dy_lep_m50_ht400to600", "dy_lep_m50_ht600to800", "dy_lep_m50_ht800to1200",
@@ -70,11 +71,29 @@ dy_lep = dy.add_process(
 # and for 13.6 TeV, based on:
 # https://twiki.cern.ch/twiki/bin/viewauth/CMS/MATRIXCrossSectionsat13p6TeV?rev=12
 
-dy_lep_m10to50 = dy_lep.add_process(
-    name="dy_lep_m10to50",
-    id=51001,
-    xsecs={13: Number(0.1)},  # TODO
-)
+# if needed for scaling from NLO to NNLO:
+# NLO cross section, based on GenXSecAnalyzer for
+# DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8 (Summer20UL16, NLO)
+# using command ./calculateXSectionAndFilterEfficiency.sh -f datasets.txt -c RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1 -n 5000000  # noqa
+dy_lep_m50_nlo_13TeV_xsec = Number(6421.0, {"tot": 11.25})
+
+# if needed for scaling from LO to NNLO:
+# LO cross section, based on GenXSecAnalyzer for DYJetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8 (Summer20UL16, LO)
+# using command ./calculateXSectionAndFilterEfficiency.sh -f datasets.txt -c RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1 -n 5000000  # noqa
+dy_lep_m50_lo_13TeV_xsec = Number(5395.0, {"tot": 1.858})
+
+# 13.6 TeV LO and NLO cross sections are based on the XSDB
+# https://xsdb-temp.app.cern.ch/xsdb/?columns=39911424&currentPage=0&pageSize=10&searchQuery=DAS%3DDYto2L-2Jets_MLL-4to10_TuneCP5_13p6TeV_amcatnloFXFX-pythia8  # noqa
+dy_lep_m4to10_nlo_13p6TeV_xsec = Number(141500, {"tot": 301.9})
+# https://xsdb-temp.app.cern.ch/xsdb/?columns=37814272&currentPage=0&pageSize=10&searchQuery=DAS%3DDYto2L-2Jets_MLL-10to50_TuneCP5_13p6TeV_amcatnloFXFX-pythia8  # noqa
+dy_lep_m10to50_nlo_13p6TeV_xsec = Number(20950.0, {"tot": 183.5})
+# https://xsdb-temp.app.cern.ch/xsdb/?columns=37814272&currentPage=0&pageSize=10&searchQuery=DAS%3DDYto2L-2Jets_MLL-50_TuneCP5_13p6TeV_amcatnloFXFX-pythia8  # noqa
+dy_lep_m50_nlo_13p6TeV_xsec = Number(6688.0, {"tot": 83.99})
+
+# https://xsdb-temp.app.cern.ch/xsdb/?columns=37814272&currentPage=0&pageSize=10&searchQuery=DAS%3DDYto2L-4Jets_MLL-10to50_TuneCP5_13p6TeV_madgraphMLM-pythia8  # noqa
+dy_lep_m10to50_lo_13p6TeV_xsec = Number(17380, {"tot": 26.57})
+# https://xsdb-temp.app.cern.ch/xsdb/?columns=37814272&currentPage=0&pageSize=10&searchQuery=DAS%3DDYto2L-4Jets_MLL-50_TuneCP5_13p6TeV_madgraphMLM-pythia8  # noqa
+dy_lep_m50_lo_13p6TeV_xsec = Number(5467, {"tot": 13.22})
 
 dy_lep_m50 = dy_lep.add_process(
     name="dy_lep_m50",
@@ -92,30 +111,59 @@ dy_lep_m50 = dy_lep.add_process(
     },
 )
 
+dy_lep_k_factor_LO_to_NNLO = {
+    13: dy_lep_m50.get_xsec(13) / dy_lep_m50_lo_13TeV_xsec,
+    13.6: dy_lep_m50.get_xsec(13.6) / dy_lep_m50_lo_13p6TeV_xsec,
+}
+dy_lep_k_factor_NLO_to_NNLO = {
+    13: dy_lep_m50.get_xsec(13) / dy_lep_m50_nlo_13TeV_xsec,
+    13.6: dy_lep_m50.get_xsec(13.6) / dy_lep_m50_nlo_13p6TeV_xsec,
+}
 
-# if needed for scaling from NLO to NNLO:
-# NLO cross section, based on GenXSecAnalyzer for
-# DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8 (Summer20UL16, NLO)
-# using command ./calculateXSectionAndFilterEfficiency.sh -f datasets.txt -c RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1 -n 5000000  # noqa
+dy_lep_m4to10 = dy_lep.add_process(
+    name="dy_lep_m4to10",
+    id=51002,
+    xsecs={
+        13: Number(0.1),  # TODO
+        13.6: dy_lep_m4to10_nlo_13p6TeV_xsec * dy_lep_k_factor_NLO_to_NNLO[13.6],
+    },
+)
+dy_lep_m10to50 = dy_lep.add_process(
+    name="dy_lep_m10to50",
+    id=51001,
+    xsecs={
+        13: Number(0.1),  # TODO
+        13.6: dy_lep_m10to50_nlo_13p6TeV_xsec * dy_lep_k_factor_NLO_to_NNLO[13.6],
+    },
+)
 
-dy_lep_m50_nlo_13TeV_xsec = Number(6421.0, {"tot": 11.25})
+#
+# N-jet binned Drell-Yan (scaled to NNLO)
+#
 
-# if needed for scaling from LO to NNLO:
-# LO cross section, based on GenXSecAnalyzer for DYJetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8 (Summer20UL16, LO)
-# using command ./calculateXSectionAndFilterEfficiency.sh -f datasets.txt -c RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1 -n 5000000  # noqa
-
-dy_lep_m50_lo_13TeV_xsec = Number(5395.0, {"tot": 1.858})
-
-# based on GenXSecAnalyzer
+# 13.6 TeV xsecs based on XSDB for datasets DYto2L-4Jets_MLL-50_{i}J_TuneCP5_13p6TeV_madgraphMLM-pythia8
+# e.g. https://xsdb-temp.app.cern.ch/xsdb/?columns=39911424&currentPage=0&pageSize=10&searchQuery=DAS%3DDYto2L-4Jets_MLL-50_1J_TuneCP5_13p6TeV_madgraphMLM-pythia8  # noqa
+# 13 TeV: based on GenXSecAnalyzer
 # for datasets DY{i}JetsToLL_M-50_MatchEWPDG20_TuneCP5_13TeV-madgraphMLM-pythia8 (Summer20UL16, LO)
 # using command ./calculateXSectionAndFilterEfficiency.sh -f datasets.txt -c RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v1 -n 5000000  # noqa
+dy_lep_m50_0j = dy_lep_m50.add_process(
+    name="dy_lep_m50_0j",
+    id=51110,
+    xsecs={
+        # NLO xsec taken from https://xsdb-temp.app.cern.ch/xsdb/?columns=39911424&currentPage=0&pageSize=10&searchQuery=DAS%3DDYto2L-2Jets_MLL-50_0J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8  # noqa
+        13.6: Number(5378, {"tot": 8.007}) * dy_lep_k_factor_NLO_to_NNLO[13.6],
+    },
+)
+
 dy_lep_m50_1j = dy_lep_m50.add_process(
     name="dy_lep_m50_1j",
     id=51111,
     xsecs={
         13: Number(926.8, {
             "tot": 0.3597,
-        }),
+        }) * dy_lep_k_factor_LO_to_NNLO[13],
+        # 13.6: Number(1017, {"tot": 6.264}) * dy_lep_k_factor_NLO_to_NNLO[13.6],
+        13.6: Number(973.1, {"tot": 2.613}) * dy_lep_k_factor_LO_to_NNLO[13.6],
     },
 )
 
@@ -125,7 +173,9 @@ dy_lep_m50_2j = dy_lep_m50.add_process(
     xsecs={
         13: Number(294.5, {
             "tot": 0.1223,
-        }),
+        }) * dy_lep_k_factor_LO_to_NNLO[13],
+        # 13.6: Number(385.5, {"tot": 3.858}) * dy_lep_k_factor_NLO_to_NNLO[13.6],
+        13.6: Number(312.4, {"tot": 0.915}) * dy_lep_k_factor_LO_to_NNLO[13.6],
     },
 )
 
@@ -135,7 +185,8 @@ dy_lep_m50_3j = dy_lep_m50.add_process(
     xsecs={
         13: Number(86.53, {
             "tot": 0.03853,
-        }),
+        }) * dy_lep_k_factor_LO_to_NNLO[13],
+        13.6: Number(93.93, {"tot": 0.2858}) * dy_lep_k_factor_LO_to_NNLO[13.6],
     },
 )
 
@@ -145,7 +196,8 @@ dy_lep_m50_4j = dy_lep_m50.add_process(
     xsecs={
         13: Number(41.21, {
             "tot": 0.02392,
-        }),
+        }) * dy_lep_k_factor_LO_to_NNLO[13],
+        13.6: Number(45.43, {"tot": 0.1393}) * dy_lep_k_factor_LO_to_NNLO[13.6],
     },
 )
 
@@ -191,7 +243,7 @@ dy_lep_m50_ht70to100 = dy_lep_m50.add_process(
     name="dy_lep_m50_ht70to100",
     id=51121,
     xsecs={
-        13: Number(139.9, {"tot": 0.5747}) * dy_lep_m50.get_xsec(13) / dy_lep_m50_lo_13TeV_xsec,
+        13: Number(139.9, {"tot": 0.5747}) * dy_lep_k_factor_LO_to_NNLO[13],
     },
 )
 
@@ -199,7 +251,7 @@ dy_lep_m50_ht100to200 = dy_lep_m50.add_process(
     name="dy_lep_m50_ht100to200",
     id=51122,
     xsecs={
-        13: Number(140.1, {"tot": 0.5875}) * dy_lep_m50.get_xsec(13) / dy_lep_m50_lo_13TeV_xsec,
+        13: Number(140.1, {"tot": 0.5875}) * dy_lep_k_factor_LO_to_NNLO[13],
     },
 )
 
@@ -207,7 +259,7 @@ dy_lep_m50_ht200to400 = dy_lep_m50.add_process(
     name="dy_lep_m50_ht200to400",
     id=51123,
     xsecs={
-        13: Number(38.38, {"tot": 0.01628}) * dy_lep_m50.get_xsec(13) / dy_lep_m50_lo_13TeV_xsec,
+        13: Number(38.38, {"tot": 0.01628}) * dy_lep_k_factor_LO_to_NNLO[13],
     },
 )
 
@@ -215,7 +267,7 @@ dy_lep_m50_ht400to600 = dy_lep_m50.add_process(
     name="dy_lep_m50_ht400to600",
     id=51124,
     xsecs={
-        13: Number(5.212, {"tot": 0.003149}) * dy_lep_m50.get_xsec(13) / dy_lep_m50_lo_13TeV_xsec,
+        13: Number(5.212, {"tot": 0.003149}) * dy_lep_k_factor_LO_to_NNLO[13],
     },
 )
 
@@ -223,7 +275,7 @@ dy_lep_m50_ht600to800 = dy_lep_m50.add_process(
     name="dy_lep_m50_ht600to800",
     id=51125,
     xsecs={
-        13: Number(1.266, {"tot": 0.0007976}) * dy_lep_m50.get_xsec(13) / dy_lep_m50_lo_13TeV_xsec,
+        13: Number(1.266, {"tot": 0.0007976}) * dy_lep_k_factor_LO_to_NNLO[13],
     },
 )
 
@@ -231,7 +283,7 @@ dy_lep_m50_ht800to1200 = dy_lep_m50.add_process(
     name="dy_lep_m50_ht800to1200",
     id=51126,
     xsecs={
-        13: Number(0.5684, {"tot": 0.0003515}) * dy_lep_m50.get_xsec(13) / dy_lep_m50_lo_13TeV_xsec,
+        13: Number(0.5684, {"tot": 0.0003515}) * dy_lep_k_factor_LO_to_NNLO[13],
     },
 )
 
@@ -239,7 +291,7 @@ dy_lep_m50_ht1200to2500 = dy_lep_m50.add_process(
     name="dy_lep_m50_ht1200to2500",
     id=51127,
     xsecs={
-        13: Number(0.1332, {"tot": 0.00009084}) * dy_lep_m50.get_xsec(13) / dy_lep_m50_lo_13TeV_xsec,
+        13: Number(0.1332, {"tot": 0.00009084}) * dy_lep_k_factor_LO_to_NNLO[13],
     },
 )
 
@@ -247,7 +299,7 @@ dy_lep_m50_ht2500 = dy_lep_m50.add_process(
     name="dy_lep_m50_ht2500",
     id=51128,
     xsecs={
-        13: Number(0.002977, {"tot": 0.000003412}) * dy_lep_m50.get_xsec(13) / dy_lep_m50_lo_13TeV_xsec,
+        13: Number(0.002977, {"tot": 0.000003412}) * dy_lep_k_factor_LO_to_NNLO[13],
     },
 )
 


### PR DESCRIPTION
This PR adds 
- 13.6 TeV xsecs for a few DY processes
- datasets for DY, single Higgs, and ttV in 2022postEE and 2022preEE