### PR TITLE
update get_das_info to include empty and broken files

### DIFF
--- a/cmsdb/campaigns/run3_2022_postEE_nano_v12/data.py
+++ b/cmsdb/campaigns/run3_2022_postEE_nano_v12/data.py
@@ -120,6 +120,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="data_muoneg_e",
     id=14783435,
+    is_data=True,
     processes=[procs.data_muoneg],
     info=dict(
         nominal=DatasetInfo(
@@ -133,11 +134,15 @@ cpn.add_dataset(
             n_events=12873327,
         ),
     ),
+    aux={
+        "era": "E",
+    },
 )
 
 cpn.add_dataset(
     name="data_muoneg_f",
     id=14784482,
+    is_data=True,
     processes=[procs.data_muoneg],
     info=dict(
         nominal=DatasetInfo(
@@ -154,11 +159,15 @@ cpn.add_dataset(
             n_events=38219969,
         ),
     ),
+    aux={
+        "era": "F",
+    },
 )
 
 cpn.add_dataset(
     name="data_muoneg_g",
     id=14784485,
+    is_data=True,
     processes=[procs.data_muoneg],
     info=dict(
         nominal=DatasetInfo(
@@ -174,4 +183,7 @@ cpn.add_dataset(
             n_events=6238527,
         ),
     ),
+    aux={
+        "era": "G",
+    },
 )

--- a/cmsdb/campaigns/run3_2022_postEE_nano_v12/data.py
+++ b/cmsdb/campaigns/run3_2022_postEE_nano_v12/data.py
@@ -4,6 +4,8 @@
 CMS datasets from the 2022 post-EE data-taking campaign
 """
 
+from order import DatasetInfo
+
 import cmsdb.processes as procs
 from cmsdb.campaigns.run3_2022_postEE_nano_v12 import campaign_run3_2022_postEE_nano_v12 as cpn
 
@@ -118,44 +120,58 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="data_muoneg_e",
     id=14783435,
-    is_data=True,
     processes=[procs.data_muoneg],
-    keys=[
-        "/MuonEG/Run2022E-22Sep2023-v1/NANOAOD",  # noqa
-    ],
-    n_files=29,
-    n_events=12873327,
-    aux={
-        "era": "E",
-    },
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/MuonEG/Run2022E-22Sep2023-v1/NANOAOD",  # noqa: E501
+            ],
+            aux={
+                "broken_files": [],
+            },
+            n_files=29,  # 29-0
+            n_events=12873327,
+        ),
+    ),
 )
 
 cpn.add_dataset(
     name="data_muoneg_f",
     id=14784482,
-    is_data=True,
     processes=[procs.data_muoneg],
-    keys=[
-        "/MuonEG/Run2022F-22Sep2023-v1/NANOAOD",  # noqa
-    ],
-    n_files=95,
-    n_events=38219969,
-    aux={
-        "era": "F",
-    },
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/MuonEG/Run2022F-22Sep2023-v1/NANOAOD",  # noqa: E501
+            ],
+            aux={
+                "broken_files": [
+                    "/store/data/Run2022F/MuonEG/NANOAOD/22Sep2023-v1/50000/4d76213a-ef14-411a-9558-559a6df3f978.root",  # empty  # noqa: E501
+                    "/store/data/Run2022F/MuonEG/NANOAOD/22Sep2023-v1/50000/4fb72196-3b02-4499-8f6c-a54e15692b32.root",  # empty  # noqa: E501
+                ],
+            },
+            n_files=93,  # 95-2
+            n_events=38219969,
+        ),
+    ),
 )
 
 cpn.add_dataset(
     name="data_muoneg_g",
     id=14784485,
-    is_data=True,
     processes=[procs.data_muoneg],
-    keys=[
-        "/MuonEG/Run2022G-22Sep2023-v1/NANOAOD",  # noqa
-    ],
-    n_files=27,
-    n_events=6238527,
-    aux={
-        "era": "G",
-    },
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/MuonEG/Run2022G-22Sep2023-v1/NANOAOD",  # noqa: E501
+            ],
+            aux={
+                "broken_files": [
+                    "/store/data/Run2022G/MuonEG/NANOAOD/22Sep2023-v1/2520000/cd404eb6-8218-4787-b5ed-af6cd9fe3750.root",  # empty  # noqa: E501
+                ],
+            },
+            n_files=26,  # 27-1
+            n_events=6238527,
+        ),
+    ),
 )

--- a/cmsdb/campaigns/run3_2022_preEE_nano_v12/data.py
+++ b/cmsdb/campaigns/run3_2022_preEE_nano_v12/data.py
@@ -120,6 +120,7 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="data_muoneg_a",
     id=14783289,
+    is_data=True,
     processes=[procs.data_muoneg],
     info=dict(
         nominal=DatasetInfo(
@@ -135,11 +136,15 @@ cpn.add_dataset(
             n_events=12,
         ),
     ),
+    aux={
+        "era": "A",
+    },
 )
 
 cpn.add_dataset(
     name="data_muoneg_b",
     id=14784076,
+    is_data=True,
     processes=[procs.data_muoneg],
     info=dict(
         nominal=DatasetInfo(
@@ -155,11 +160,15 @@ cpn.add_dataset(
             n_events=254803,
         ),
     ),
+    aux={
+        "era": "B",
+    },
 )
 
 cpn.add_dataset(
     name="data_muoneg_c",
     id=14784125,
+    is_data=True,
     processes=[procs.data_muoneg],
     info=dict(
         nominal=DatasetInfo(
@@ -173,11 +182,15 @@ cpn.add_dataset(
             n_events=15768439,
         ),
     ),
+    aux={
+        "era": "C",
+    },
 )
 
 cpn.add_dataset(
     name="data_muoneg_d",
     id=14784209,
+    is_data=True,
     processes=[procs.data_muoneg],
     info=dict(
         nominal=DatasetInfo(
@@ -191,4 +204,7 @@ cpn.add_dataset(
             n_events=8007031,
         ),
     ),
+    aux={
+        "era": "D",
+    },
 )

--- a/cmsdb/campaigns/run3_2022_preEE_nano_v12/data.py
+++ b/cmsdb/campaigns/run3_2022_preEE_nano_v12/data.py
@@ -4,6 +4,8 @@
 CMS datasets from the 2022 pre-EE data-taking campaign
 """
 
+from order import DatasetInfo
+
 import cmsdb.processes as procs
 from cmsdb.campaigns.run3_2022_preEE_nano_v12 import campaign_run3_2022_preEE_nano_v12 as cpn
 
@@ -118,59 +120,75 @@ cpn.add_dataset(
 cpn.add_dataset(
     name="data_muoneg_a",
     id=14783289,
-    is_data=True,
     processes=[procs.data_muoneg],
-    keys=[
-        "/MuonEG/Run2022A-22Sep2023-v1/NANOAOD",  # noqa
-    ],
-    n_files=5,
-    n_events=12,
-    aux={
-        "era": "A",
-    },
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/MuonEG/Run2022A-22Sep2023-v1/NANOAOD",  # noqa: E501
+            ],
+            aux={
+                "broken_files": [
+                    "/store/data/Run2022A/MuonEG/NANOAOD/22Sep2023-v1/50000/9a127bdb-9522-4f49-b754-67bb9152c0b3.root",  # empty  # noqa: E501
+                ],
+            },
+            n_files=4,  # 5-1
+            n_events=12,
+        ),
+    ),
 )
 
 cpn.add_dataset(
     name="data_muoneg_b",
     id=14784076,
-    is_data=True,
     processes=[procs.data_muoneg],
-    keys=[
-        "/MuonEG/Run2022B-22Sep2023-v1/NANOAOD",  # noqa
-    ],
-    n_files=7,
-    n_events=254803,
-    aux={
-        "era": "B",
-    },
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/MuonEG/Run2022B-22Sep2023-v1/NANOAOD",  # noqa: E501
+            ],
+            aux={
+                "broken_files": [
+                    "/store/data/Run2022B/MuonEG/NANOAOD/22Sep2023-v1/50000/947809ff-822e-4a3a-84a2-d3fe84fc2573.root",  # empty  # noqa: E501
+                ],
+            },
+            n_files=6,  # 7-1
+            n_events=254803,
+        ),
+    ),
 )
 
 cpn.add_dataset(
     name="data_muoneg_c",
     id=14784125,
-    is_data=True,
     processes=[procs.data_muoneg],
-    keys=[
-        "/MuonEG/Run2022C-22Sep2023-v1/NANOAOD",  # noqa
-    ],
-    n_files=28,
-    n_events=15768439,
-    aux={
-        "era": "C",
-    },
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/MuonEG/Run2022C-22Sep2023-v1/NANOAOD",  # noqa: E501
+            ],
+            aux={
+                "broken_files": [],
+            },
+            n_files=28,  # 28-0
+            n_events=15768439,
+        ),
+    ),
 )
 
 cpn.add_dataset(
     name="data_muoneg_d",
     id=14784209,
-    is_data=True,
     processes=[procs.data_muoneg],
-    keys=[
-        "/MuonEG/Run2022D-22Sep2023-v1/NANOAOD",  # noqa
-    ],
-    n_files=16,
-    n_events=8007031,
-    aux={
-        "era": "D",
-    },
+    info=dict(
+        nominal=DatasetInfo(
+            keys=[
+                "/MuonEG/Run2022D-22Sep2023-v1/NANOAOD",  # noqa: E501
+            ],
+            aux={
+                "broken_files": [],
+            },
+            n_files=16,  # 16-0
+            n_events=8007031,
+        ),
+    ),
 )

--- a/scripts/get_das_info.py
+++ b/scripts/get_das_info.py
@@ -26,15 +26,15 @@ def get_generator_name(name: str) -> str:
         return ""
 
 
-def get_broken_files_str(data: dict, n_spaces: int = 12) -> str:
+def get_broken_files_str(data: dict, n_spaces: int = 20) -> str:
     """
     Function that returns a string represenatation of broken files
     """
 
     broken_files_list = [
-        f'"{d}",  # broken' for d in data["broken_files"]
+        f'"{d}",  # broken  # noqa: E501' for d in data["broken_files"]
     ] + [
-        f'"{d}",  # empty' for d in data["empty_files"] if d not in data["broken_files"]
+        f'"{d}",  # empty  # noqa: E501' for d in data["empty_files"] if d not in data["broken_files"]
     ]
 
     if not broken_files_list:
@@ -57,34 +57,15 @@ def convert_default(data: dict, placeholder="PLACEHOLDER") -> str:
     name="{placeholder}{generator}",
     id={data['dataset_id']},
     processes=[procs.{placeholder}],
-    keys=[
-        "{data['name']}",  # noqa
-    ],
-    aux={{
-        "broken_files": [{get_broken_files_str(data)}],
-    }},
-    n_files={data['nfiles_good']},  # {data["nfiles"]}-{data["nfiles_bad"]}
-    n_events={data['nevents']},
-)
-"""
-
-
-def convert_variation(data: dict, placeholder="PLACEHOLDER") -> str:
-    """
-    Function that converts dataset info into one order Dataset per query. Stores the dataset info
-    in a dict with the dataset type as key.
-    """
-    generator = get_generator_name(data["name"])
-    return f"""cpn.add_dataset(
-    name="{placeholder}{generator}",
-    id={data['dataset_id']},
-    processes=[procs.{placeholder}],
     info=dict(
         nominal=DatasetInfo(
             keys=[
-                "{data['name']}",  # noqa
+                "{data['name']}",  # noqa: E501
             ],
-            n_files={data['nfiles']},
+            aux={{
+                "broken_files": [{get_broken_files_str(data)}],
+            }},
+            n_files={data['nfiles_good']},  # {data["nfiles"]}-{data["nfiles_bad"]}
             n_events={data['nevents']},
         ),
     ),
@@ -153,9 +134,12 @@ def convert_top(data: dict, placeholder="PLACEHOLDER") -> str:
     info=dict(
         nominal=DatasetInfo(
             keys=[
-                "{data['name']}",  # noqa
+                "{data['name']}",  # noqa: E501
             ],
-            n_files={data['nfiles']},
+            aux={{
+                "broken_files": [{get_broken_files_str(data)}],
+            }},
+            n_files={data['nfiles_good']},  # {data["nfiles"]}-{data["nfiles_bad"]}
             n_events={data['nevents']},
         ),
     ),
@@ -164,9 +148,12 @@ def convert_top(data: dict, placeholder="PLACEHOLDER") -> str:
         # comment out this dataset
         return f"""        # {identifier}=DatasetInfo(
         #     keys=[
-        #         "{data['name']}",  # noqa
+        #         "{data['name']}",  # noqa: E501
         #     ],
-        #     n_files={data['nfiles']},
+        #     aux={{
+        #         "broken_files": [{get_broken_files_str(data)}],
+        #     }},
+        #     n_files={data['nfiles_good']},  # {data["nfiles"]}-{data["nfiles_bad"]}
         #     n_events={data['nevents']},
         # ),"""
     elif dataset_type == "ignore":
@@ -175,9 +162,12 @@ def convert_top(data: dict, placeholder="PLACEHOLDER") -> str:
         # some known variation of the dataset
         return f"""        {dataset_type}=DatasetInfo(
             keys=[
-                "{data['name']}",  # noqa
+                "{data['name']}",  # noqa: E501
             ],
-            n_files={data['nfiles']},
+            aux={{
+                "broken_files": [{get_broken_files_str(data)}],
+            }},
+            n_files={data['nfiles_good']},  # {data["nfiles"]}-{data["nfiles_bad"]}
             n_events={data['nevents']},
         ),"""
 
@@ -193,12 +183,11 @@ def convert_minimal(data: dict) -> str:
     """
     Function that only returns the dataset key + number of events.
     """
-    return f"""{data['name']}\nFiles: {data['nfiles']}\nEvents: {data['nevents']}\n"""
+    return f"""{data['name']}\nFiles: {data['nfiles_good']}\nEvents: {data['nevents']}\n"""
 
 
 convert_functions = {
     "default": convert_default,
-    "variation": convert_variation,
     "keys": convert_keys,
     "top": convert_top,
     "minimal": convert_minimal,

--- a/scripts/get_das_info.py
+++ b/scripts/get_das_info.py
@@ -212,49 +212,7 @@ def load_das_info(dataset: str, add_file_info: bool = False) -> dict:
     return infos
 
 
-def get_das_info(
-    dataset: str,
-    add_file_info: bool = False,
-) -> dict:
-    infos = load_das_info(dataset, add_file_info=False)
-
-    info_of_interest = {"name": dataset}
-    for info in infos:
-        dataset_info = info["dataset"][0]
-        if "files_via_dataset" in info["das"]["services"][0]:
-            print("should not be called")
-            empty_files = list(filter(lambda x: x["file"][0]["nevents"] == 0, info))
-            broken_files = list(filter(lambda x: x["file"][0]["is_file_valid"] == 0, info))
-
-        # Get json format of single das_string gives multiple dictornaries with different info
-        # Avoid to print multiple infos twice and ask specificly for the kew of interest
-        if "dataset_info" in info["das"]["services"][0]:
-            info_of_interest["dataset_id"] = dataset_info.get("dataset_id", "")
-        elif "filesummaries" in info["das"]["services"][0]:
-            info_of_interest["nfiles"] = dataset_info.get("nfiles", "")
-            info_of_interest["nevents"] = dataset_info.get("nevents", "")
-
-    if add_file_info:
-        file_infos = load_das_info(dataset, add_file_info=True)
-
-        empty_files = [
-            info["file"][0]["name"]
-            for info in filter(lambda info: info["file"][0]["nevents"] == 0, file_infos)
-        ]
-        broken_files = [
-            info["file"][0]["name"]
-            for info in filter(lambda info: info["file"][0]["is_file_valid"] == 0, file_infos)
-        ]
-        info_of_interest["empty_files"] = empty_files
-        info_of_interest["broken_files"] = broken_files
-    else:
-        info_of_interest["empty_files"] = "UNKNOWN"
-        info_of_interest["broken_files"] = "UNKNOWN"
-
-    return info_of_interest
-
-
-def new_get_das_info(dataset: str) -> dict:
+def get_das_info(dataset: str) -> dict:
     info_of_interest = {"name": dataset}
 
     file_infos = load_das_info(dataset, add_file_info=True)
@@ -320,7 +278,7 @@ def print_das_info(
                 datasets.append(dataset_name)
 
         for dataset in datasets:
-            info_of_interest = new_get_das_info(dataset)
+            info_of_interest = get_das_info(dataset)
             desired_output = convert_function(info_of_interest)
             print(desired_output)
 


### PR DESCRIPTION
This PR adds auxiliary information to each dataset inst that is generated via the `get_das_info` script. The main difference is that we need to load the meta data for each file instead of for the full dataset (e.g. f"dasgoclient -query='file dataset={dataset}' -json").

I timed the runtime of the `get_das_info` and compared it with the `new_get_das_info` with the following command:
```
python3 get_das_info.py -d "/TTto*/Run3Summer22EENanoAODv12-130X*/NANOAODSIM"
```
The increased runtime duration due to having to check the info of each dataset was negligibly (50s vs 48s) even when running over 65 datasets with O(10k) files in total.

TODO:
- [x] decide on how to store the meta data 
    - [x] two separate aux entries or one combined ( --> changed to one combined + comments)
    - [x] should we be more explicit when writing the n_files (e.g. `95 -2` instead of `93` when there are 95 datasets with two empty/broken ones) ( --> added comment)
- [x] add the aux entries to all convert functions 
- [x] consistency checks: is it sufficient to sum over all files ourselves or should we compare this result from the `filesummaries`service? ( --> should be fine without checks)