### PR TITLE
Update st s-channel cross sections.

### DIFF
--- a/cmsdb/processes/top.py
+++ b/cmsdb/processes/top.py
@@ -89,13 +89,14 @@ tt_fh = tt.add_process(
 # single-top
 #
 # using updated tables from 2022
-# t- and tw-channel: https://twiki.cern.ch/twiki/bin/view/LHCPhysics/SingleTopNNLORef?rev=20#Predictions_for_top_quark_produc  # noqa
-# s-channel: https://twiki.cern.ch/twiki/bin/view/LHCPhysics/SingleTopRefXsec?rev=36#Single_top_s_channel_cross_secti
-# for the tW-channel, the t and tbar channels contribute equally as stated in
-# Ref https://twiki.cern.ch/twiki/bin/view/LHCPhysics/SingleTopRefXsec?rev=36#Single_top_Wt_channel_cross_sect
-#
-# 13 TeV s-channel cross sections from here:
-# https://twiki.cern.ch/twiki/bin/viewauth/CMS/SingleTopSigma?rev=12#Single_Top_Cross_sections_at_13?rev=12
+# t- and tw-channel:
+#   - https://twiki.cern.ch/twiki/bin/view/LHCPhysics/SingleTopNNLORef?rev=20#Predictions_for_top_quark_produc  # noqa
+# s-channel:
+#   - https://twiki.cern.ch/twiki/bin/view/LHCPhysics/SingleTopNNLORef?rev=21 (NNLO)
+#   - we used NLO before from https://twiki.cern.ch/twiki/bin/view/LHCPhysics/SingleTopRefXsec?rev=36#Single_top_s_channel_cross_secti  # noqa
+# tW-channel:
+#   - the t and tbar channels contribute equally as stated in
+#   - https://twiki.cern.ch/twiki/bin/view/LHCPhysics/SingleTopRefXsec?rev=36#Single_top_Wt_channel_cross_sect
 
 st = Process(
     name="st",
@@ -189,6 +190,7 @@ st_twchannel = st.add_process(
     },
 )
 
+# TODO: dividing by half as there is no recommended value yet
 st_twchannel_t = st_twchannel.add_process(
     name="st_twchannel_t",
     id=2210,
@@ -216,6 +218,7 @@ st_twchannel_t_fh = st_twchannel_t.add_process(
     xsecs=multiply_xsecs(st_twchannel_t, const.br_ww.fh),
 )
 
+# TODO: dividing by half as there is no recommended value yet
 st_twchannel_tbar = st_twchannel.add_process(
     name="st_twchannel_tbar",
     id=2220,
@@ -248,20 +251,14 @@ st_schannel = st.add_process(
     id=2300,
     label=f"{st.label}, s-channel",
     xsecs={
-        13: Number(10.32, {
-            "scale": (0.29, 0.24),
-            "pdf": 0.27,
-            "mtop": (0.23, 0.22),
-            "E_beam": 0.01,
+        # only scale uncertainty is given in the twiki
+        # https://twiki.cern.ch/twiki/bin/view/LHCPhysics/SingleTopNNLORef?rev=21
+        13: Number(11.073, {
+            "scale": (0.058, 0.034),
         }),
-        13.6: Number(7.246, {
+        13.6: Number(11.778, {
             "scale": (0.059, 0.043),
         }),
-        # only scale uncertainty is given in the twiki
-        # https://twiki.cern.ch/twiki/bin/view/LHCPhysics/SingleTopNNLORef?rev=20
-        # TODO: update after final calculations
-        # no value for 13.6 in NLO twiki
-        # https://twiki.cern.ch/twiki/bin/view/LHCPhysics/SingleTopRefXsec?rev=36
     },
 )
 
@@ -281,15 +278,19 @@ st_schannel_t = st_schannel.add_process(
     name="st_schannel_t",
     id=2310,
     xsecs={
-        13: Number(6.35, {
-            "scale": (0.18, 0.15),
-            "pdf": 0.14,
-            "mtop": (0.14, 0.13),
-            "E_beam": 0.01,
+        # https://twiki.cern.ch/twiki/bin/view/LHCPhysics/SingleTopNNLORef?rev=21
+        # no scale uncertainties given for t/tbar subchannels, so assume 100% correlation and split
+        # scale uncertainty on sum of t + tbar accordingly
+        13: Number(6.828, {
+            "scale": tuple(
+                tot * 6.828 / st_schannel.get_xsec(13).n
+                for tot in st_schannel.get_xsec(13).u("scale")
+            ),
         }),
-        # TODO: 13.6 TeV xsecs
-        # not available yet in
-        # https://twiki.cern.ch/twiki/bin/view/LHCPhysics/SingleTopNNLORef?rev=20
+        13.6: Number(7.244, {
+            tot * 7.244 / st_schannel.get_xsec(13.6).n
+            for tot in st_schannel.get_xsec(13.6).u("scale")
+        }),
     },
 )
 
@@ -309,15 +310,19 @@ st_schannel_tbar = st_schannel.add_process(
     name="st_schannel_tbar",
     id=2320,
     xsecs={
-        13: Number(3.97, {
-            "scale": (0.11, 0.09),
-            "pdf": 0.15,
-            "mtop": 0.09,
-            "E_beam": 0.01,
+        # https://twiki.cern.ch/twiki/bin/view/LHCPhysics/SingleTopNNLORef?rev=21
+        # no scale uncertainties given for t/tbar subchannels, so assume 100% correlation and split
+        # scale uncertainty on sum of t + tbar accordingly
+        13: Number(4.245, {
+            "scale": tuple(
+                tot * 4.245 / st_schannel.get_xsec(13).n
+                for tot in st_schannel.get_xsec(13).u("scale")
+            ),
         }),
-        # TODO: 13.6 TeV xsecs
-        # not available yet in
-        # https://twiki.cern.ch/twiki/bin/view/LHCPhysics/SingleTopNNLORef?rev=20
+        13.6: Number(4.534, {
+            tot * 4.534 / st_schannel.get_xsec(13.6).n
+            for tot in st_schannel.get_xsec(13.6).u("scale")
+        }),
     },
 )
 

--- a/cmsdb/processes/top.py
+++ b/cmsdb/processes/top.py
@@ -190,7 +190,6 @@ st_twchannel = st.add_process(
     },
 )
 
-# TODO: dividing by half as there is no recommended value yet
 st_twchannel_t = st_twchannel.add_process(
     name="st_twchannel_t",
     id=2210,
@@ -218,7 +217,6 @@ st_twchannel_t_fh = st_twchannel_t.add_process(
     xsecs=multiply_xsecs(st_twchannel_t, const.br_ww.fh),
 )
 
-# TODO: dividing by half as there is no recommended value yet
 st_twchannel_tbar = st_twchannel.add_process(
     name="st_twchannel_tbar",
     id=2220,

--- a/cmsdb/processes/top.py
+++ b/cmsdb/processes/top.py
@@ -288,8 +288,10 @@ st_schannel_t = st_schannel.add_process(
             ),
         }),
         13.6: Number(7.244, {
-            tot * 7.244 / st_schannel.get_xsec(13.6).n
-            for tot in st_schannel.get_xsec(13.6).u("scale")
+            "scale": tuple(
+                tot * 7.244 / st_schannel.get_xsec(13.6).n
+                for tot in st_schannel.get_xsec(13.6).u("scale")
+            ),
         }),
     },
 )
@@ -320,8 +322,10 @@ st_schannel_tbar = st_schannel.add_process(
             ),
         }),
         13.6: Number(4.534, {
-            tot * 4.534 / st_schannel.get_xsec(13.6).n
-            for tot in st_schannel.get_xsec(13.6).u("scale")
+            "scale": tuple(
+                tot * 4.534 / st_schannel.get_xsec(13.6).n
+                for tot in st_schannel.get_xsec(13.6).u("scale")
+            ),
         }),
     },
 )


### PR DESCRIPTION
This small PR updates our s-channel single-top cross sections.

We used NLO values so far but there was actually an update last month in
https://twiki.cern.ch/twiki/bin/view/LHCPhysics/SingleTopNNLORef?rev=21#Single_top_quark_s_channel_cross
which provided updates to the t/tbar specific cross sections at **NN**LO, even for 13.6 TeV.

I updated the nominal values as well as scale uncertainties.