### PR TITLE
Tests/test das info

### DIFF
--- a/cmsdb/campaigns/run2_2017_nano_v9/data.py
+++ b/cmsdb/campaigns/run2_2017_nano_v9/data.py
@@ -219,7 +219,7 @@ cpn.add_dataset(
 
 cpn.add_dataset(
     name="data_tau_e",
-    id=14233325,
+    id=14302263,
     is_data=True,
     processes=[procs.data_tau],
     keys=[

--- a/cmsdb/campaigns/run2_2017_nano_v9/ewk.py
+++ b/cmsdb/campaigns/run2_2017_nano_v9/ewk.py
@@ -180,63 +180,6 @@ cpn.add_dataset(
     n_events=1480047,
 )
 
-# pt binned
-cpn.add_dataset(
-    name="dy_lep_pt50to100_amcatnlo",
-    id=14231159,
-    processes=[procs.dy_lep_pt50to100],
-    keys=[
-        "/DYJetsToLL_Pt-50To100_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
-    ],
-    n_files=88,
-    n_events=107079717,
-)
-
-cpn.add_dataset(
-    name="dy_lep_pt100to250_amcatnlo",
-    id=14300156,
-    processes=[procs.dy_lep_pt100to250],
-    keys=[
-        "/DYJetsToLL_Pt-100To250_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
-    ],
-    n_files=56,
-    n_events=75818801,
-)
-
-cpn.add_dataset(
-    name="dy_lep_pt250to400_amcatnlo",
-    id=14235259,
-    processes=[procs.dy_lep_pt250to400],
-    keys=[
-        "/DYJetsToLL_Pt-250To400_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
-    ],
-    n_files=45,
-    n_events=18739246,
-)
-
-cpn.add_dataset(
-    name="dy_lep_pt400to650_amcatnlo",
-    id=14228178,
-    processes=[procs.dy_lep_pt400to650],
-    keys=[
-        "/DYJetsToLL_Pt-400To650_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
-    ],
-    n_files=3,
-    n_events=1895259,
-)
-
-cpn.add_dataset(
-    name="dy_lep_pt650_amcatnlo",
-    id=14232153,
-    processes=[procs.dy_lep_pt650],
-    keys=[
-        "/DYJetsToLL_Pt-650ToInf_MatchEWPDG20_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL17NanoAODv9-106X_mc2017_realistic_v9-v1/NANOAODSIM",  # noqa
-    ],
-    n_files=24,
-    n_events=1921546,
-)
-
-
 #
 # W boson production
 #
@@ -499,7 +442,6 @@ cpn.add_dataset(
     n_files=46,
     n_events=7098000,
 )
-
 
 #
 # Triple-boson

--- a/scripts/get_das_info.py
+++ b/scripts/get_das_info.py
@@ -12,14 +12,31 @@ from argparse import ArgumentParser
 import law
 
 
-def convert_default(data: dict) -> str:
+def get_generator_name(name: str) -> str:
+    """
+    Function that returns the generator name of a dataset
+    """
+    if "powheg" in name:
+        return "_powheg"
+    elif "madgraph" in name:
+        return "_madgraph"
+    elif "amcatnlo" in name:
+        return "_amcatnlo"
+    elif "pythia8" in name:
+        return "_pythia8"
+    else:
+        return ""
+
+
+def convert_default(data: dict, placeholder="PLACEHOLDER") -> str:
     """
     Function that converts dataset info into one order Dataset per query
     """
+    generator = get_generator_name(data["name"])
     return f"""cpn.add_dataset(
-    name="PLACEHOLDER",
+    name="{placeholder}{generator}",
     id={data['dataset_id']},
-    processes=[procs.PLACEHOLDER],
+    processes=[procs.{placeholder}],
     keys=[
         "{data['name']}",  # noqa
     ],
@@ -29,7 +46,32 @@ def convert_default(data: dict) -> str:
 """
 
 
+def convert_variation(data: dict, placeholder="PLACEHOLDER") -> str:
+    """
+    Function that converts dataset info into one order Dataset per query. Stores the dataset info
+    in a dict with the dataset type as key.
+    """
+    generator = get_generator_name(data["name"])
+    return f"""cpn.add_dataset(
+    name="{placeholder}{generator}",
+    id={data['dataset_id']},
+    processes=[procs.{placeholder}],
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "{data['name']}",  # noqa
+            ],
+            n_files={data['nfiles']},
+            n_events={data['nevents']},
+        ),
+    ),
+)
+"""
+
+
 identifier_map = {
+    "_CP5TuneDown_": "tune_down",
+    "_CP5TuneUp_": "tune_up",
     "_TuneCP5Down_": "tune_down",
     "_TuneCP5Up_": "tune_up",
     "_TuneCP5CR1_": "cr_1",
@@ -38,6 +80,8 @@ identifier_map = {
     "_Hdamp-418_": "hdamp_up",
     "_MT-171p5_": "mtop_down",
     "_MT-173p5_": "mtop_up",
+    "_withDipoleRecoil_": "with_dipole_recoil",
+    "_dipoleRecoilOn_": "dipole_recoil_on",
     # dataset types that I have no use for but want to keep anyways
     "_MT-166p5_": "comment",
     "_MT-169p5_": "comment",
@@ -49,11 +93,13 @@ identifier_map = {
     # dataset types that I want to skip completely
     # "example_key": "ignore",
     # nominal entry as the last one such that other dataset types get priority
+    "ext1": "extension",
     "_TuneCP5_": "nominal",
+    "_CP5_": "nominal",
 }
 
 
-def convert_top(data: dict) -> str:
+def convert_top(data: dict, placeholder="PLACEHOLDER") -> str:
     """
     Function that converts dataset info into either an order Datset for nominal datasets
     or to a DatasetInfo for variations of datasets such as tune or mtop.
@@ -61,6 +107,7 @@ def convert_top(data: dict) -> str:
     Exemplary usage:
     python get_das_info.py -c top -d "/TTtoLNu2Q*/Run3Summer22EENanoAODv12-130X_*/NANOAODSIM"
     """
+    generator = get_generator_name(data["name"])
     dataset_type = None
 
     for identifier in identifier_map:
@@ -77,9 +124,9 @@ def convert_top(data: dict) -> str:
 
     if dataset_type == "nominal":
         return f"""cpn.add_dataset(
-    name="PLACEHOLDER",
+    name="{placeholder}{generator}",
     id={data['dataset_id']},
-    processes=[procs.PLACEHOLDER],
+    processes=[procs.{placeholder}],
     info=dict(
         nominal=DatasetInfo(
             keys=[
@@ -112,10 +159,55 @@ def convert_top(data: dict) -> str:
         ),"""
 
 
+def convert_keys(data: dict) -> str:
+    """
+    Function that only returns the dataset key.
+    """
+    return f"""{data['name']}"""
+
+
+def convert_minimal(data: dict) -> str:
+    """
+    Function that only returns the dataset key + number of events.
+    """
+    return f"""{data['name']}\nFiles: {data['nfiles']}\nEvents: {data['nevents']}\n"""
+
+
 convert_functions = {
     "default": convert_default,
+    "variation": convert_variation,
+    "keys": convert_keys,
     "top": convert_top,
+    "minimal": convert_minimal,
 }
+
+
+def get_das_info(
+    dataset: str,
+) -> dict:
+    # call dasgoclient command
+    cmd = f"dasgoclient -query='dataset={dataset}' -json"
+    code, out, _ = law.util.interruptable_popen(
+        cmd,
+        shell=True,
+        stdout=subprocess.PIPE,
+        executable="/bin/bash",
+    )
+    if code != 0:
+        raise Exception(f"dasgoclient query failed:\n{out}")
+    infos = json.loads(out)
+    info_of_interest = {"name": dataset}
+    for info in infos:
+        dataset_info = info["dataset"][0]
+        # Get json format of single das_string gives multiple dictornaries with different info
+        # Avoid to print multiple infos twice and ask specificly for the kew of interest
+        if "dataset_info" in info["das"]["services"][0]:
+            info_of_interest["dataset_id"] = dataset_info.get("dataset_id", "")
+        elif "filesummaries" in info["das"]["services"][0]:
+            info_of_interest["nfiles"] = dataset_info.get("nfiles", "")
+            info_of_interest["nevents"] = dataset_info.get("nevents", "")
+
+    return info_of_interest
 
 
 def print_das_info(
@@ -128,6 +220,7 @@ def print_das_info(
 
     for das_string in das_strings:
         # set default keys of interest
+        # NOTE: this attribute is currently not used
         keys_of_interest = keys_of_interest or (
             "name", "dataset_id", "nfiles", "nevents",
         )
@@ -154,28 +247,7 @@ def print_das_info(
                 datasets.append(dataset_name)
 
         for dataset in datasets:
-            # call dasgoclient command
-            cmd = f"dasgoclient -query='dataset={dataset}' -json"
-            code, out, _ = law.util.interruptable_popen(
-                cmd,
-                shell=True,
-                stdout=subprocess.PIPE,
-                executable="/bin/bash",
-            )
-            if code != 0:
-                raise Exception(f"dasgoclient query failed:\n{out}")
-            infos = json.loads(out)
-            info_of_interest = {"name": dataset}
-            for info in infos:
-                dataset_info = info["dataset"][0]
-                # Get json format of single das_string gives multiple dictornaries with different info
-                # Avoid to print multiple infos twice and ask specificly for the kew of interest
-                if "dataset_info" in info["das"]["services"][0]:
-                    info_of_interest["dataset_id"] = dataset_info.get("dataset_id", "")
-                elif "filesummaries" in info["das"]["services"][0]:
-                    info_of_interest["nfiles"] = dataset_info.get("nfiles", "")
-                    info_of_interest["nevents"] = dataset_info.get("nevents", "")
-
+            info_of_interest = get_das_info(dataset)
             desired_output = convert_function(info_of_interest)
             print(desired_output)
 

--- a/scripts/get_das_info.py
+++ b/scripts/get_das_info.py
@@ -9,9 +9,6 @@ import subprocess
 import json
 from argparse import ArgumentParser
 
-import law
-
-
 def get_generator_name(name: str) -> str:
     """
     Function that returns the generator name of a dataset
@@ -185,9 +182,11 @@ convert_functions = {
 def get_das_info(
     dataset: str,
 ) -> dict:
+    from law.util import interruptable_popen
+
     # call dasgoclient command
     cmd = f"dasgoclient -query='dataset={dataset}' -json"
-    code, out, _ = law.util.interruptable_popen(
+    code, out, _ = interruptable_popen(
         cmd,
         shell=True,
         stdout=subprocess.PIPE,
@@ -215,6 +214,8 @@ def print_das_info(
     keys_of_interest: tuple | None = None,
     convert_function_str: str | None = None,
 ):
+    from law.util import interruptable_popen
+
     # get the requested convert function
     convert_function = convert_functions[convert_function_str]
 
@@ -233,7 +234,7 @@ def print_das_info(
         else:
             # using a wildcard leads to a different structer in json format
             cmd = f"dasgoclient -query='dataset={das_string}' -json"
-            code, out, _ = law.util.interruptable_popen(
+            code, out, _ = interruptable_popen(
                 cmd,
                 shell=True,
                 stdout=subprocess.PIPE,

--- a/scripts/get_das_info.py
+++ b/scripts/get_das_info.py
@@ -9,6 +9,7 @@ import subprocess
 import json
 from argparse import ArgumentParser
 
+
 def get_generator_name(name: str) -> str:
     """
     Function that returns the generator name of a dataset

--- a/tests/test_campaigns.py
+++ b/tests/test_campaigns.py
@@ -1,6 +1,9 @@
 # coding: utf-8
 
+from __future__ import annotations
+
 __all__ = ["TestCampaigns"]
+
 
 import os
 import re
@@ -9,25 +12,36 @@ import unittest
 
 import cmsdb
 
+from scripts.get_das_info import get_das_info
+
 
 class TestCampaigns(unittest.TestCase):
+    # list of generator names to check for in dataset names
     generator_names = ("powheg", "madgraph", "amcatnlo", "pythia")
 
+    # boolean flag whether to check consistency between dataset and process names
     check_proc_name: bool = False
+
+    # boolean flag whether to check correctness of DAS info for each dataset
+    check_das_info: bool = False
+
+    # list of campaign names to test, if None, all campaigns are tested
+    campaign_names: list | None = None
 
     @classmethod
     def setUpClass(cls):
-        # find campaigns
-        campaign_dir = os.path.join(os.path.dirname(cmsdb.__file__), "campaigns")
-        campaign_names = [
-            name
-            for name in os.listdir(campaign_dir)
-            if os.path.isdir(os.path.join(campaign_dir, name)) and re.match(r"^run\d.*v\d.*$", name)
-        ]
+        if not cls.campaign_names:
+            # if not provided, find and test all campaigns
+            campaign_dir = os.path.join(os.path.dirname(cmsdb.__file__), "campaigns")
+            cls.campaign_names = [
+                name
+                for name in os.listdir(campaign_dir)
+                if os.path.isdir(os.path.join(campaign_dir, name)) and re.match(r"^run\d.*v\d.*$", name)
+            ]
 
         # import modules and store campaign objects if present
         cls.campaigns = {}
-        for name in campaign_names:
+        for name in cls.campaign_names:
             module = importlib.import_module(f"cmsdb.campaigns.{name}")
             for attr in dir(module):
                 if attr.startswith("campaign_"):
@@ -41,6 +55,67 @@ class TestCampaigns(unittest.TestCase):
                 self.assertTrue(hasattr(campaign_inst, "ecm"))
                 self.assertTrue(hasattr(campaign_inst, "bx"))
 
+    def single_dataset_test(self, campaign_inst, dataset_inst):
+        # check existence of attributes
+        self.assertTrue(hasattr(dataset_inst, "name"))
+        self.assertTrue(hasattr(dataset_inst, "id"))
+        self.assertTrue(hasattr(dataset_inst, "processes"))
+        self.assertTrue(hasattr(dataset_inst, "keys"))
+        self.assertTrue(hasattr(dataset_inst, "n_files"))
+        self.assertTrue(hasattr(dataset_inst, "n_events"))
+
+        # check that the generator is encoded in the dataset name
+        if dataset_inst.is_mc:
+            self.assertIn(dataset_inst.name.rsplit("_", 1)[-1], self.generator_names)
+
+        # check that the name is lowercase, but take into account known exceptions
+        if not dataset_inst.x("allow_uppercase_name", False):
+            self.assertEquals(dataset_inst.name, dataset_inst.name.lower())
+
+        # check that there is at least one process linked
+        self.assertTrue(len(dataset_inst.processes) > 0)
+
+        # optionally check that namings between dataset and process are consistent
+        if (
+            self.check_proc_name and
+            "data" not in dataset_inst.name and
+            len(dataset_inst.processes) == 1
+        ):
+            proc_name = dataset_inst.processes.get_first().name
+
+            if "data" not in dataset_inst.name:
+                dataset_name_wo_generator = dataset_inst.name
+                for name in self.generator_names:
+                    dataset_name_wo_generator = dataset_name_wo_generator.replace(f"_{name}", "")
+
+                self.assertEqual(dataset_name_wo_generator, proc_name)
+
+        if self.check_das_info and not campaign_inst.has_aux("custom"):
+            # check that all dataset keys exist and that the DAS info (id, n_events, n_files) is correct
+            # optional, since this needs a Grid Proxy and takes a long time
+            for key in dataset_inst.keys:
+                key_info = f"{campaign_inst.name}/{dataset_inst.name}, key: {key}"
+                # print(f"checking DAS info from dataset {campaign_inst.name}/{dataset_inst.name}, key {key}")
+                das_info = get_das_info(key)
+                with self.subTest(f"checking DAS info from {key_info}"):
+                    das_info = get_das_info(key)
+                    self.assertTrue(
+                        das_info.get("dataset_id", None) is not None,
+                        msg=f"did not find DAS key from {key_info}",
+                    )
+
+                    das_info = {
+                        key: value for key, value in das_info.items()
+                        if key in ("dataset_id", "nevents", "nfiles")
+                    }
+
+                    dataset_info = {
+                        "dataset_id": dataset_inst.id,
+                        "nevents": dataset_inst.n_events,
+                        "nfiles": dataset_inst.n_files,
+                    }
+                    self.assertEqual(dataset_info, das_info, msg=f"mismatch in DAS info from {key_info}")
+
     def test_campaign_datasets(self):
         for campaign_inst in self.campaigns.values():
             with self.subTest(f"testing datasets {campaign_inst.name}"):
@@ -50,36 +125,4 @@ class TestCampaigns(unittest.TestCase):
                 # loop through the datasets and test their properties
                 for dataset_inst in campaign_inst.datasets.values():
                     with self.subTest(f"testing dataset {campaign_inst.name}/{dataset_inst.name}"):
-                        # check existence of attributes
-                        self.assertTrue(hasattr(dataset_inst, "name"))
-                        self.assertTrue(hasattr(dataset_inst, "id"))
-                        self.assertTrue(hasattr(dataset_inst, "processes"))
-                        self.assertTrue(hasattr(dataset_inst, "keys"))
-                        self.assertTrue(hasattr(dataset_inst, "n_files"))
-                        self.assertTrue(hasattr(dataset_inst, "n_events"))
-
-                        # check that the generator is encoded in the dataset name
-                        if dataset_inst.is_mc:
-                            self.assertIn(dataset_inst.name.rsplit("_", 1)[-1], self.generator_names)
-
-                        # check that the name is lowercase, but take into account known exceptions
-                        if not dataset_inst.x("allow_uppercase_name", False):
-                            self.assertEquals(dataset_inst.name, dataset_inst.name.lower())
-
-                        # check that there is at least one process linked
-                        self.assertTrue(len(dataset_inst.processes) > 0)
-
-                        # optionally check that namings between dataset and process are consistent
-                        if (
-                            self.check_proc_name and
-                            "data" not in dataset_inst.name and
-                            len(dataset_inst.processes) == 1
-                        ):
-                            proc_name = dataset_inst.processes.get_first().name
-
-                            if "data" not in dataset_inst.name:
-                                dataset_name_wo_generator = dataset_inst.name
-                                for name in self.generator_names:
-                                    dataset_name_wo_generator = dataset_name_wo_generator.replace(f"_{name}", "")
-
-                                self.assertEqual(dataset_name_wo_generator, proc_name)
+                        self.single_dataset_test(campaign_inst, dataset_inst)


### PR DESCRIPTION
This PR:

- extends the `get_das_info` script
   - automatic generator names
   - some new identifier
   - customizable placeholder (to allow implementing convert functions that automatically determine the dataset name)
   - simple convert functions to only obtain keys etc.
- adds an optional test to compare the info stored in the cmsdb with the info from DAS

TODO: fix all the failed tests
- in 2022postEE and 2022preEE, the test ran successfully (but has only been run for nominal datasets)
- in 2017 and 2018 there were quite a few mismatches (20 and 38). Someone should take care and correct these in a follow-up PR
- remaining campaigns were not tested at all

