### PR TITLE
Update HH cross sections.

### DIFF
--- a/cmsdb/processes/hh.py
+++ b/cmsdb/processes/hh.py
@@ -218,6 +218,8 @@ hh_vbf_kv1_k2v1_kl1 = hh_vbf.add_process(
     aux={"production_mode_parent": hh_vbf},
 )
 
+# the kappa values are defined as the N3LO cross section divided by the LO cross section as taken
+# from XSDB (see link above), with all kappas at 1 (SM configuration)
 hh_vbf_k_13p0 = hh_vbf_kv1_k2v1_kl1.get_xsec(13).nominal / 1.626
 hh_vbf_k_13p6 = hh_vbf_kv1_k2v1_kl1.get_xsec(13.6).nominal / 1.912
 

--- a/cmsdb/processes/hh.py
+++ b/cmsdb/processes/hh.py
@@ -51,9 +51,23 @@ __all__ = [
 ####################################################################################################
 
 
-# https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHWGHH?rev=90#Current_recommendations_for_HH_c
+# https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHWGHH?rev=98#Current_recommendations_for_HH_c
 # scale is according to recommendation: scale + mtop unc
 # pdf is according to recommendation: pdf + aS
+# NNLO
+
+# scaling formula in fb
+hh_xsec_13p0 = lambda kl: 68.5624 - 48.3673 * kl + 10.5635 * kl**2
+hh_unc_scale_hi_13p0 = lambda kl: 75.4551 - 55.401 * kl + 12.4555 * kl**2
+hh_unc_scale_lo_13p0 = lambda kl: 56.5063 - 41.9131 * kl + 9.30669 * kl**2
+hh_unc_scale_up_13p0 = lambda kl: max(hh_unc_scale_hi_13p0(kl), hh_unc_scale_lo_13p0(kl))
+hh_unc_scale_down_13p0 = lambda kl: min(hh_unc_scale_hi_13p0(kl), hh_unc_scale_lo_13p0(kl))
+
+hh_xsec_13p6 = lambda kl: 75.7617 - 53.2855 * kl + 11.6126 * kl**2
+hh_unc_scale_hi_13p6 = lambda kl: 83.3897 - 61.0213 * kl + 13.6898 * kl**2
+hh_unc_scale_lo_13p6 = lambda kl: 62.4328 - 46.1854 * kl + 10.2342 * kl**2
+hh_unc_scale_up_13p6 = lambda kl: max(hh_unc_scale_hi_13p6(kl), hh_unc_scale_lo_13p6(kl))
+hh_unc_scale_down_13p6 = lambda kl: min(hh_unc_scale_hi_13p6(kl), hh_unc_scale_lo_13p6(kl))
 
 hh = Process(
     name="hh",
@@ -65,51 +79,40 @@ hh_ggf = hh.add_process(
     name="hh_ggf",
     id=21000,
     label=r"$HH_{ggf}$",
-    xsecs={
-        13: 0.001 * Number(31.05, {
-            "pdf": 0.03j,
-            "scale": (0.06j, 0.23j),
-        }),
-        13.6: 0.001 * Number(34.43, {
-            "pdf": 0.03j,
-            "scale": (0.06j, 0.23j),
-        }),
-    },
     aux={"production_mode_parent": hh},
 )
 
 # Naming conventions, cross sections and uncertainties are based on:
 # https://gitlab.cern.ch/hh/naming-conventions
-# Missing uncertainties are based on:
-# https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHWGHH?rev=89
-
-hh_ggf_kl0_kt1 = hh_ggf.add_process(
-    name="hh_ggf_kl0_kt1",
-    id=21001,
-    xsecs={
-        13: Number(0.069725, {
-            "scale": (0.024j, 0.061j),
-            "pdf": 0.03j,
-            "mtop": (0.06j, 0.12j),
-        }),
-        13.6: Number(0.1),  # TODO
-    },
-    aux={"production_mode_parent": hh_ggf},
-)
 
 hh_ggf_kl1_kt1 = hh_ggf.add_process(
     name="hh_ggf_kl1_kt1",
     id=21002,
     xsecs={
-        13: Number(0.031047, {
-            "scale": (0.022j, 0.050j),
-            "pdf": 0.03j,
-            "mtop": (0.04j, 0.18j),
+        # sm values taken from summary table on twiki
+        13: 0.001 * Number(30.77, {
+            "pdf": 0.023j,
+            "scale": (0.06j, 0.23j),
         }),
-        13.6: Number(0.03443, {  # value for mH=125 GeV
-            "scale": (0.021j, 0.049j),
-            "pdf": 0.03j,
-            "mtop": (0.04j, 0.18j),
+        13.6: 0.001 * Number(34.13, {
+            "pdf": 0.023j,
+            "scale": (0.06j, 0.23j),
+        }),
+    },
+    aux={"production_mode_parent": hh_ggf},
+)
+
+hh_ggf_kl0_kt1 = hh_ggf.add_process(
+    name="hh_ggf_kl0_kt1",
+    id=21001,
+    xsecs={
+        13: 0.001 * Number(hh_xsec_13p0(0), {
+            "pdf": 0.023j,
+            "scale": (hh_unc_scale_up_13p0(0), hh_unc_scale_down_13p0(0)),
+        }),
+        13.6: 0.001 * Number(hh_xsec_13p6(0), {
+            "pdf": 0.023j,
+            "scale": (hh_unc_scale_up_13p6(0), hh_unc_scale_down_13p6(0)),
         }),
     },
     aux={"production_mode_parent": hh_ggf},
@@ -119,12 +122,14 @@ hh_ggf_kl2p45_kt1 = hh_ggf.add_process(
     name="hh_ggf_kl2p45_kt1",
     id=21003,
     xsecs={
-        13: Number(0.013124, {
-            "scale": (0.023j, 0.051j),
-            "pdf": 0.03j,
-            "mtop": (0.04j, 0.22j),
+        13: 0.001 * Number(hh_xsec_13p0(2.45), {
+            "pdf": 0.023j,
+            "scale": (hh_unc_scale_up_13p0(2.45), hh_unc_scale_down_13p0(2.45)),
         }),
-        13.6: Number(0.1),  # TODO
+        13.6: 0.001 * Number(hh_xsec_13p6(2.45), {
+            "pdf": 0.023j,
+            "scale": (hh_unc_scale_up_13p6(2.45), hh_unc_scale_down_13p6(2.45)),
+        }),
     },
     aux={"production_mode_parent": hh_ggf},
 )
@@ -133,12 +138,14 @@ hh_ggf_kl5_kt1 = hh_ggf.add_process(
     name="hh_ggf_kl5_kt1",
     id=21004,
     xsecs={
-        13: Number(0.091172, {
-            "scale": (0.049j, 0.088j),
-            "pdf": 0.03j,
-            "mtop": (0.13j, 0.04j),
+        13: 0.001 * Number(hh_xsec_13p0(5), {
+            "pdf": 0.023j,
+            "scale": (hh_unc_scale_up_13p0(5), hh_unc_scale_down_13p0(5)),
         }),
-        13.6: Number(0.1),  # TODO
+        13.6: 0.001 * Number(hh_xsec_13p6(5), {
+            "pdf": 0.023j,
+            "scale": (hh_unc_scale_up_13p6(5), hh_unc_scale_down_13p6(5)),
+        }),
     },
     aux={"production_mode_parent": hh_ggf},
 )
@@ -146,68 +153,58 @@ hh_ggf_kl5_kt1 = hh_ggf.add_process(
 hh_ggf_kl0_kt1_c21 = hh_ggf.add_process(
     name="hh_ggf_kl0_kt1_c21",
     id=21005,
-    xsecs={
-        13: Number(0.1),  # TODO
-        13.6: Number(0.1),  # TODO
-    },
     aux={"production_mode_parent": hh_ggf},
 )
 
 hh_ggf_kl1_kt1_c20p10 = hh_ggf.add_process(
     name="hh_ggf_kl1_kt1_c20p10",
     id=21006,
-    xsecs={
-        13: Number(0.1),  # TODO
-        13.6: Number(0.1),  # TODO
-    },
     aux={"production_mode_parent": hh_ggf},
 )
 
 hh_ggf_kl1_kt1_c20p35 = hh_ggf.add_process(
     name="hh_ggf_kl1_kt1_c20p35",
     id=21007,
-    xsecs={
-        13: Number(0.1),  # TODO
-        13.6: Number(0.1),  # TODO
-    },
     aux={"production_mode_parent": hh_ggf},
 )
 
 hh_ggf_kl1_kt1_c23 = hh_ggf.add_process(
     name="hh_ggf_kl1_kt1_c23",
     id=21008,
-    xsecs={
-        13: Number(0.1),  # TODO
-        13.6: Number(0.1),  # TODO
-    },
     aux={"production_mode_parent": hh_ggf},
 )
 
 hh_ggf_kl1_kt1_c2m2 = hh_ggf.add_process(
     name="hh_ggf_kl1_kt1_c2m2",
     id=21009,
-    xsecs={
-        13: Number(0.1),  # TODO
-        13.6: Number(0.1),  # TODO
-    },
     aux={"production_mode_parent": hh_ggf},
 )
 
-# Source: xsecs were given in fb but are converted to pb,
-# uncertainties in %, values are taken for m_H = 125 GeV
-# https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHWGHH?rev=90#HHjj_VBF
+"""
+Source: https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHWGHH?rev=98#HHjj_VBF
+Extraction workflow for VBF cross sections:
+- values are taken for m_H = 125 GeV
+- LO values from XSDB, see e.g.:
+https://xsdb-temp.app.cern.ch/xsdb/?columns=67108863&currentPage=0&pageSize=10&searchQuery=process_name%3D%5EVBFHHto2B2Tau_CV.%2B_C2V.%2B_C3.%2B_.%2A13p6TeV.%2A%24  # noqa
+- xsecs were given in fb but are converted to pb
+- k-factor derived by comparing SM LO value to N3LO value from Twiki above
+- it is assumed to be constant across all other kappas and multiplied to corresponding LO values
+- uncertainties are constant and taken from the Twiki above
+"""
+
+hh_vbf_uncs_13p0 = {
+    "scale": (0.0005j, 0.0004j),
+    "pdf": 0.027j,
+}
+hh_vbf_uncs_13p6 = {
+    "scale": (0.0005j, 0.0003j),
+    "pdf": 0.027j,
+}
 
 hh_vbf = hh.add_process(
     name="hh_vbf",
     id=22000,
     label=r"$HH_{vbf}$",
-    xsecs={
-        13: 0.001 * Number(1.726, {
-            "scale": (0.0003j, 0.0004j),
-            "pdf": 0.021j,
-        }),
-        13.6: Number(0.1),  # TODO
-    },
     aux={"production_mode_parent": hh},
 )
 
@@ -215,24 +212,22 @@ hh_vbf_kv1_k2v1_kl1 = hh_vbf.add_process(
     name="hh_vbf_kv1_k2v1_kl1",
     id=22001,
     xsecs={
-        13: Number(0.0017260, {
-            "scale": (0.0003j, 0.0004j),
-            "pdf": 0.021j,
-        }),
-        13.6: Number(0.1),  # TODO
+        13: Number(1.687, hh_vbf_uncs_13p0) * 0.001,
+        13.6: Number(1.874, hh_vbf_uncs_13p6) * 0.001,
     },
     aux={"production_mode_parent": hh_vbf},
 )
+
+hh_vbf_k_13p0 = hh_vbf_kv1_k2v1_kl1.get_xsec(13).nominal / 1.626
+hh_vbf_k_13p6 = hh_vbf_kv1_k2v1_kl1.get_xsec(13.6).nominal / 1.912
 
 hh_vbf_kv1_k2v1_kl0 = hh_vbf.add_process(
     name="hh_vbf_kv1_k2v1_kl0",
     id=22002,
     xsecs={
-        13: Number(0.0046089, {
-            "scale": (0.0003j, 0.0004j),
-            "pdf": 0.021j,
-        }),
-        13.6: Number(0.1),  # TODO
+        13: Number(4.337 * hh_vbf_k_13p0, hh_vbf_uncs_13p0) * 0.001,
+        # no 13p6TeV sample generated, but we could use the scaling formula in the hh tools
+        # 13.6: Number(TODO * hh_vbf_k_13p6, hh_vbf_uncs_13p6) * 0.001,
     },
     aux={"production_mode_parent": hh_vbf},
 )
@@ -241,11 +236,8 @@ hh_vbf_kv1_k2v1_kl2 = hh_vbf.add_process(
     name="hh_vbf_kv1_k2v1_kl2",
     id=22003,
     xsecs={
-        13: Number(0.0014228, {
-            "scale": (0.0003j, 0.0004j),
-            "pdf": 0.021j,
-        }),
-        13.6: Number(0.1),  # TODO
+        13: Number(1.325 * hh_vbf_k_13p0, hh_vbf_uncs_13p0) * 0.001,
+        13.6: Number(1.593 * hh_vbf_k_13p6, hh_vbf_uncs_13p6) * 0.001,
     },
     aux={"production_mode_parent": hh_vbf},
 )
@@ -254,11 +246,8 @@ hh_vbf_kv1_k2v0_kl1 = hh_vbf.add_process(
     name="hh_vbf_kv1_k2v0_kl1",
     id=22004,
     xsecs={
-        13: Number(0.0270800, {
-            "scale": (0.0003j, 0.0004j),
-            "pdf": 0.021j,
-        }),
-        13.6: Number(0.1),  # TODO
+        13: Number(26.08 * hh_vbf_k_13p0, hh_vbf_uncs_13p0) * 0.001,
+        13.6: Number(29.32 * hh_vbf_k_13p6, hh_vbf_uncs_13p6) * 0.001,
     },
     aux={"production_mode_parent": hh_vbf},
 )
@@ -267,11 +256,8 @@ hh_vbf_kv1_k2v2_kl1 = hh_vbf.add_process(
     name="hh_vbf_kv1_k2v2_kl1",
     id=22005,
     xsecs={
-        13: Number(0.00142178, {
-            "scale": (0.0003j, 0.0004j),
-            "pdf": 0.021j,
-        }),
-        13.6: Number(0.1),  # TODO
+        13: Number(14.05 * hh_vbf_k_13p0, hh_vbf_uncs_13p0) * 0.001,
+        13.6: Number(15.71 * hh_vbf_k_13p6, hh_vbf_uncs_13p6) * 0.001,
     },
     aux={"production_mode_parent": hh_vbf},
 )
@@ -280,10 +266,9 @@ hh_vbf_kv0p5_k2v1_kl1 = hh_vbf.add_process(
     name="hh_vbf_kv0p5_k2v1_kl1",
     id=22006,
     xsecs={
-        13: Number(0.0108237, {
-            "scale": (0.0003j, 0.0004j),
-            "pdf": 0.021j,
-        }),
+        13: Number(10.47 * hh_vbf_k_13p0, hh_vbf_uncs_13p0) * 0.001,
+        # no 13p6TeV sample generated, but we could use the scaling formula in the hh tools
+        # 13.6: Number(TODO * hh_vbf_k_13p6, hh_vbf_uncs_13p6) * 0.001,
     },
     aux={"production_mode_parent": hh_vbf},
 )
@@ -292,10 +277,9 @@ hh_vbf_kv1p5_k2v1_kl1 = hh_vbf.add_process(
     name="hh_vbf_kv1p5_k2v1_kl1",
     id=22007,
     xsecs={
-        13: Number(0.0660185, {
-            "scale": (0.0003j, 0.0004j),
-            "pdf": 0.021j,
-        }),
+        13: Number(63.99 * hh_vbf_k_13p0, hh_vbf_uncs_13p0) * 0.001,
+        # no 13p6TeV sample generated, but we could use the scaling formula in the hh tools
+        # 13.6: Number(TODO * hh_vbf_k_13p6, hh_vbf_uncs_13p6) * 0.001,
     },
     aux={"production_mode_parent": hh_vbf},
 )
@@ -304,8 +288,9 @@ hh_vbf_kv1p74_k2v1p37_kl14p4 = hh_vbf.add_process(
     name="hh_vbf_kv1p74_k2v1p37_kl14p4",
     id=22008,
     xsecs={
-        13: Number(0.1),  # TODO
-        13.6: Number(0.1),  # TODO
+        # no 13p0TeV sample generated, but we could use the scaling formula in the hh tools
+        # 13: Number(TODO, hh_vbf_uncs_13p0) * 0.001,
+        13.6: Number(395.4, hh_vbf_uncs_13p6) * 0.001,
     },
     aux={"production_mode_parent": hh_vbf},
 )
@@ -314,8 +299,9 @@ hh_vbf_kvm0p012_k2v0p030_kl10p2 = hh_vbf.add_process(
     name="hh_vbf_kvm0p012_k2v0p030_kl10p2",
     id=22009,
     xsecs={
-        13: Number(0.1),  # TODO
-        13.6: Number(0.1),  # TODO
+        # no 13p0TeV sample generated, but we could use the scaling formula in the hh tools
+        # 13: Number(TODO, hh_vbf_uncs_13p0) * 0.001,
+        13.6: Number(0.01257, hh_vbf_uncs_13p6) * 0.001,
     },
     aux={"production_mode_parent": hh_vbf},
 )
@@ -324,8 +310,9 @@ hh_vbf_kvm0p758_k2v1p44_klm19p3 = hh_vbf.add_process(
     name="hh_vbf_kvm0p758_k2v1p44_klm19p3",
     id=22010,
     xsecs={
-        13: Number(0.1),  # TODO
-        13.6: Number(0.1),  # TODO
+        # no 13p0TeV sample generated, but we could use the scaling formula in the hh tools
+        # 13: Number(TODO, hh_vbf_uncs_13p0) * 0.001,
+        13.6: Number(355.0, hh_vbf_uncs_13p6) * 0.001,
     },
     aux={"production_mode_parent": hh_vbf},
 )
@@ -334,8 +321,9 @@ hh_vbf_kvm0p962_k2v0p959_klm1p43 = hh_vbf.add_process(
     name="hh_vbf_kvm0p962_k2v0p959_klm1p43",
     id=22011,
     xsecs={
-        13: Number(0.1),  # TODO
-        13.6: Number(0.1),  # TODO
+        # no 13p0TeV sample generated, but we could use the scaling formula in the hh tools
+        # 13: Number(TODO, hh_vbf_uncs_13p0) * 0.001,
+        13.6: Number(1.114, hh_vbf_uncs_13p6) * 0.001,
     },
     aux={"production_mode_parent": hh_vbf},
 )
@@ -344,8 +332,9 @@ hh_vbf_kvm1p21_k2v1p94_klm0p94 = hh_vbf.add_process(
     name="hh_vbf_kvm1p21_k2v1p94_klm0p94",
     id=22012,
     xsecs={
-        13: Number(0.1),  # TODO
-        13.6: Number(0.1),  # TODO
+        # no 13p0TeV sample generated, but we could use the scaling formula in the hh tools
+        # 13: Number(TODO, hh_vbf_uncs_13p0) * 0.001,
+        13.6: Number(3.753, hh_vbf_uncs_13p6) * 0.001,
     },
     aux={"production_mode_parent": hh_vbf},
 )
@@ -354,8 +343,9 @@ hh_vbf_kvm1p60_k2v2p72_klm1p36 = hh_vbf.add_process(
     name="hh_vbf_kvm1p60_k2v2p72_klm1p36",
     id=22013,
     xsecs={
-        13: Number(0.1),  # TODO
-        13.6: Number(0.1),  # TODO
+        # no 13p0TeV sample generated, but we could use the scaling formula in the hh tools
+        # 13: Number(TODO, hh_vbf_uncs_13p0) * 0.001,
+        13.6: Number(11.56, hh_vbf_uncs_13p6) * 0.001,
     },
     aux={"production_mode_parent": hh_vbf},
 )
@@ -364,8 +354,9 @@ hh_vbf_kvm1p83_k2v3p57_klm3p39 = hh_vbf.add_process(
     name="hh_vbf_kvm1p83_k2v3p57_klm3p39",
     id=22014,
     xsecs={
-        13: Number(0.1),  # TODO
-        13.6: Number(0.1),  # TODO
+        # no 13p0TeV sample generated, but we could use the scaling formula in the hh tools
+        # 13: Number(TODO, hh_vbf_uncs_13p0) * 0.001,
+        13.6: Number(16.65, hh_vbf_uncs_13p6) * 0.001,
     },
     aux={"production_mode_parent": hh_vbf},
 )
@@ -374,12 +365,12 @@ hh_vbf_kvm2p12_k2v3p87_klm5p96 = hh_vbf.add_process(
     name="hh_vbf_kvm2p12_k2v3p87_klm5p96",
     id=22015,
     xsecs={
-        13: Number(0.1),  # TODO
-        13.6: Number(0.1),  # TODO
+        # no 13p0TeV sample generated, but we could use the scaling formula in the hh tools
+        # 13: Number(TODO, hh_vbf_uncs_13p0) * 0.001,
+        13.6: Number(6.719, hh_vbf_uncs_13p6) * 0.001,
     },
     aux={"production_mode_parent": hh_vbf},
 )
-
 
 hh.xsecs = add_xsecs(hh_ggf, hh_vbf)
 


### PR DESCRIPTION
This PR updates HH cross sections to the latest recommendations of https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHWGHH, which includes an update on both the ggf and vbf production modes.

The cross sections are now NNLO (ggf) and N3LO (vbf), so that no kl-dependent scaling is required in the inference tools.