### PR TITLE
add full set of diboson processes

### DIFF
--- a/cmsdb/constants/__init__.py
+++ b/cmsdb/constants/__init__.py
@@ -44,6 +44,15 @@ br_zz = DotDict(
     qqnunu=2 * br_z.qq * br_z.nunu,
 )
 
+br_wz = DotDict.wrap({
+    "3lnu": br_z.clep * br_w.lep,
+    "l3nu": br_z.nunu * br_w.lep,
+    "lnu2q": br_z.qq * br_w.lep,
+    "2l2q": br_z.clep * br_w.had,
+    "2nu2q": br_z.nunu * br_w.had,
+    "4q": br_z.qq * br_w.had,
+})
+
 # higgs branching ratios from lhchwg, taken for mH = 125GeV
 # https://twiki.cern.ch/twiki/bin/view/LHCPhysics/CERNYellowReportPageBR?rev=23
 

--- a/cmsdb/processes/diboson.py
+++ b/cmsdb/processes/diboson.py
@@ -1,0 +1,212 @@
+# coding: utf-8
+
+"""
+Diboson process definitions.
+"""
+
+__all__ = [
+    "vv", "ww", "zz", "wz",
+    "vv4l", "vv2l2nu", "vv2l2q", "vv2nu2q", "vv4nu", "vv4q", "vvlnu2q", "vv3lnu", "vvl3nu",
+    "zz4l", "zz2l2nu", "zz2l2q", "zz2nu2q", "zz4nu", "zz4q",
+    "wz3lnu", "wzl3nu", "wzlnu2q", "wz2l2q", "wz2nu2q", "wz4q",
+]
+
+from functools import partial
+
+from order import Process
+from scinum import Number
+
+import cmsdb.constants as const
+
+from cmsdb.util import DotDict, add_xsecs, add_decay_process
+
+add_vv_decay_process = partial(add_decay_process, name_separator="", label_separator=" $\rightarrow$ ")
+
+vv_decay_map = DotDict.wrap({
+    "4l": {  # ZZ
+        "name": "4l",
+        "id": 10,
+        "label": r"$4\ell$",
+        "br": -1,
+    },
+    "2l2nu": {  # ZZ, WW
+        "name": "2l2nu",
+        "id": 20,
+        "label": r"$2\ell 2\nu$",
+        "br": -1,
+    },
+    "2l2q": {  # ZZ, WZ
+        "name": "2l2q",
+        "id": 30,
+        "label": r"$2\ell 2q$",
+        "br": -1,
+    },
+    "2nu2q": {  # ZZ, WZ
+        "name": "2nu2q",
+        "id": 40,
+        "label": r"$2\nu 2q$",
+        "br": -1,
+    },
+    "4nu": {  # ZZ
+        "name": "4nu",
+        "id": 50,
+        "label": r"$4\nu$",
+        "br": -1,
+    },
+    "4q": {  # ZZ, WW, WZ
+        "name": "4q",
+        "id": 60,
+        "label": r"$4q$",
+        "br": -1,
+    },
+    "lnu2q": {  # WW, WZ
+        "name": "lnu2q",
+        "id": 70,
+        "label": r"$\ell\nu 2q$",
+        "br": -1,
+    },
+    "3lnu": {  # WZ
+        "name": "3lnu",
+        "id": 80,
+        "label": r"$3\ell\nu$",
+        "br": -1,
+    },
+    "l3nu": {  # WZ
+        "name": "l3nu",
+        "id": 90,
+        "label": r"$\ell 3\nu$",
+        "br": -1,
+    },
+})
+
+zz_decay_map = {
+    final_state: vv_decay_map[final_state].copy()
+    for final_state in ("4l", "2l2nu", "2l2q", "2nu2q", "4nu", "4q")
+}
+zz_decay_map["4l"]["br"] = const.br_zz.llll
+zz_decay_map["2l2nu"]["br"] = const.br_zz.llnunu
+zz_decay_map["2l2q"]["br"] = const.br_zz.llqq
+zz_decay_map["2nu2q"]["br"] = const.br_zz.qqnunu
+zz_decay_map["4nu"]["br"] = const.br_zz.nunununu
+zz_decay_map["4q"]["br"] = const.br_zz.qqqq
+
+ww_decay_map = {
+    final_state: vv_decay_map[final_state].copy()
+    for final_state in ("2l2nu", "lnu2q", "4q")
+}
+ww_decay_map["2l2nu"]["br"] = const.br_ww.dl
+ww_decay_map["lnu2q"]["br"] = const.br_ww.sl
+ww_decay_map["4q"]["br"] = const.br_ww.fh
+
+wz_decay_map = {
+    final_state: vv_decay_map[final_state].copy()
+    for final_state in ("3lnu", "l3nu", "lnu2q", "2l2q", "2nu2q", "4q")
+}
+wz_decay_map["3lnu"]["br"] = const.br_wz["3lnu"]
+wz_decay_map["l3nu"]["br"] = const.br_wz["l3nu"]
+wz_decay_map["lnu2q"]["br"] = const.br_wz["lnu2q"]
+wz_decay_map["2l2q"]["br"] = const.br_wz["2l2q"]
+wz_decay_map["2nu2q"]["br"] = const.br_wz["2nu2q"]
+wz_decay_map["4q"]["br"] = const.br_wz["4q"]
+
+#
+# Di-boson
+#
+
+vv = Process(
+    name="vv",
+    id=8000,
+    label="VV",
+    xsecs={13: Number(0.1)},  # updated below as the sum over WW, WZ, ZZ
+)
+
+vv4l = add_vv_decay_process(vv, vv_decay_map["4l"], add_production_mode_parent=False)
+vv2l2nu = add_vv_decay_process(vv, vv_decay_map["2l2nu"], add_production_mode_parent=False)
+vv2l2q = add_vv_decay_process(vv, vv_decay_map["2l2q"], add_production_mode_parent=False)
+vv2nu2q = add_vv_decay_process(vv, vv_decay_map["2nu2q"], add_production_mode_parent=False)
+vv4nu = add_vv_decay_process(vv, vv_decay_map["4nu"], add_production_mode_parent=False)
+vv4q = add_vv_decay_process(vv, vv_decay_map["4q"], add_production_mode_parent=False)
+vvlnu2q = add_vv_decay_process(vv, vv_decay_map["lnu2q"], add_production_mode_parent=False)
+vv3lnu = add_vv_decay_process(vv, vv_decay_map["3lnu"], add_production_mode_parent=False)
+vvl3nu = add_vv_decay_process(vv, vv_decay_map["l3nu"], add_production_mode_parent=False)
+
+# ZZ xsec values at NLO from https://arxiv.org/pdf/1105.0020.pdf v1
+# old value before update:
+# https://cms.cern.ch/iCMS/jsp/db_notes/noteInfo.jsp?cmsnoteid=CMS%20AN-2019/197 (v3) Number(12.13) (LO)
+
+zz = vv.add_process(
+    name="zz",
+    id=8100,
+    label="ZZ",
+    xsecs={
+        13: Number(15.99, {"scale": (0.037j, 0.026j)}),
+    },
+    aux={"production_mode_parent": "vv"},
+)
+
+zz4l = add_vv_decay_process(zz, zz_decay_map["4l"])
+zz2l2nu = add_vv_decay_process(zz, zz_decay_map["2l2nu"])
+zz2l2q = add_vv_decay_process(zz, zz_decay_map["2l2q"])
+zz2nu2q = add_vv_decay_process(zz, zz_decay_map["2nu2q"])
+zz4nu = add_vv_decay_process(zz, zz_decay_map["4nu"])
+zz4q = add_vv_decay_process(zz, zz_decay_map["4q"])
+
+# WZ xsec values at NLO from https://arxiv.org/pdf/1105.0020.pdf v1
+# can this be used too? https://arxiv.org/pdf/2110.11231.pdf -> actual measurement, no theory prediction
+wp_z_xsec = {
+    13: Number(28.55, {"scale": (0.041j, 0.032j)}),
+}
+
+wm_z_xsec = {
+    13: Number(18.19, {"scale": (0.041j, 0.033j)}),
+}
+
+# old value before update:
+# https://cms.cern.ch/iCMS/jsp/db_notes/noteInfo.jsp?cmsnoteid=CMS%20AN-2019/197 (v3) Number(25.56) (LO)
+wz = vv.add_process(
+    name="wz",
+    id=8200,
+    label="WZ",
+    xsecs={
+        # as a remark, the W cross section calculation from
+        # https://twiki.cern.ch/twiki/bin/viewauth/CMS/StandardModelCrossSectionsat13TeV?rev=28
+        # shows a permille difference in the values calculated directly and the ones added from w+ and w-
+        13: wp_z_xsec[13] + wm_z_xsec[13],
+    },
+    aux={"production_mode_parent": "vv"},
+)
+
+wz3lnu = add_vv_decay_process(wz, wz_decay_map["3lnu"])
+wzl3nu = add_vv_decay_process(wz, wz_decay_map["l3nu"])
+wzlnu2q = add_vv_decay_process(wz, wz_decay_map["lnu2q"])
+wz2l2q = add_vv_decay_process(wz, wz_decay_map["2l2q"])
+wz2nu2q = add_vv_decay_process(wz, wz_decay_map["2nu2q"])
+wz4q = add_vv_decay_process(wz, wz_decay_map["4q"])
+
+# old value before update:
+# https://cms.cern.ch/iCMS/jsp/db_notes/noteInfo.jsp?cmsnoteid=CMS%20AN-2019/197 (v3) Number(75.91) (LO)
+ww = vv.add_process(
+    name="ww",
+    id=8300,
+    label="WW",
+    xsecs={
+        13: Number(118.7, {"scale": (0.025j, 0.022j)}),
+    },
+    aux={"production_mode_parent": "vv"},
+)
+
+ww2l2nu = add_vv_decay_process(ww, ww_decay_map["2l2nu"])
+wwlnu2q = add_vv_decay_process(ww, ww_decay_map["lnu2q"])
+ww4q = add_vv_decay_process(ww, ww_decay_map["4q"])
+
+# update vv cross section TODO use helper
+vv.xsecs = add_xsecs(ww, wz, zz)
+vv4l.xsecs = add_xsecs(zz4l)
+vv2l2nu.xsecs = add_xsecs(zz2l2nu, ww2l2nu)
+vv2l2q.xsecs = add_xsecs(zz2l2q, wz2l2q)
+vv2nu2q.xsecs = add_xsecs(zz2nu2q, wz2nu2q)
+vv4nu.xsecs = add_xsecs(zz4nu)
+vv4q.xsecs = add_xsecs(zz4q, ww4q, wz4q)
+vvlnu2q.xsecs = add_xsecs(wwlnu2q, wzlnu2q)
+vv3lnu.xsecs = add_xsecs(wz3lnu)
+vvl3nu.xsecs = add_xsecs(wzl3nu)


### PR DESCRIPTION
This PR adds all the diboson decay channels, including the VV parent processes.

Open questions:
- should we always be consistent in the order of listing VV decay products (leptons, then neutrinos, then quarks)? This would also be more consistent with DAS conventions
    - example: VV->lnu2q instead of VV -> qqlnu (as it currently is for Higgs + HH(bbVV))
- There are some processes in the `ewk` with an m4 cut, e.g. this one: https://github.com/uhh-cms/cmsdb/blob/284b6c52d82ee36608cb6ccecd518e5c5c2fecf5/cmsdb/processes/ewk.py#L743-L749
    - are these sub-processes required? Is the difference between cross sections with and without the m4 cut expected to be significant?
    - also, the cross sections of these sub-processes seem to be much larger when comparing them to the inclusive xs times BR (I'd expect them to be smaller since there is some cut applied)