### PR TITLE
correct kvm2p12_k2v3p87_klm5p96 sample xsec

### DIFF
--- a/cmsdb/processes/hh.py
+++ b/cmsdb/processes/hh.py
@@ -373,7 +373,7 @@ hh_vbf_kvm2p12_k2v3p87_klm5p96 = hh_vbf.add_process(
     xsecs={
         # no 13p0TeV sample generated, but we could use the scaling formula in the hh tools
         # 13: Number(TODO, hh_vbf_uncs_13p0) * 0.001,
-        13.6: Number(6.719 * hh_vbf_k_13p6, hh_vbf_uncs_13p6) * 0.001,
+        13.6: Number(671.9 * hh_vbf_k_13p6, hh_vbf_uncs_13p6) * 0.001,
     },
     aux={"production_mode_parent": hh_vbf},
 )


### PR DESCRIPTION
source: 
https://xsecdb-xsdb-official.app.cern.ch/xsdb/?columns=67108863&currentPage=0&pageSize=10&searchQuery=DAS%3DVBFHHto2B2Tau_CV_m2p12_C2V_3p87_C3_m5p96_TuneCP5_13p6TeV_madgraph-pythia8