### PR TITLE
Add more DY NNLO samples.

### DIFF
--- a/cmsdb/campaigns/run3_2022_postEE_nano_uhh_v14/ewk.py
+++ b/cmsdb/campaigns/run3_2022_postEE_nano_uhh_v14/ewk.py
@@ -10,7 +10,7 @@ from cmsdb.campaigns.run3_2022_postEE_nano_uhh_v14 import campaign_run3_2022_pos
 
 
 #
-# Drell-Yan
+# Drell-Yan, NLO
 #
 
 cpn.add_dataset(
@@ -270,6 +270,509 @@ cpn.add_dataset(
     ],
     n_files=5,
     n_events=1_682_240,
+    aux={
+        "merging_factors": {
+            "nominal": 13,
+        },
+    },
+)
+
+#
+# Drell-Yan NNLO
+#
+
+# 2 e
+cpn.add_dataset(
+    name="dy_ee_m50toinf_powheg",
+    id=14803659,
+    processes=[procs.dy_ee_m50toinf],
+    keys=[
+        "/DYto2E_M-50_NNPDF31_TuneCP5_13p6TeV-powheg-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=124,
+    n_events=95_080_708,
+    aux={
+        "merging_factors": {
+            "nominal": 13,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_ee_m10to50_powheg",
+    id=14790843,
+    processes=[procs.dy_ee_m10to50],
+    keys=[
+        "/DYto2E_MLL-10to50_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=4,
+    n_events=5_333_106,
+    aux={
+        "merging_factors": {
+            "nominal": 27,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_ee_m50to120_powheg",
+    id=14791654,
+    processes=[procs.dy_ee_m50to120],
+    keys=[
+        "/DYto2E_MLL-50to120_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=14,
+    n_events=10_403_118,
+    aux={
+        "merging_factors": {
+            "nominal": 17,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_ee_m120to200_powheg",
+    id=14791361,
+    processes=[procs.dy_ee_m120to200],
+    keys=[
+        "/DYto2E_MLL-120to200_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=8,
+    n_events=5_238_528,
+    aux={
+        "merging_factors": {
+            "nominal": 15,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_ee_m200to400_powheg",
+    id=14791638,
+    processes=[procs.dy_ee_m200to400],
+    keys=[
+        "/DYto2E_MLL-200to400_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=6,
+    n_events=3_147_891,
+    aux={
+        "merging_factors": {
+            "nominal": 13,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_ee_m400to800_powheg",
+    id=14791636,
+    processes=[procs.dy_ee_m400to800],
+    keys=[
+        "/DYto2E_MLL-400to800_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=6,
+    n_events=2_989_350,
+    aux={
+        "merging_factors": {
+            "nominal": 12,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_ee_m800to1500_powheg",
+    id=14791352,
+    processes=[procs.dy_ee_m800to1500],
+    keys=[
+        "/DYto2E_MLL-800to1500_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=5,
+    n_events=2_004_300,
+    aux={
+        "merging_factors": {
+            "nominal": 12,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_ee_m1500to2500_powheg",
+    id=14791880,
+    processes=[procs.dy_ee_m1500to2500],
+    keys=[
+        "/DYto2E_MLL-1500to2500_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=5,
+    n_events=2_053_944,
+    aux={
+        "merging_factors": {
+            "nominal": 18,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_ee_m2500to4000_powheg",
+    id=14792309,
+    processes=[procs.dy_ee_m2500to4000],
+    keys=[
+        "/DYto2E_MLL-2500to4000_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=3,
+    n_events=986_496,
+    aux={
+        "merging_factors": {
+            "nominal": 13,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_ee_m4000to6000_powheg",
+    id=14791229,
+    processes=[procs.dy_ee_m4000to6000],
+    keys=[
+        "/DYto2E_MLL-4000to6000_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=3,
+    n_events=1_027_656,
+    aux={
+        "merging_factors": {
+            "nominal": 19,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_ee_m6000toinf_powheg",
+    id=14791422,
+    processes=[procs.dy_ee_m6000toinf],
+    keys=[
+        "/DYto2E_MLL-6000_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=550_816,
+    aux={
+        "merging_factors": {
+            "nominal": 19,
+        },
+    },
+)
+
+# 2 mu
+cpn.add_dataset(
+    name="dy_mumu_m10to50_powheg",
+    id=14791053,
+    processes=[procs.dy_mumu_m10to50],
+    keys=[
+        "/DYto2Mu_MLL-10to50_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=4,
+    n_events=5_026_256,
+    aux={
+        "merging_factors": {
+            "nominal": 36,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_mumu_m50to120_powheg",
+    id=14790991,
+    processes=[procs.dy_mumu_m50to120],
+    keys=[
+        "/DYto2Mu_MLL-50to120_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=12,
+    n_events=10_150_330,
+    aux={
+        "merging_factors": {
+            "nominal": 20,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_mumu_m120to200_powheg",
+    id=14791940,
+    processes=[procs.dy_mumu_m120to200],
+    keys=[
+        "/DYto2Mu_MLL-120to200_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=7,
+    n_events=4_999_610,
+    aux={
+        "merging_factors": {
+            "nominal": 21,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_mumu_m200to400_powheg",
+    id=14792035,
+    processes=[procs.dy_mumu_m200to400],
+    keys=[
+        "/DYto2Mu_MLL-200to400_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=5,
+    n_events=3_051_242,
+    aux={
+        "merging_factors": {
+            "nominal": 21,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_mumu_m400to800_powheg",
+    id=14790881,
+    processes=[procs.dy_mumu_m400to800],
+    keys=[
+        "/DYto2Mu_MLL-400to800_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=5,
+    n_events=2_930_748,
+    aux={
+        "merging_factors": {
+            "nominal": 17,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_mumu_m800to1500_powheg",
+    id=14806101,
+    processes=[procs.dy_mumu_m800to1500],
+    keys=[
+        "/DYto2Mu_MLL-800to1500_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=4,
+    n_events=2_088_496,
+    aux={
+        "merging_factors": {
+            "nominal": 16,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_mumu_m1500to2500_powheg",
+    id=14791845,
+    processes=[procs.dy_mumu_m1500to2500],
+    keys=[
+        "/DYto2Mu_MLL-1500to2500_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=4,
+    n_events=2_008_146,
+    aux={
+        "merging_factors": {
+            "nominal": 21,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_mumu_m2500to4000_powheg",
+    id=14792266,
+    processes=[procs.dy_mumu_m2500to4000],
+    keys=[
+        "/DYto2Mu_MLL-2500to4000_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=1_000_182,
+    aux={
+        "merging_factors": {
+            "nominal": 23,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_mumu_m4000to6000_powheg",
+    id=14791526,
+    processes=[procs.dy_mumu_m4000to6000],
+    keys=[
+        "/DYto2Mu_MLL-4000to6000_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=994_900,
+    aux={
+        "merging_factors": {
+            "nominal": 26,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_mumu_m6000toinf_powheg",
+    id=14802011,
+    processes=[procs.dy_mumu_m6000toinf],
+    keys=[
+        "/DYto2Mu_MLL-6000_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=503_888,
+    aux={
+        "merging_factors": {
+            "nominal": 23,
+        },
+    },
+)
+
+# 2 tau
+cpn.add_dataset(
+    name="dy_tautau_m10to50_powheg",
+    id=14790883,
+    processes=[procs.dy_tautau_m10to50],
+    keys=[
+        "/DYto2Tau_MLL-10to50_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=4,
+    n_events=5_249_261,
+    aux={
+        "merging_factors": {
+            "nominal": 22,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_tautau_m50to120_powheg",
+    id=14791401,
+    processes=[procs.dy_tautau_m50to120],
+    keys=[
+        "/DYto2Tau_MLL-50to120_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=11,
+    n_events=10_293_446,
+    aux={
+        "merging_factors": {
+            "nominal": 16,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_tautau_m120to200_powheg",
+    id=14791625,
+    processes=[procs.dy_tautau_m120to200],
+    keys=[
+        "/DYto2Tau_MLL-120to200_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=7,
+    n_events=5_249_271,
+    aux={
+        "merging_factors": {
+            "nominal": 14,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_tautau_m200to400_powheg",
+    id=14791554,
+    processes=[procs.dy_tautau_m200to400],
+    keys=[
+        "/DYto2Tau_MLL-200to400_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=5,
+    n_events=3_021_840,
+    aux={
+        "merging_factors": {
+            "nominal": 20,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_tautau_m400to800_powheg",
+    id=14791169,
+    processes=[procs.dy_tautau_m400to800],
+    keys=[
+        "/DYto2Tau_MLL-400to800_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=6,
+    n_events=3_110_408,
+    aux={
+        "merging_factors": {
+            "nominal": 15,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_tautau_m800to1500_powheg",
+    id=14791666,
+    processes=[procs.dy_tautau_m800to1500],
+    keys=[
+        "/DYto2Tau_MLL-800to1500_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=5,
+    n_events=2_205_546,
+    aux={
+        "merging_factors": {
+            "nominal": 14,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_tautau_m1500to2500_powheg",
+    id=14791764,
+    processes=[procs.dy_tautau_m1500to2500],
+    keys=[
+        "/DYto2Tau_MLL-1500to2500_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=5,
+    n_events=1_995_777,
+    aux={
+        "merging_factors": {
+            "nominal": 13,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_tautau_m2500to4000_powheg",
+    id=14791740,
+    processes=[procs.dy_tautau_m2500to4000],
+    keys=[
+        "/DYto2Tau_MLL-2500to4000_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=3,
+    n_events=1_050_000,
+    aux={
+        "merging_factors": {
+            "nominal": 15,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_tautau_m4000to6000_powheg",
+    id=14793280,
+    processes=[procs.dy_tautau_m4000to6000],
+    keys=[
+        "/DYto2Tau_MLL-4000to6000_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=3,
+    n_events=1_047_456,
+    aux={
+        "merging_factors": {
+            "nominal": 22,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_tautau_m6000toinf_powheg",
+    id=14790786,
+    processes=[procs.dy_tautau_m6000toinf],
+    keys=[
+        "/DYto2Tau_MLL-6000_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=523_113,
     aux={
         "merging_factors": {
             "nominal": 13,

--- a/cmsdb/campaigns/run3_2022_preEE_nano_uhh_v14/ewk.py
+++ b/cmsdb/campaigns/run3_2022_preEE_nano_uhh_v14/ewk.py
@@ -558,11 +558,10 @@ cpn.add_dataset(
 )
 
 #
-# Drell-Yan NNLO, split in leptons
+# Drell-Yan NNLO
 #
 
-# 2 electron
-
+# 2 e
 cpn.add_dataset(
     name="dy_ee_m50toinf_powheg",
     id=14803284,
@@ -643,7 +642,6 @@ cpn.add_dataset(
     },
 )
 
-
 cpn.add_dataset(
     name="dy_ee_m400to800_powheg",
     id=14791330,
@@ -659,7 +657,6 @@ cpn.add_dataset(
         },
     },
 )
-
 
 cpn.add_dataset(
     name="dy_ee_m800to1500_powheg",
@@ -741,8 +738,7 @@ cpn.add_dataset(
     },
 )
 
-# 2 muon
-
+# 2 mu
 cpn.add_dataset(
     name="dy_mumu_m10to50_powheg",
     id=14801977,
@@ -904,7 +900,6 @@ cpn.add_dataset(
 )
 
 # 2 tau
-
 cpn.add_dataset(
     name="dy_tautau_m10to50_powheg",
     id=14791054,

--- a/cmsdb/campaigns/run3_2023_postBPix_nano_uhh_v14/ewk.py
+++ b/cmsdb/campaigns/run3_2023_postBPix_nano_uhh_v14/ewk.py
@@ -10,7 +10,7 @@ from cmsdb.campaigns.run3_2023_postBPix_nano_uhh_v14 import campaign_run3_2023_p
 
 
 #
-# Drell-Yan
+# Drell-Yan, LO
 #
 
 cpn.add_dataset(
@@ -265,6 +265,493 @@ cpn.add_dataset(
     aux={
         "merging_factors": {
             "nominal": 20,
+        },
+    },
+)
+
+#
+# Drell-Yan, NLO
+#
+
+# 2 e
+cpn.add_dataset(
+    name="dy_ee_m10to50_powheg",
+    id=14811287,
+    processes=[procs.dy_ee_m10to50],
+    keys=[
+        "/DYto2E_MLL-10to50_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v2-v3/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=1_476_000,
+    aux={
+        "merging_factors": {
+            "nominal": 44,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_ee_m50to120_powheg",
+    id=14809373,
+    processes=[procs.dy_ee_m50to120],
+    keys=[
+        "/DYto2E_MLL-50to120_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v2-v3/NANOAODSIM",  # noqa
+    ],
+    n_files=4,
+    n_events=2_910_000,
+    aux={
+        "merging_factors": {
+            "nominal": 26,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_ee_m120to200_powheg",
+    id=14808963,
+    processes=[procs.dy_ee_m120to200],
+    keys=[
+        "/DYto2E_MLL-120to200_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v2-v3/NANOAODSIM",  # noqa
+    ],
+    n_files=3,
+    n_events=1_476_000,
+    aux={
+        "merging_factors": {
+            "nominal": 17,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_ee_m200to400_powheg",
+    id=14808883,
+    processes=[procs.dy_ee_m200to400],
+    keys=[
+        "/DYto2E_MLL-200to400_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v2-v3/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=867_000,
+    aux={
+        "merging_factors": {
+            "nominal": 17,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_ee_m400to800_powheg",
+    id=14809497,
+    processes=[procs.dy_ee_m400to800],
+    keys=[
+        "/DYto2E_MLL-400to800_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v2-v3/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=894_000,
+    aux={
+        "merging_factors": {
+            "nominal": 28,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_ee_m800to1500_powheg",
+    id=14811299,
+    processes=[procs.dy_ee_m800to1500],
+    keys=[
+        "/DYto2E_MLL-800to1500_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v2-v3/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=591_000,
+    aux={
+        "merging_factors": {
+            "nominal": 16,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_ee_m1500to2500_powheg",
+    id=14809507,
+    processes=[procs.dy_ee_m1500to2500],
+    keys=[
+        "/DYto2E_MLL-1500to2500_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v2-v3/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=578_000,
+    aux={
+        "merging_factors": {
+            "nominal": 16,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_ee_m2500to4000_powheg",
+    id=14808646,
+    processes=[procs.dy_ee_m2500to4000],
+    keys=[
+        "/DYto2E_MLL-2500to4000_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v2-v3/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=278_000,
+    aux={
+        "merging_factors": {
+            "nominal": 22,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_ee_m4000to6000_powheg",
+    id=14808303,
+    processes=[procs.dy_ee_m4000to6000],
+    keys=[
+        "/DYto2E_MLL-4000to6000_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v2-v3/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=300_000,
+    aux={
+        "merging_factors": {
+            "nominal": 28,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_ee_m6000toinf_powheg",
+    id=14807806,
+    processes=[procs.dy_ee_m6000toinf],
+    keys=[
+        "/DYto2E_MLL-6000_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v2-v3/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=150_000,
+    aux={
+        "merging_factors": {
+            "nominal": 12,
+        },
+    },
+)
+
+# 2 mu
+cpn.add_dataset(
+    name="dy_mumu_m10to50_powheg",
+    id=14809405,
+    processes=[procs.dy_mumu_m10to50],
+    keys=[
+        "/DYto2Mu_MLL-10to50_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v2-v3/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=1_468_000,
+    aux={
+        "merging_factors": {
+            "nominal": 46,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_mumu_m50to120_powheg",
+    id=14811432,
+    processes=[procs.dy_mumu_m50to120],
+    keys=[
+        "/DYto2Mu_MLL-50to120_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v2-v3/NANOAODSIM",  # noqa
+    ],
+    n_files=4,
+    n_events=2_852_000,
+    aux={
+        "merging_factors": {
+            "nominal": 22,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_mumu_m120to200_powheg",
+    id=14811002,
+    processes=[procs.dy_mumu_m120to200],
+    keys=[
+        "/DYto2Mu_MLL-120to200_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v2-v3/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=1_496_000,
+    aux={
+        "merging_factors": {
+            "nominal": 25,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_mumu_m200to400_powheg",
+    id=14808258,
+    processes=[procs.dy_mumu_m200to400],
+    keys=[
+        "/DYto2Mu_MLL-200to400_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v2-v3/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=891_000,
+    aux={
+        "merging_factors": {
+            "nominal": 20,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_mumu_m400to800_powheg",
+    id=14810814,
+    processes=[procs.dy_mumu_m400to800],
+    keys=[
+        "/DYto2Mu_MLL-400to800_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v2-v3/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=892_000,
+    aux={
+        "merging_factors": {
+            "nominal": 23,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_mumu_m800to1500_powheg",
+    id=14809305,
+    processes=[procs.dy_mumu_m800to1500],
+    keys=[
+        "/DYto2Mu_MLL-800to1500_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v2-v3/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=584_000,
+    aux={
+        "merging_factors": {
+            "nominal": 30,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_mumu_m1500to2500_powheg",
+    id=14801369,
+    processes=[procs.dy_mumu_m1500to2500],
+    keys=[
+        "/DYto2Mu_MLL-1500to2500_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v2-v4/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=600_000,
+    aux={
+        "merging_factors": {
+            "nominal": 26,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_mumu_m2500to4000_powheg",
+    id=14808321,
+    processes=[procs.dy_mumu_m2500to4000],
+    keys=[
+        "/DYto2Mu_MLL-2500to4000_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v2-v3/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=291_000,
+    aux={
+        "merging_factors": {
+            "nominal": 18,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_mumu_m4000to6000_powheg",
+    id=14808096,
+    processes=[procs.dy_mumu_m4000to6000],
+    keys=[
+        "/DYto2Mu_MLL-4000to6000_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v2-v3/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=294_000,
+    aux={
+        "merging_factors": {
+            "nominal": 20,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_mumu_m6000toinf_powheg",
+    id=14808312,
+    processes=[procs.dy_mumu_m6000toinf],
+    keys=[
+        "/DYto2Mu_MLL-6000_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v2-v3/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=150_000,
+    aux={
+        "merging_factors": {
+            "nominal": 12,
+        },
+    },
+)
+
+# 2 tau
+cpn.add_dataset(
+    name="dy_tautau_m10to50_powheg",
+    id=14808689,
+    processes=[procs.dy_tautau_m10to50],
+    keys=[
+        "/DYto2Tau_MLL-10to50_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v2-v3/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=1_500_000,
+    aux={
+        "merging_factors": {
+            "nominal": 46,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_tautau_m50to120_powheg",
+    id=14810799,
+    processes=[procs.dy_tautau_m50to120],
+    keys=[
+        "/DYto2Tau_MLL-50to120_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v2-v3/NANOAODSIM",  # noqa
+    ],
+    n_files=3,
+    n_events=2_856_000,
+    aux={
+        "merging_factors": {
+            "nominal": 27,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_tautau_m120to200_powheg",
+    id=14811310,
+    processes=[procs.dy_tautau_m120to200],
+    keys=[
+        "/DYto2Tau_MLL-120to200_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v2-v3/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=1_500_000,
+    aux={
+        "merging_factors": {
+            "nominal": 29,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_tautau_m200to400_powheg",
+    id=14808910,
+    processes=[procs.dy_tautau_m200to400],
+    keys=[
+        "/DYto2Tau_MLL-200to400_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v2-v3/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=900_000,
+    aux={
+        "merging_factors": {
+            "nominal": 19,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_tautau_m400to800_powheg",
+    id=14808457,
+    processes=[procs.dy_tautau_m400to800],
+    keys=[
+        "/DYto2Tau_MLL-400to800_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v2-v3/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=882_000,
+    aux={
+        "merging_factors": {
+            "nominal": 18,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_tautau_m800to1500_powheg",
+    id=14808384,
+    processes=[procs.dy_tautau_m800to1500],
+    keys=[
+        "/DYto2Tau_MLL-800to1500_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v2-v3/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=585_000,
+    aux={
+        "merging_factors": {
+            "nominal": 20,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_tautau_m1500to2500_powheg",
+    id=14809458,
+    processes=[procs.dy_tautau_m1500to2500],
+    keys=[
+        "/DYto2Tau_MLL-1500to2500_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v2-v3/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=588_000,
+    aux={
+        "merging_factors": {
+            "nominal": 13,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_tautau_m2500to4000_powheg",
+    id=14809626,
+    processes=[procs.dy_tautau_m2500to4000],
+    keys=[
+        "/DYto2Tau_MLL-2500to4000_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v2-v3/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=291_000,
+    aux={
+        "merging_factors": {
+            "nominal": 22,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_tautau_m4000to6000_powheg",
+    id=14808308,
+    processes=[procs.dy_tautau_m4000to6000],
+    keys=[
+        "/DYto2Tau_MLL-4000to6000_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v2-v3/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=297_000,
+    aux={
+        "merging_factors": {
+            "nominal": 15,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_tautau_m6000toinf_powheg",
+    id=14808291,
+    processes=[procs.dy_tautau_m6000toinf],
+    keys=[
+        "/DYto2Tau_MLL-6000_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v2-v3/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=150_000,
+    aux={
+        "merging_factors": {
+            "nominal": 13,
         },
     },
 )

--- a/cmsdb/campaigns/run3_2023_preBPix_nano_uhh_v14/ewk.py
+++ b/cmsdb/campaigns/run3_2023_preBPix_nano_uhh_v14/ewk.py
@@ -10,7 +10,7 @@ from cmsdb.campaigns.run3_2023_preBPix_nano_uhh_v14 import campaign_run3_2023_pr
 
 
 #
-# Drell-Yan
+# Drell-Yan, NLO
 #
 
 cpn.add_dataset(
@@ -265,6 +265,493 @@ cpn.add_dataset(
     aux={
         "merging_factors": {
             "nominal": 20,
+        },
+    },
+)
+
+#
+# Drell-Yan, NNLO
+#
+
+# 2 e
+cpn.add_dataset(
+    name="dy_ee_m10to50_powheg",
+    id=14819517,
+    processes=[procs.dy_ee_m10to50],
+    keys=[
+        "/DYto2E_MLL-10to50_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v14-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=3,
+    n_events=2_968_000,
+    aux={
+        "merging_factors": {
+            "nominal": 31,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_ee_m50to120_powheg",
+    id=14819448,
+    processes=[procs.dy_ee_m50to120],
+    keys=[
+        "/DYto2E_MLL-50to120_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v14-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=9,
+    n_events=5_904_000,
+    aux={
+        "merging_factors": {
+            "nominal": 18,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_ee_m120to200_powheg",
+    id=14827651,
+    processes=[procs.dy_ee_m120to200],
+    keys=[
+        "/DYto2E_MLL-120to200_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v14-v3/NANOAODSIM",  # noqa
+    ],
+    n_files=5,
+    n_events=2_991_000,
+    aux={
+        "merging_factors": {
+            "nominal": 15,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_ee_m200to400_powheg",
+    id=14815197,
+    processes=[procs.dy_ee_m200to400],
+    keys=[
+        "/DYto2E_MLL-200to400_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v14-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=3,
+    n_events=1_731_000,
+    aux={
+        "merging_factors": {
+            "nominal": 20,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_ee_m400to800_powheg",
+    id=14819116,
+    processes=[procs.dy_ee_m400to800],
+    keys=[
+        "/DYto2E_MLL-400to800_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v14-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=4,
+    n_events=1_788_000,
+    aux={
+        "merging_factors": {
+            "nominal": 17,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_ee_m800to1500_powheg",
+    id=14827196,
+    processes=[procs.dy_ee_m800to1500],
+    keys=[
+        "/DYto2E_MLL-800to1500_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v14-v3/NANOAODSIM",  # noqa
+    ],
+    n_files=3,
+    n_events=1_192_000,
+    aux={
+        "merging_factors": {
+            "nominal": 14,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_ee_m1500to2500_powheg",
+    id=14818854,
+    processes=[procs.dy_ee_m1500to2500],
+    keys=[
+        "/DYto2E_MLL-1500to2500_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v14-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=3,
+    n_events=1_154_000,
+    aux={
+        "merging_factors": {
+            "nominal": 17,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_ee_m2500to4000_powheg",
+    id=14819537,
+    processes=[procs.dy_ee_m2500to4000],
+    keys=[
+        "/DYto2E_MLL-2500to4000_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v14-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=590_000,
+    aux={
+        "merging_factors": {
+            "nominal": 23,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_ee_m4000to6000_powheg",
+    id=14818938,
+    processes=[procs.dy_ee_m4000to6000],
+    keys=[
+        "/DYto2E_MLL-4000to6000_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v14-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=593_000,
+    aux={
+        "merging_factors": {
+            "nominal": 23,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_ee_m6000toinf_powheg",
+    id=14824907,
+    processes=[procs.dy_ee_m6000toinf],
+    keys=[
+        "/DYto2E_MLL-6000_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v14-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=297_000,
+    aux={
+        "merging_factors": {
+            "nominal": 28,
+        },
+    },
+)
+
+# 2 mu
+cpn.add_dataset(
+    name="dy_mumu_m10to50_powheg",
+    id=14819568,
+    processes=[procs.dy_mumu_m10to50],
+    keys=[
+        "/DYto2Mu_MLL-10to50_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v14-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=3,
+    n_events=3_000_000,
+    aux={
+        "merging_factors": {
+            "nominal": 27,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_mumu_m50to120_powheg",
+    id=14819516,
+    processes=[procs.dy_mumu_m50to120],
+    keys=[
+        "/DYto2Mu_MLL-50to120_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v14-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=7,
+    n_events=5_860_000,
+    aux={
+        "merging_factors": {
+            "nominal": 22,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_mumu_m120to200_powheg",
+    id=14819224,
+    processes=[procs.dy_mumu_m120to200],
+    keys=[
+        "/DYto2Mu_MLL-120to200_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v14-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=4,
+    n_events=2_997_000,
+    aux={
+        "merging_factors": {
+            "nominal": 30,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_mumu_m200to400_powheg",
+    id=14824908,
+    processes=[procs.dy_mumu_m200to400],
+    keys=[
+        "/DYto2Mu_MLL-200to400_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v14-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=3,
+    n_events=1_776_000,
+    aux={
+        "merging_factors": {
+            "nominal": 17,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_mumu_m400to800_powheg",
+    id=14819294,
+    processes=[procs.dy_mumu_m400to800],
+    keys=[
+        "/DYto2Mu_MLL-400to800_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v14-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=3,
+    n_events=1_797_000,
+    aux={
+        "merging_factors": {
+            "nominal": 30,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_mumu_m800to1500_powheg",
+    id=14819220,
+    processes=[procs.dy_mumu_m800to1500],
+    keys=[
+        "/DYto2Mu_MLL-800to1500_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v14-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=3,
+    n_events=1_179_000,
+    aux={
+        "merging_factors": {
+            "nominal": 18,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_mumu_m1500to2500_powheg",
+    id=14819528,
+    processes=[procs.dy_mumu_m1500to2500],
+    keys=[
+        "/DYto2Mu_MLL-1500to2500_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v14-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=3,
+    n_events=1_191_000,
+    aux={
+        "merging_factors": {
+            "nominal": 25,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_mumu_m2500to4000_powheg",
+    id=14819606,
+    processes=[procs.dy_mumu_m2500to4000],
+    keys=[
+        "/DYto2Mu_MLL-2500to4000_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v14-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=600_000,
+    aux={
+        "merging_factors": {
+            "nominal": 15,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_mumu_m4000to6000_powheg",
+    id=14819166,
+    processes=[procs.dy_mumu_m4000to6000],
+    keys=[
+        "/DYto2Mu_MLL-4000to6000_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v14-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=558_000,
+    aux={
+        "merging_factors": {
+            "nominal": 32,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_mumu_m6000toinf_powheg",
+    id=14821541,
+    processes=[procs.dy_mumu_m6000toinf],
+    keys=[
+        "/DYto2Mu_MLL-6000_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v14-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=300_000,
+    aux={
+        "merging_factors": {
+            "nominal": 18,
+        },
+    },
+)
+
+# 2 tau
+cpn.add_dataset(
+    name="dy_tautau_m10to50_powheg",
+    id=14824899,
+    processes=[procs.dy_tautau_m10to50],
+    keys=[
+        "/DYto2Tau_MLL-10to50_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v14-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=2_972_000,
+    aux={
+        "merging_factors": {
+            "nominal": 31,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_tautau_m50to120_powheg",
+    id=14819493,
+    processes=[procs.dy_tautau_m50to120],
+    keys=[
+        "/DYto2Tau_MLL-50to120_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v14-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=7,
+    n_events=5_824_000,
+    aux={
+        "merging_factors": {
+            "nominal": 24,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_tautau_m120to200_powheg",
+    id=14820294,
+    processes=[procs.dy_tautau_m120to200],
+    keys=[
+        "/DYto2Tau_MLL-120to200_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v14-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=4,
+    n_events=2_964_000,
+    aux={
+        "merging_factors": {
+            "nominal": 16,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_tautau_m200to400_powheg",
+    id=14819554,
+    processes=[procs.dy_tautau_m200to400],
+    keys=[
+        "/DYto2Tau_MLL-200to400_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v14-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=3,
+    n_events=1_794_000,
+    aux={
+        "merging_factors": {
+            "nominal": 23,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_tautau_m400to800_powheg",
+    id=14826840,
+    processes=[procs.dy_tautau_m400to800],
+    keys=[
+        "/DYto2Tau_MLL-400to800_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v14-v3/NANOAODSIM",  # noqa
+    ],
+    n_files=3,
+    n_events=1_797_000,
+    aux={
+        "merging_factors": {
+            "nominal": 13,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_tautau_m800to1500_powheg",
+    id=14821647,
+    processes=[procs.dy_tautau_m800to1500],
+    keys=[
+        "/DYto2Tau_MLL-800to1500_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v14-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=3,
+    n_events=1_143_000,
+    aux={
+        "merging_factors": {
+            "nominal": 12,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_tautau_m1500to2500_powheg",
+    id=14819622,
+    processes=[procs.dy_tautau_m1500to2500],
+    keys=[
+        "/DYto2Tau_MLL-1500to2500_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v14-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=3,
+    n_events=1_164_000,
+    aux={
+        "merging_factors": {
+            "nominal": 19,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_tautau_m2500to4000_powheg",
+    id=14826879,
+    processes=[procs.dy_tautau_m2500to4000],
+    keys=[
+        "/DYto2Tau_MLL-2500to4000_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v14-v3/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=600_000,
+    aux={
+        "merging_factors": {
+            "nominal": 16,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_tautau_m4000to6000_powheg",
+    id=14819532,
+    processes=[procs.dy_tautau_m4000to6000],
+    keys=[
+        "/DYto2Tau_MLL-4000to6000_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v14-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=594_000,
+    aux={
+        "merging_factors": {
+            "nominal": 27,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="dy_tautau_m6000toinf_powheg",
+    id=14819569,
+    processes=[procs.dy_tautau_m6000toinf],
+    keys=[
+        "/DYto2Tau_MLL-6000_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v14-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=294_000,
+    aux={
+        "merging_factors": {
+            "nominal": 33,
         },
     },
 )


### PR DESCRIPTION
- Adds DY NNLO samples (split into leptons) to the 22post, 23pre and 23post UHH v14 eras.
- Fixed some typos in the already existing datasets for 22pre.