### PR TITLE
Fix wrong kV value in VBF HH samples, processes and labels

### DIFF
--- a/cmsdb/campaigns/run3_2022_postEE_nano_uhh_v12/hh2bbtautau.py
+++ b/cmsdb/campaigns/run3_2022_postEE_nano_uhh_v12/hh2bbtautau.py
@@ -226,9 +226,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="hh_vbf_hbb_htt_kvm2p12_k2v3p87_klm5p96_madgraph",
+    name="hh_vbf_hbb_htt_kv2p12_k2v3p87_klm5p96_madgraph",
     id=14877436,
-    processes=[procs.hh_vbf_hbb_htt_kvm2p12_k2v3p87_klm5p96],
+    processes=[procs.hh_vbf_hbb_htt_kv2p12_k2v3p87_klm5p96],
     keys=[
         "/VBFHHto2B2Tau_CV-m2p12_C2V-3p87_C3-m5p96_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EEMiniAODv4_NanoAODv12UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
     ],

--- a/cmsdb/campaigns/run3_2022_postEE_nano_uhh_v14/hh2bbtautau.py
+++ b/cmsdb/campaigns/run3_2022_postEE_nano_uhh_v14/hh2bbtautau.py
@@ -338,9 +338,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="hh_vbf_hbb_htt_kvm2p12_k2v3p87_klm5p96_madgraph",
+    name="hh_vbf_hbb_htt_kv2p12_k2v3p87_klm5p96_madgraph",
     id=14877436,
-    processes=[procs.hh_vbf_hbb_htt_kvm2p12_k2v3p87_klm5p96],
+    processes=[procs.hh_vbf_hbb_htt_kv2p12_k2v3p87_klm5p96],
     keys=[
         "/VBFHHto2B2Tau_CV-m2p12_C2V-3p87_C3-m5p96_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
     ],

--- a/cmsdb/campaigns/run3_2022_postEE_nano_uhh_v14/hh2bbvv.py
+++ b/cmsdb/campaigns/run3_2022_postEE_nano_uhh_v14/hh2bbvv.py
@@ -323,9 +323,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="hh_vbf_hbb_hvv_kvm2p12_k2v3p87_klm5p96_madgraph",
+    name="hh_vbf_hbb_hvv_kv2p12_k2v3p87_klm5p96_madgraph",
     id=14879463,
-    processes=[procs.hh_vbf_hbb_hvv_kvm2p12_k2v3p87_klm5p96],
+    processes=[procs.hh_vbf_hbb_hvv_kv2p12_k2v3p87_klm5p96],
     keys=[
         "/VBFHHto2B2V_CV-m2p12_C2V-3p87_C3-m5p96_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
     ],
@@ -483,9 +483,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="hh_vbf_hbb_hvv2l2nu_kvm2p12_k2v3p87_klm5p96_madgraph",
+    name="hh_vbf_hbb_hvv2l2nu_kv2p12_k2v3p87_klm5p96_madgraph",
     id=14877427,
-    processes=[procs.hh_vbf_hbb_hvv2l2nu_kvm2p12_k2v3p87_klm5p96],
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kv2p12_k2v3p87_klm5p96],
     keys=[
         "/VBFHHto2B2Vto2L2Nu_CV-m2p12_C2V-3p87_C3-m5p96_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
     ],
@@ -643,9 +643,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="hh_vbf_hbb_hvvqqlnu_kvm2p12_k2v3p87_klm5p96_madgraph",
+    name="hh_vbf_hbb_hvvqqlnu_kv2p12_k2v3p87_klm5p96_madgraph",
     id=14870853,
-    processes=[procs.hh_vbf_hbb_hvvqqlnu_kvm2p12_k2v3p87_klm5p96],
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kv2p12_k2v3p87_klm5p96],
     keys=[
         "/VBFHHto2B2WtoLNu2Q_CV-m2p12_C2V-3p87_C3-m5p96_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
     ],

--- a/cmsdb/campaigns/run3_2022_postEE_nano_uhh_v14/hh2ml.py
+++ b/cmsdb/campaigns/run3_2022_postEE_nano_uhh_v14/hh2ml.py
@@ -316,9 +316,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="hh_vbf_htt_htt_kvm2p12_k2v3p87_klm5p96_madgraph",
+    name="hh_vbf_htt_htt_kv2p12_k2v3p87_klm5p96_madgraph",
     id=14880800,
-    processes=[procs.hh_vbf_htt_htt_kvm2p12_k2v3p87_klm5p96],
+    processes=[procs.hh_vbf_htt_htt_kv2p12_k2v3p87_klm5p96],
     keys=[
         "/VBFHHto4Tau_CV-m2p12_C2V-3p87_C3-m5p96_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
     ],
@@ -480,9 +480,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="hh_vbf_hvv_hvv_kvm2p12_k2v3p87_klm5p96_madgraph",
+    name="hh_vbf_hvv_hvv_kv2p12_k2v3p87_klm5p96_madgraph",
     id=14879358,
-    processes=[procs.hh_vbf_hvv_hvv_kvm2p12_k2v3p87_klm5p96],
+    processes=[procs.hh_vbf_hvv_hvv_kv2p12_k2v3p87_klm5p96],
     keys=[
         "/VBFHHto4V_CV-m2p12_C2V-3p87_C3-m5p96_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
     ],
@@ -644,9 +644,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="hh_vbf_htt_hvv_kvm2p12_k2v3p87_klm5p96_madgraph",
+    name="hh_vbf_htt_hvv_kv2p12_k2v3p87_klm5p96_madgraph",
     id=14879703,
-    processes=[procs.hh_vbf_htt_hvv_kvm2p12_k2v3p87_klm5p96],
+    processes=[procs.hh_vbf_htt_hvv_kv2p12_k2v3p87_klm5p96],
     keys=[
         "/VBFHHto2Tau2V_CV-m2p12_C2V-3p87_C3-m5p96_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
     ],

--- a/cmsdb/campaigns/run3_2022_postEE_nano_v12/hh2bbvv.py
+++ b/cmsdb/campaigns/run3_2022_postEE_nano_v12/hh2bbvv.py
@@ -203,9 +203,9 @@ cpn.add_dataset(
     ),
 )
 cpn.add_dataset(
-    name="hh_vbf_hbb_hvv_kvm2p12_k2v3p87_klm5p96_madgraph",
+    name="hh_vbf_hbb_hvv_kv2p12_k2v3p87_klm5p96_madgraph",
     id=14879734,
-    processes=[procs.hh_vbf_hbb_hvv_kvm2p12_k2v3p87_klm5p96],
+    processes=[procs.hh_vbf_hbb_hvv_kv2p12_k2v3p87_klm5p96],
     info=dict(
         nominal=DatasetInfo(
             keys=[
@@ -273,9 +273,9 @@ cpn.add_dataset(
     ),
 )
 cpn.add_dataset(
-    name="hh_vbf_hbb_hvv2l2nu_kvm2p12_k2v3p87_klm5p96_madgraph",
+    name="hh_vbf_hbb_hvv2l2nu_kv2p12_k2v3p87_klm5p96_madgraph",
     id=14877430,
-    processes=[procs.hh_vbf_hbb_hvv2l2nu_kvm2p12_k2v3p87_klm5p96],
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kv2p12_k2v3p87_klm5p96],
     info=dict(
         nominal=DatasetInfo(
             keys=[
@@ -483,9 +483,9 @@ cpn.add_dataset(
     ),
 )
 cpn.add_dataset(
-    name="hh_vbf_hbb_hvvqqlnu_kvm2p12_k2v3p87_klm5p96_madgraph",
+    name="hh_vbf_hbb_hvvqqlnu_kv2p12_k2v3p87_klm5p96_madgraph",
     id=14870854,
-    processes=[procs.hh_vbf_hbb_hvvqqlnu_kvm2p12_k2v3p87_klm5p96],
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kv2p12_k2v3p87_klm5p96],
     info=dict(
         nominal=DatasetInfo(
             keys=[

--- a/cmsdb/campaigns/run3_2022_preEE_nano_uhh_v12/hh2bbtautau.py
+++ b/cmsdb/campaigns/run3_2022_preEE_nano_uhh_v12/hh2bbtautau.py
@@ -342,9 +342,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="hh_vbf_hbb_htt_kvm2p12_k2v3p87_klm5p96_madgraph",
+    name="hh_vbf_hbb_htt_kv2p12_k2v3p87_klm5p96_madgraph",
     id=14877633,
-    processes=[procs.hh_vbf_hbb_htt_kvm2p12_k2v3p87_klm5p96],
+    processes=[procs.hh_vbf_hbb_htt_kv2p12_k2v3p87_klm5p96],
     keys=[
         "/VBFHHto2B2Tau_CV-m2p12_C2V-3p87_C3-m5p96_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22MiniAODv4_NanoAODv12UHH-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
     ],

--- a/cmsdb/campaigns/run3_2022_preEE_nano_uhh_v14/hh2bbtautau.py
+++ b/cmsdb/campaigns/run3_2022_preEE_nano_uhh_v14/hh2bbtautau.py
@@ -338,9 +338,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="hh_vbf_hbb_htt_kvm2p12_k2v3p87_klm5p96_madgraph",
+    name="hh_vbf_hbb_htt_kv2p12_k2v3p87_klm5p96_madgraph",
     id=14877633,
-    processes=[procs.hh_vbf_hbb_htt_kvm2p12_k2v3p87_klm5p96],
+    processes=[procs.hh_vbf_hbb_htt_kv2p12_k2v3p87_klm5p96],
     keys=[
         "/VBFHHto2B2Tau_CV-m2p12_C2V-3p87_C3-m5p96_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22MiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
     ],

--- a/cmsdb/campaigns/run3_2022_preEE_nano_uhh_v14/hh2bbvv.py
+++ b/cmsdb/campaigns/run3_2022_preEE_nano_uhh_v14/hh2bbvv.py
@@ -322,9 +322,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="hh_vbf_hbb_hvv_kvm2p12_k2v3p87_klm5p96_madgraph",
+    name="hh_vbf_hbb_hvv_kv2p12_k2v3p87_klm5p96_madgraph",
     id=14878390,
-    processes=[procs.hh_vbf_hbb_hvv_kvm2p12_k2v3p87_klm5p96],
+    processes=[procs.hh_vbf_hbb_hvv_kv2p12_k2v3p87_klm5p96],
     keys=[
         "/VBFHHto2B2V_CV-m2p12_C2V-3p87_C3-m5p96_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22MiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
     ],
@@ -482,9 +482,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="hh_vbf_hbb_hvv2l2nu_kvm2p12_k2v3p87_klm5p96_madgraph",
+    name="hh_vbf_hbb_hvv2l2nu_kv2p12_k2v3p87_klm5p96_madgraph",
     id=14877654,
-    processes=[procs.hh_vbf_hbb_hvv2l2nu_kvm2p12_k2v3p87_klm5p96],
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kv2p12_k2v3p87_klm5p96],
     keys=[
         "/VBFHHto2B2Vto2L2Nu_CV-m2p12_C2V-3p87_C3-m5p96_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22MiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
     ],
@@ -642,9 +642,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="hh_vbf_hbb_hvvqqlnu_kvm2p12_k2v3p87_klm5p96_madgraph",
+    name="hh_vbf_hbb_hvvqqlnu_kv2p12_k2v3p87_klm5p96_madgraph",
     id=14877660,
-    processes=[procs.hh_vbf_hbb_hvvqqlnu_kvm2p12_k2v3p87_klm5p96],
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kv2p12_k2v3p87_klm5p96],
     keys=[
         "/VBFHHto2B2WtoLNu2Q_CV-m2p12_C2V-3p87_C3-m5p96_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22MiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
     ],

--- a/cmsdb/campaigns/run3_2022_preEE_nano_uhh_v14/hh2ml.py
+++ b/cmsdb/campaigns/run3_2022_preEE_nano_uhh_v14/hh2ml.py
@@ -316,9 +316,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="hh_vbf_htt_htt_kvm2p12_k2v3p87_klm5p96_madgraph",
+    name="hh_vbf_htt_htt_kv2p12_k2v3p87_klm5p96_madgraph",
     id=14878379,
-    processes=[procs.hh_vbf_htt_htt_kvm2p12_k2v3p87_klm5p96],
+    processes=[procs.hh_vbf_htt_htt_kv2p12_k2v3p87_klm5p96],
     keys=[
         "/VBFHHto4Tau_CV-m2p12_C2V-3p87_C3-m5p96_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22MiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
     ],
@@ -480,9 +480,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="hh_vbf_hvv_hvv_kvm2p12_k2v3p87_klm5p96_madgraph",
+    name="hh_vbf_hvv_hvv_kv2p12_k2v3p87_klm5p96_madgraph",
     id=14878719,
-    processes=[procs.hh_vbf_hvv_hvv_kvm2p12_k2v3p87_klm5p96],
+    processes=[procs.hh_vbf_hvv_hvv_kv2p12_k2v3p87_klm5p96],
     keys=[
         "/VBFHHto4V_CV-m2p12_C2V-3p87_C3-m5p96_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22MiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
     ],
@@ -644,9 +644,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="hh_vbf_htt_hvv_kvm2p12_k2v3p87_klm5p96_madgraph",
+    name="hh_vbf_htt_hvv_kv2p12_k2v3p87_klm5p96_madgraph",
     id=14877315,
-    processes=[procs.hh_vbf_htt_hvv_kvm2p12_k2v3p87_klm5p96],
+    processes=[procs.hh_vbf_htt_hvv_kv2p12_k2v3p87_klm5p96],
     keys=[
         "/VBFHHto2Tau2V_CV-m2p12_C2V-3p87_C3-m5p96_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22MiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
     ],

--- a/cmsdb/campaigns/run3_2022_preEE_nano_v12/hh2bbvv.py
+++ b/cmsdb/campaigns/run3_2022_preEE_nano_v12/hh2bbvv.py
@@ -188,9 +188,9 @@ cpn.add_dataset(
     ),
 )
 cpn.add_dataset(
-    name="hh_vbf_hbb_hvv_kvm2p12_k2v3p87_klm5p96_madgraph",
+    name="hh_vbf_hbb_hvv_kv2p12_k2v3p87_klm5p96_madgraph",
     id=14878523,
-    processes=[procs.hh_vbf_hbb_hvv_kvm2p12_k2v3p87_klm5p96],
+    processes=[procs.hh_vbf_hbb_hvv_kv2p12_k2v3p87_klm5p96],
     info=dict(
         nominal=DatasetInfo(
             keys=[
@@ -258,9 +258,9 @@ cpn.add_dataset(
     ),
 )
 cpn.add_dataset(
-    name="hh_vbf_hbb_hvv2l2nu_kvm2p12_k2v3p87_klm5p96_madgraph",
+    name="hh_vbf_hbb_hvv2l2nu_kv2p12_k2v3p87_klm5p96_madgraph",
     id=14877665,
-    processes=[procs.hh_vbf_hbb_hvv2l2nu_kvm2p12_k2v3p87_klm5p96],
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kv2p12_k2v3p87_klm5p96],
     info=dict(
         nominal=DatasetInfo(
             keys=[
@@ -440,9 +440,9 @@ cpn.add_dataset(
     ),
 )
 cpn.add_dataset(
-    name="hh_vbf_hbb_hvvqqlnu_kvm2p12_k2v3p87_klm5p96_madgraph",
+    name="hh_vbf_hbb_hvvqqlnu_kv2p12_k2v3p87_klm5p96_madgraph",
     id=14877670,
-    processes=[procs.hh_vbf_hbb_hvvqqlnu_kvm2p12_k2v3p87_klm5p96],
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kv2p12_k2v3p87_klm5p96],
     info=dict(
         nominal=DatasetInfo(
             keys=[

--- a/cmsdb/campaigns/run3_2023_postBPix_nano_uhh_v14/hh2bbtautau.py
+++ b/cmsdb/campaigns/run3_2023_postBPix_nano_uhh_v14/hh2bbtautau.py
@@ -306,9 +306,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="hh_vbf_hbb_htt_kvm2p12_k2v3p87_klm5p96_madgraph",
+    name="hh_vbf_hbb_htt_kv2p12_k2v3p87_klm5p96_madgraph",
     id=14964375,
-    processes=[procs.hh_vbf_hbb_htt_kvm2p12_k2v3p87_klm5p96],
+    processes=[procs.hh_vbf_hbb_htt_kv2p12_k2v3p87_klm5p96],
     keys=[
         "/VBFHHto2B2Tau_CV_m2p12_C2V_3p87_C3_m5p96_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM",  # noqa
     ],

--- a/cmsdb/campaigns/run3_2023_postBPix_nano_uhh_v14/hh2bbvv.py
+++ b/cmsdb/campaigns/run3_2023_postBPix_nano_uhh_v14/hh2bbvv.py
@@ -354,9 +354,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="hh_vbf_hbb_hvv_kvm2p12_k2v3p87_klm5p96_madgraph",
+    name="hh_vbf_hbb_hvv_kv2p12_k2v3p87_klm5p96_madgraph",
     id=14965636,
-    processes=[procs.hh_vbf_hbb_hvv_kvm2p12_k2v3p87_klm5p96],
+    processes=[procs.hh_vbf_hbb_hvv_kv2p12_k2v3p87_klm5p96],
     keys=[
         "/VBFHHto2B2V_CV_m2p12_C2V_3p87_C3_m5p96_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM",  # noqa
     ],
@@ -514,9 +514,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="hh_vbf_hbb_hvv2l2nu_kvm2p12_k2v3p87_klm5p96_madgraph",
+    name="hh_vbf_hbb_hvv2l2nu_kv2p12_k2v3p87_klm5p96_madgraph",
     id=14965499,
-    processes=[procs.hh_vbf_hbb_hvv2l2nu_kvm2p12_k2v3p87_klm5p96],
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kv2p12_k2v3p87_klm5p96],
     keys=[
         "/VBFHHto2B2Vto2L2Nu_CV_m2p12_C2V_3p87_C3_m5p96_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM",  # noqa
     ],
@@ -674,9 +674,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="hh_vbf_hbb_hvvqqlnu_kvm2p12_k2v3p87_klm5p96_madgraph",
+    name="hh_vbf_hbb_hvvqqlnu_kv2p12_k2v3p87_klm5p96_madgraph",
     id=14960963,
-    processes=[procs.hh_vbf_hbb_hvvqqlnu_kvm2p12_k2v3p87_klm5p96],
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kv2p12_k2v3p87_klm5p96],
     keys=[
         "/VBFHHto2B2WtoLNu2Q_CV_m2p12_C2V_3p87_C3_m5p96_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM",  # noqa
     ],

--- a/cmsdb/campaigns/run3_2023_postBPix_nano_uhh_v14/hh2ml.py
+++ b/cmsdb/campaigns/run3_2023_postBPix_nano_uhh_v14/hh2ml.py
@@ -316,9 +316,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="hh_vbf_htt_htt_kvm2p12_k2v3p87_klm5p96_madgraph",
+    name="hh_vbf_htt_htt_kv2p12_k2v3p87_klm5p96_madgraph",
     id=14962114,
-    processes=[procs.hh_vbf_htt_htt_kvm2p12_k2v3p87_klm5p96],
+    processes=[procs.hh_vbf_htt_htt_kv2p12_k2v3p87_klm5p96],
     keys=[
         "/VBFHHto4Tau_CV_m2p12_C2V_3p87_C3_m5p96_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM",  # noqa
     ],
@@ -464,9 +464,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="hh_vbf_hvv_hvv_kvm2p12_k2v3p87_klm5p96_madgraph",
+    name="hh_vbf_hvv_hvv_kv2p12_k2v3p87_klm5p96_madgraph",
     id=14961385,
-    processes=[procs.hh_vbf_hvv_hvv_kvm2p12_k2v3p87_klm5p96],
+    processes=[procs.hh_vbf_hvv_hvv_kv2p12_k2v3p87_klm5p96],
     keys=[
         "/VBFHHto4V_CV_m2p12_C2V_3p87_C3_m5p96_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM",  # noqa
     ],
@@ -612,9 +612,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="hh_vbf_htt_hvv_kvm2p12_k2v3p87_klm5p96_madgraph",
+    name="hh_vbf_htt_hvv_kv2p12_k2v3p87_klm5p96_madgraph",
     id=14963039,
-    processes=[procs.hh_vbf_htt_hvv_kvm2p12_k2v3p87_klm5p96],
+    processes=[procs.hh_vbf_htt_hvv_kv2p12_k2v3p87_klm5p96],
     keys=[
         "/VBFHHto2Tau2V_CV_m2p12_C2V_3p87_C3_m5p96_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM",  # noqa
     ],

--- a/cmsdb/campaigns/run3_2023_postBPix_nano_v13/hh2bbtautau.py
+++ b/cmsdb/campaigns/run3_2023_postBPix_nano_v13/hh2bbtautau.py
@@ -117,9 +117,9 @@ cpn.add_dataset(
     n_events=1306333,
 )
 cpn.add_dataset(
-    name="hh_vbf_hbb_htt_kvm2p12_k2v3p87_klm5p96_madgraph",
+    name="hh_vbf_hbb_htt_kv2p12_k2v3p87_klm5p96_madgraph",
     id=14964374,
-    processes=[procs.hh_vbf_hbb_htt_kvm2p12_k2v3p87_klm5p96],
+    processes=[procs.hh_vbf_hbb_htt_kv2p12_k2v3p87_klm5p96],
     keys=[
         "/VBFHHto2B2Tau_CV_m2p12_C2V_3p87_C3_m5p96_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23BPixNanoAODv13-133X_mcRun3_2023_realistic_postBPix_ForNanov13_v2-v2/NANOAODSIM",  # noqa
     ],

--- a/cmsdb/campaigns/run3_2023_postBPix_nano_v13/hh2bbvv.py
+++ b/cmsdb/campaigns/run3_2023_postBPix_nano_v13/hh2bbvv.py
@@ -243,9 +243,9 @@ cpn.add_dataset(
     ),
 )
 cpn.add_dataset(
-    name="hh_vbf_hbb_hvv_kvm2p12_k2v3p87_klm5p96_madgraph",
+    name="hh_vbf_hbb_hvv_kv2p12_k2v3p87_klm5p96_madgraph",
     id=14965637,
-    processes=[procs.hh_vbf_hbb_hvv_kvm2p12_k2v3p87_klm5p96],
+    processes=[procs.hh_vbf_hbb_hvv_kv2p12_k2v3p87_klm5p96],
     info=dict(
         nominal=DatasetInfo(
             keys=[
@@ -397,9 +397,9 @@ cpn.add_dataset(
     ),
 )
 cpn.add_dataset(
-    name="hh_vbf_hbb_hvv2l2nu_kvm2p12_k2v3p87_klm5p96_madgraph",
+    name="hh_vbf_hbb_hvv2l2nu_kv2p12_k2v3p87_klm5p96_madgraph",
     id=14965571,
-    processes=[procs.hh_vbf_hbb_hvv2l2nu_kvm2p12_k2v3p87_klm5p96],
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kv2p12_k2v3p87_klm5p96],
     info=dict(
         nominal=DatasetInfo(
             keys=[
@@ -453,9 +453,9 @@ cpn.add_dataset(
     ),
 )
 cpn.add_dataset(
-    name="hh_vbf_hbb_hvvqqlnu_kvm2p12_k2v3p87_klm5p96_madgraph",
+    name="hh_vbf_hbb_hvvqqlnu_kv2p12_k2v3p87_klm5p96_madgraph",
     id=14960962,
-    processes=[procs.hh_vbf_hbb_hvvqqlnu_kvm2p12_k2v3p87_klm5p96],
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kv2p12_k2v3p87_klm5p96],
     info=dict(
         nominal=DatasetInfo(
             keys=[

--- a/cmsdb/campaigns/run3_2023_preBPix_nano_uhh_v14/hh2bbtautau.py
+++ b/cmsdb/campaigns/run3_2023_preBPix_nano_uhh_v14/hh2bbtautau.py
@@ -306,9 +306,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="hh_vbf_hbb_htt_kvm2p12_k2v3p87_klm5p96_madgraph",
+    name="hh_vbf_hbb_htt_kv2p12_k2v3p87_klm5p96_madgraph",
     id=14966453,
-    processes=[procs.hh_vbf_hbb_htt_kvm2p12_k2v3p87_klm5p96],
+    processes=[procs.hh_vbf_hbb_htt_kv2p12_k2v3p87_klm5p96],
     keys=[
         "/VBFHHto2B2Tau_CV_m2p12_C2V_3p87_C3_m5p96_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM",  # noqa
     ],

--- a/cmsdb/campaigns/run3_2023_preBPix_nano_uhh_v14/hh2bbvv.py
+++ b/cmsdb/campaigns/run3_2023_preBPix_nano_uhh_v14/hh2bbvv.py
@@ -354,9 +354,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="hh_vbf_hbb_hvv_kvm2p12_k2v3p87_klm5p96_madgraph",
+    name="hh_vbf_hbb_hvv_kv2p12_k2v3p87_klm5p96_madgraph",
     id=14966434,
-    processes=[procs.hh_vbf_hbb_hvv_kvm2p12_k2v3p87_klm5p96],
+    processes=[procs.hh_vbf_hbb_hvv_kv2p12_k2v3p87_klm5p96],
     keys=[
         "/VBFHHto2B2V_CV_m2p12_C2V_3p87_C3_m5p96_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM",  # noqa
     ],
@@ -514,9 +514,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="hh_vbf_hbb_hvv2l2nu_kvm2p12_k2v3p87_klm5p96_madgraph",
+    name="hh_vbf_hbb_hvv2l2nu_kv2p12_k2v3p87_klm5p96_madgraph",
     id=14966238,
-    processes=[procs.hh_vbf_hbb_hvv2l2nu_kvm2p12_k2v3p87_klm5p96],
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kv2p12_k2v3p87_klm5p96],
     keys=[
         "/VBFHHto2B2Vto2L2Nu_CV_m2p12_C2V_3p87_C3_m5p96_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM",  # noqa
     ],
@@ -674,9 +674,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="hh_vbf_hbb_hvvqqlnu_kvm2p12_k2v3p87_klm5p96_madgraph",
+    name="hh_vbf_hbb_hvvqqlnu_kv2p12_k2v3p87_klm5p96_madgraph",
     id=14966353,
-    processes=[procs.hh_vbf_hbb_hvvqqlnu_kvm2p12_k2v3p87_klm5p96],
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kv2p12_k2v3p87_klm5p96],
     keys=[
         "/VBFHHto2B2WtoLNu2Q_CV_m2p12_C2V_3p87_C3_m5p96_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM",  # noqa
     ],

--- a/cmsdb/campaigns/run3_2023_preBPix_nano_uhh_v14/hh2ml.py
+++ b/cmsdb/campaigns/run3_2023_preBPix_nano_uhh_v14/hh2ml.py
@@ -314,9 +314,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="hh_vbf_htt_htt_kvm2p12_k2v3p87_klm5p96_madgraph",
+    name="hh_vbf_htt_htt_kv2p12_k2v3p87_klm5p96_madgraph",
     id=14966401,
-    processes=[procs.hh_vbf_htt_htt_kvm2p12_k2v3p87_klm5p96],
+    processes=[procs.hh_vbf_htt_htt_kv2p12_k2v3p87_klm5p96],
     keys=[
         "/VBFHHto4Tau_CV_m2p12_C2V_3p87_C3_m5p96_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM",  # noqa
     ],
@@ -462,9 +462,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="hh_vbf_hvv_hvv_kvm2p12_k2v3p87_klm5p96_madgraph",
+    name="hh_vbf_hvv_hvv_kv2p12_k2v3p87_klm5p96_madgraph",
     id=14966382,
-    processes=[procs.hh_vbf_hvv_hvv_kvm2p12_k2v3p87_klm5p96],
+    processes=[procs.hh_vbf_hvv_hvv_kv2p12_k2v3p87_klm5p96],
     keys=[
         "/VBFHHto4V_CV_m2p12_C2V_3p87_C3_m5p96_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM",  # noqa
     ],
@@ -610,9 +610,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="hh_vbf_htt_hvv_kvm2p12_k2v3p87_klm5p96_madgraph",
+    name="hh_vbf_htt_hvv_kv2p12_k2v3p87_klm5p96_madgraph",
     id=14966806,
-    processes=[procs.hh_vbf_htt_hvv_kvm2p12_k2v3p87_klm5p96],
+    processes=[procs.hh_vbf_htt_hvv_kv2p12_k2v3p87_klm5p96],
     keys=[
         "/VBFHHto2Tau2V_CV_m2p12_C2V_3p87_C3_m5p96_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM",  # noqa
     ],

--- a/cmsdb/campaigns/run3_2023_preBPix_nano_v13/hh2bbtautau.py
+++ b/cmsdb/campaigns/run3_2023_preBPix_nano_v13/hh2bbtautau.py
@@ -117,9 +117,9 @@ cpn.add_dataset(
     n_events=2666667,
 )
 cpn.add_dataset(
-    name="hh_vbf_hbb_htt_kvm2p12_k2v3p87_klm5p96_madgraph",
+    name="hh_vbf_hbb_htt_kv2p12_k2v3p87_klm5p96_madgraph",
     id=14966454,
-    processes=[procs.hh_vbf_hbb_htt_kvm2p12_k2v3p87_klm5p96],
+    processes=[procs.hh_vbf_hbb_htt_kv2p12_k2v3p87_klm5p96],
     keys=[
         "/VBFHHto2B2Tau_CV_m2p12_C2V_3p87_C3_m5p96_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23NanoAODv13-133X_mcRun3_2023_realistic_ForNanov13_v1-v2/NANOAODSIM",  # noqa
     ],

--- a/cmsdb/campaigns/run3_2023_preBPix_nano_v13/hh2bbvv.py
+++ b/cmsdb/campaigns/run3_2023_preBPix_nano_v13/hh2bbvv.py
@@ -243,9 +243,9 @@ cpn.add_dataset(
     ),
 )
 cpn.add_dataset(
-    name="hh_vbf_hbb_hvv_kvm2p12_k2v3p87_klm5p96_madgraph",
+    name="hh_vbf_hbb_hvv_kv2p12_k2v3p87_klm5p96_madgraph",
     id=14966436,
-    processes=[procs.hh_vbf_hbb_hvv_kvm2p12_k2v3p87_klm5p96],
+    processes=[procs.hh_vbf_hbb_hvv_kv2p12_k2v3p87_klm5p96],
     info=dict(
         nominal=DatasetInfo(
             keys=[
@@ -397,9 +397,9 @@ cpn.add_dataset(
     ),
 )
 cpn.add_dataset(
-    name="hh_vbf_hbb_hvv2l2nu_kvm2p12_k2v3p87_klm5p96_madgraph",
+    name="hh_vbf_hbb_hvv2l2nu_kv2p12_k2v3p87_klm5p96_madgraph",
     id=14966240,
-    processes=[procs.hh_vbf_hbb_hvv2l2nu_kvm2p12_k2v3p87_klm5p96],
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kv2p12_k2v3p87_klm5p96],
     info=dict(
         nominal=DatasetInfo(
             keys=[
@@ -453,9 +453,9 @@ cpn.add_dataset(
     ),
 )
 cpn.add_dataset(
-    name="hh_vbf_hbb_hvvqqlnu_kvm2p12_k2v3p87_klm5p96_madgraph",
+    name="hh_vbf_hbb_hvvqqlnu_kv2p12_k2v3p87_klm5p96_madgraph",
     id=14966356,
-    processes=[procs.hh_vbf_hbb_hvvqqlnu_kvm2p12_k2v3p87_klm5p96],
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kv2p12_k2v3p87_klm5p96],
     info=dict(
         nominal=DatasetInfo(
             keys=[

--- a/cmsdb/processes/hh.py
+++ b/cmsdb/processes/hh.py
@@ -373,7 +373,7 @@ hh_vbf_kv2p12_k2v3p87_klm5p96 = hh_vbf.add_process(
     xsecs={
         # no 13p0TeV sample generated, but we could use the scaling formula in the hh tools
         # 13: Number(TODO, hh_vbf_uncs_13p0) * 0.001,
-        13.6: Number(671.9 * hh_vbf_k_13p6, hh_vbf_uncs_13p6) * 0.001,  # TODO: need to check this value
+        13.6: Number(671.9 * hh_vbf_k_13p6, hh_vbf_uncs_13p6) * 0.001,
     },
     aux={"production_mode_parent": hh_vbf},
 )

--- a/cmsdb/processes/hh.py
+++ b/cmsdb/processes/hh.py
@@ -39,7 +39,7 @@ __all__ = [
     "hh_vbf_kv1p74_k2v1p37_kl14p4", "hh_vbf_kvm0p012_k2v0p03_kl10p2",
     "hh_vbf_kvm0p758_k2v1p44_klm19p3", "hh_vbf_kvm0p962_k2v0p959_klm1p43",
     "hh_vbf_kvm1p21_k2v1p94_klm0p94", "hh_vbf_kvm1p6_k2v2p72_klm1p36",
-    "hh_vbf_kvm1p83_k2v3p57_klm3p39", "hh_vbf_kvm2p12_k2v3p87_klm5p96",
+    "hh_vbf_kvm1p83_k2v3p57_klm3p39", "hh_vbf_kv2p12_k2v3p87_klm5p96",
     "radion_hh_ggf", "graviton_hh_ggf",
     "radion_hh_vbf", "graviton_hh_vbf",
 ]
@@ -367,13 +367,13 @@ hh_vbf_kvm1p83_k2v3p57_klm3p39 = hh_vbf.add_process(
     aux={"production_mode_parent": hh_vbf},
 )
 
-hh_vbf_kvm2p12_k2v3p87_klm5p96 = hh_vbf.add_process(
-    name="hh_vbf_kvm2p12_k2v3p87_klm5p96",
+hh_vbf_kv2p12_k2v3p87_klm5p96 = hh_vbf.add_process(
+    name="hh_vbf_kv2p12_k2v3p87_klm5p96",
     id=22015,
     xsecs={
         # no 13p0TeV sample generated, but we could use the scaling formula in the hh tools
         # 13: Number(TODO, hh_vbf_uncs_13p0) * 0.001,
-        13.6: Number(671.9 * hh_vbf_k_13p6, hh_vbf_uncs_13p6) * 0.001,
+        13.6: Number(671.9 * hh_vbf_k_13p6, hh_vbf_uncs_13p6) * 0.001,  # TODO: need to check this value
     },
     aux={"production_mode_parent": hh_vbf},
 )

--- a/cmsdb/processes/hh2bbtautau.py
+++ b/cmsdb/processes/hh2bbtautau.py
@@ -54,7 +54,7 @@ __all__ = [
     "hh_vbf_hbb_htt_kvm0p012_k2v0p03_kl10p2", "hh_vbf_hbb_htt_kvm0p758_k2v1p44_klm19p3",
     "hh_vbf_hbb_htt_kvm0p962_k2v0p959_klm1p43", "hh_vbf_hbb_htt_kvm1p21_k2v1p94_klm0p94",
     "hh_vbf_hbb_htt_kvm1p6_k2v2p72_klm1p36", "hh_vbf_hbb_htt_kvm1p83_k2v3p57_klm3p39",
-    "hh_vbf_hbb_htt_kvm2p12_k2v3p87_klm5p96",
+    "hh_vbf_hbb_htt_kv2p12_k2v3p87_klm5p96",
     "radion_hh_vbf_hbb_htt",
     "radion_hh_vbf_hbb_htt_m250", "radion_hh_vbf_hbb_htt_m260", "radion_hh_vbf_hbb_htt_m270",
     "radion_hh_vbf_hbb_htt_m280", "radion_hh_vbf_hbb_htt_m300", "radion_hh_vbf_hbb_htt_m320",
@@ -93,7 +93,7 @@ from cmsdb.processes.hh import (
     hh_vbf_kvm0p012_k2v0p03_kl10p2, hh_vbf_kvm0p758_k2v1p44_klm19p3,
     hh_vbf_kvm0p962_k2v0p959_klm1p43, hh_vbf_kvm1p21_k2v1p94_klm0p94,
     hh_vbf_kvm1p6_k2v2p72_klm1p36, hh_vbf_kvm1p83_k2v3p57_klm3p39,
-    hh_vbf_kvm2p12_k2v3p87_klm5p96,
+    hh_vbf_kv2p12_k2v3p87_klm5p96,
 )
 from cmsdb.xsec_bsm_nodes import calculate_xsec_node
 from cmsdb.util import multiply_xsecs
@@ -824,11 +824,11 @@ hh_vbf_hbb_htt_kvm1p83_k2v3p57_klm3p39 = hh_vbf_kvm1p83_k2v3p57_klm3p39.add_proc
     xsecs=multiply_xsecs(hh_vbf_kvm1p83_k2v3p57_klm3p39, const.br_hh.bbtt),
 )
 
-hh_vbf_hbb_htt_kvm2p12_k2v3p87_klm5p96 = hh_vbf_kvm2p12_k2v3p87_klm5p96.add_process(
-    name="hh_vbf_hbb_htt_kvm2p12_k2v3p87_klm5p96",
+hh_vbf_hbb_htt_kv2p12_k2v3p87_klm5p96 = hh_vbf_kv2p12_k2v3p87_klm5p96.add_process(
+    name="hh_vbf_hbb_htt_kv2p12_k2v3p87_klm5p96",
     id=22112,
-    label=r"$HH_{vbf} \rightarrow bb\tau\tau$ ($\kappa_{V}=-2.12$, $\kappa_{2V}=3.87$, $\kappa_{\lambda}=-5.96$)",
-    xsecs=multiply_xsecs(hh_vbf_kvm2p12_k2v3p87_klm5p96, const.br_hh.bbtt),
+    label=r"$HH_{vbf} \rightarrow bb\tau\tau$ ($\kappa_{V}=2.12$, $\kappa_{2V}=3.87$, $\kappa_{\lambda}=-5.96$)",
+    xsecs=multiply_xsecs(hh_vbf_kv2p12_k2v3p87_klm5p96, const.br_hh.bbtt),
 )
 
 #

--- a/cmsdb/processes/hh2bbvv.py
+++ b/cmsdb/processes/hh2bbvv.py
@@ -34,7 +34,7 @@ vbf_params = [
     "_kv1_k2v2_kl1", "_kv0p5_k2v1_kl1", "_kv1p5_k2v1_kl1",
     "_kv1p74_k2v1p37_kl14p4", "_kvm0p012_k2v0p03_kl10p2", "_kvm0p758_k2v1p44_klm19p3",
     "_kvm0p962_k2v0p959_klm1p43", "_kvm1p21_k2v1p94_klm0p94", "_kvm1p6_k2v2p72_klm1p36",
-    "_kvm1p83_k2v3p57_klm3p39", "_kvm2p12_k2v3p87_klm5p96",
+    "_kvm1p83_k2v3p57_klm3p39", "_kv2p12_k2v3p87_klm5p96",
 ]
 vv_decay_modes = ["", "qqlnu", "2l2nu", "4q", "2q2nu", "4nu", "4l", "2l2q"]
 ww_decay_modes = ["", "qqlnu", "2l2nu", "4q"]
@@ -103,7 +103,7 @@ from cmsdb.processes.hh import (
     hh_vbf_kv1_k2v0_kl1, hh_vbf_kv1_k2v2_kl1, hh_vbf_kv0p5_k2v1_kl1, hh_vbf_kv1p5_k2v1_kl1,
     hh_vbf_kv1p74_k2v1p37_kl14p4, hh_vbf_kvm0p012_k2v0p03_kl10p2, hh_vbf_kvm0p758_k2v1p44_klm19p3,
     hh_vbf_kvm0p962_k2v0p959_klm1p43, hh_vbf_kvm1p21_k2v1p94_klm0p94, hh_vbf_kvm1p6_k2v2p72_klm1p36,
-    hh_vbf_kvm1p83_k2v3p57_klm3p39, hh_vbf_kvm2p12_k2v3p87_klm5p96,
+    hh_vbf_kvm1p83_k2v3p57_klm3p39, hh_vbf_kv2p12_k2v3p87_klm5p96,
     radion_hh_ggf, graviton_hh_ggf,
 )
 
@@ -278,7 +278,7 @@ hh_vbf_hbb_hvv_kvm0p962_k2v0p959_klm1p43 = add_bbvv_decay_process(hh_vbf_kvm0p96
 hh_vbf_hbb_hvv_kvm1p21_k2v1p94_klm0p94 = add_bbvv_decay_process(hh_vbf_kvm1p21_k2v1p94_klm0p94, hh_decay_map.hbb_hvv)
 hh_vbf_hbb_hvv_kvm1p6_k2v2p72_klm1p36 = add_bbvv_decay_process(hh_vbf_kvm1p6_k2v2p72_klm1p36, hh_decay_map.hbb_hvv)
 hh_vbf_hbb_hvv_kvm1p83_k2v3p57_klm3p39 = add_bbvv_decay_process(hh_vbf_kvm1p83_k2v3p57_klm3p39, hh_decay_map.hbb_hvv)
-hh_vbf_hbb_hvv_kvm2p12_k2v3p87_klm5p96 = add_bbvv_decay_process(hh_vbf_kvm2p12_k2v3p87_klm5p96, hh_decay_map.hbb_hvv)
+hh_vbf_hbb_hvv_kv2p12_k2v3p87_klm5p96 = add_bbvv_decay_process(hh_vbf_kv2p12_k2v3p87_klm5p96, hh_decay_map.hbb_hvv)
 
 ####################################################################################################
 #
@@ -307,7 +307,7 @@ hh_vbf_hbb_hww_kvm0p962_k2v0p959_klm1p43 = add_hvv_decay(hh_vbf_hbb_hvv_kvm0p962
 hh_vbf_hbb_hww_kvm1p21_k2v1p94_klm0p94 = add_hvv_decay(hh_vbf_hbb_hvv_kvm1p21_k2v1p94_klm0p94, hh_decay_map.hbb_hww)
 hh_vbf_hbb_hww_kvm1p6_k2v2p72_klm1p36 = add_hvv_decay(hh_vbf_hbb_hvv_kvm1p6_k2v2p72_klm1p36, hh_decay_map.hbb_hww)
 hh_vbf_hbb_hww_kvm1p83_k2v3p57_klm3p39 = add_hvv_decay(hh_vbf_hbb_hvv_kvm1p83_k2v3p57_klm3p39, hh_decay_map.hbb_hww)
-hh_vbf_hbb_hww_kvm2p12_k2v3p87_klm5p96 = add_hvv_decay(hh_vbf_hbb_hvv_kvm2p12_k2v3p87_klm5p96, hh_decay_map.hbb_hww)
+hh_vbf_hbb_hww_kv2p12_k2v3p87_klm5p96 = add_hvv_decay(hh_vbf_hbb_hvv_kv2p12_k2v3p87_klm5p96, hh_decay_map.hbb_hww)
 
 ####################################################################################################
 #
@@ -336,7 +336,7 @@ hh_vbf_hbb_hzz_kvm0p962_k2v0p959_klm1p43 = add_hvv_decay(hh_vbf_hbb_hvv_kvm0p962
 hh_vbf_hbb_hzz_kvm1p21_k2v1p94_klm0p94 = add_hvv_decay(hh_vbf_hbb_hvv_kvm1p21_k2v1p94_klm0p94, hh_decay_map.hbb_hzz)
 hh_vbf_hbb_hzz_kvm1p6_k2v2p72_klm1p36 = add_hvv_decay(hh_vbf_hbb_hvv_kvm1p6_k2v2p72_klm1p36, hh_decay_map.hbb_hzz)
 hh_vbf_hbb_hzz_kvm1p83_k2v3p57_klm3p39 = add_hvv_decay(hh_vbf_hbb_hvv_kvm1p83_k2v3p57_klm3p39, hh_decay_map.hbb_hzz)
-hh_vbf_hbb_hzz_kvm2p12_k2v3p87_klm5p96 = add_hvv_decay(hh_vbf_hbb_hvv_kvm2p12_k2v3p87_klm5p96, hh_decay_map.hbb_hzz)
+hh_vbf_hbb_hzz_kv2p12_k2v3p87_klm5p96 = add_hvv_decay(hh_vbf_hbb_hvv_kv2p12_k2v3p87_klm5p96, hh_decay_map.hbb_hzz)
 
 #
 # assign cross sections to HH -> bbVV processes
@@ -382,7 +382,7 @@ hh_vbf_hbb_hvvqqlnu_kvm0p962_k2v0p959_klm1p43 = add_bbvv_sub_decay(hh_vbf_hbb_hv
 hh_vbf_hbb_hvvqqlnu_kvm1p21_k2v1p94_klm0p94 = add_bbvv_sub_decay(hh_vbf_hbb_hvv_kvm1p21_k2v1p94_klm0p94, vv_decay_map["qqlnu"])  # noqa
 hh_vbf_hbb_hvvqqlnu_kvm1p6_k2v2p72_klm1p36 = add_bbvv_sub_decay(hh_vbf_hbb_hvv_kvm1p6_k2v2p72_klm1p36, vv_decay_map["qqlnu"])  # noqa
 hh_vbf_hbb_hvvqqlnu_kvm1p83_k2v3p57_klm3p39 = add_bbvv_sub_decay(hh_vbf_hbb_hvv_kvm1p83_k2v3p57_klm3p39, vv_decay_map["qqlnu"])  # noqa
-hh_vbf_hbb_hvvqqlnu_kvm2p12_k2v3p87_klm5p96 = add_bbvv_sub_decay(hh_vbf_hbb_hvv_kvm2p12_k2v3p87_klm5p96, vv_decay_map["qqlnu"])  # noqa
+hh_vbf_hbb_hvvqqlnu_kv2p12_k2v3p87_klm5p96 = add_bbvv_sub_decay(hh_vbf_hbb_hvv_kv2p12_k2v3p87_klm5p96, vv_decay_map["qqlnu"])  # noqa
 
 hh_ggf_hbb_hvv2l2nu = add_bbvv_sub_decay(hh_ggf_hbb_hvv, vv_decay_map["2l2nu"], add_production_mode_parent=False)
 hh_ggf_hbb_hvv2l2nu_kl0_kt1 = add_bbvv_sub_decay(hh_ggf_hbb_hvv_kl0_kt1, vv_decay_map["2l2nu"])
@@ -405,7 +405,7 @@ hh_vbf_hbb_hvv2l2nu_kvm0p962_k2v0p959_klm1p43 = add_bbvv_sub_decay(hh_vbf_hbb_hv
 hh_vbf_hbb_hvv2l2nu_kvm1p21_k2v1p94_klm0p94 = add_bbvv_sub_decay(hh_vbf_hbb_hvv_kvm1p21_k2v1p94_klm0p94, vv_decay_map["2l2nu"])  # noqa
 hh_vbf_hbb_hvv2l2nu_kvm1p6_k2v2p72_klm1p36 = add_bbvv_sub_decay(hh_vbf_hbb_hvv_kvm1p6_k2v2p72_klm1p36, vv_decay_map["2l2nu"])  # noqa
 hh_vbf_hbb_hvv2l2nu_kvm1p83_k2v3p57_klm3p39 = add_bbvv_sub_decay(hh_vbf_hbb_hvv_kvm1p83_k2v3p57_klm3p39, vv_decay_map["2l2nu"])  # noqa
-hh_vbf_hbb_hvv2l2nu_kvm2p12_k2v3p87_klm5p96 = add_bbvv_sub_decay(hh_vbf_hbb_hvv_kvm2p12_k2v3p87_klm5p96, vv_decay_map["2l2nu"])  # noqa
+hh_vbf_hbb_hvv2l2nu_kv2p12_k2v3p87_klm5p96 = add_bbvv_sub_decay(hh_vbf_hbb_hvv_kv2p12_k2v3p87_klm5p96, vv_decay_map["2l2nu"])  # noqa
 
 
 hh_ggf_hbb_hvv4q = add_bbvv_sub_decay(hh_ggf_hbb_hvv, vv_decay_map["4q"], add_production_mode_parent=False)
@@ -429,7 +429,7 @@ hh_vbf_hbb_hvv4q_kvm0p962_k2v0p959_klm1p43 = add_bbvv_sub_decay(hh_vbf_hbb_hvv_k
 hh_vbf_hbb_hvv4q_kvm1p21_k2v1p94_klm0p94 = add_bbvv_sub_decay(hh_vbf_hbb_hvv_kvm1p21_k2v1p94_klm0p94, vv_decay_map["4q"])  # noqa
 hh_vbf_hbb_hvv4q_kvm1p6_k2v2p72_klm1p36 = add_bbvv_sub_decay(hh_vbf_hbb_hvv_kvm1p6_k2v2p72_klm1p36, vv_decay_map["4q"])  # noqa
 hh_vbf_hbb_hvv4q_kvm1p83_k2v3p57_klm3p39 = add_bbvv_sub_decay(hh_vbf_hbb_hvv_kvm1p83_k2v3p57_klm3p39, vv_decay_map["4q"])  # noqa
-hh_vbf_hbb_hvv4q_kvm2p12_k2v3p87_klm5p96 = add_bbvv_sub_decay(hh_vbf_hbb_hvv_kvm2p12_k2v3p87_klm5p96, vv_decay_map["4q"])  # noqa
+hh_vbf_hbb_hvv4q_kv2p12_k2v3p87_klm5p96 = add_bbvv_sub_decay(hh_vbf_hbb_hvv_kv2p12_k2v3p87_klm5p96, vv_decay_map["4q"])  # noqa
 
 hh_ggf_hbb_hvv2q2nu = add_bbvv_sub_decay(hh_ggf_hbb_hvv, vv_decay_map["2q2nu"], add_production_mode_parent=False)
 hh_ggf_hbb_hvv2q2nu_kl0_kt1 = add_bbvv_sub_decay(hh_ggf_hbb_hvv_kl0_kt1, vv_decay_map["2q2nu"])
@@ -452,7 +452,7 @@ hh_vbf_hbb_hvv2q2nu_kvm0p962_k2v0p959_klm1p43 = add_bbvv_sub_decay(hh_vbf_hbb_hv
 hh_vbf_hbb_hvv2q2nu_kvm1p21_k2v1p94_klm0p94 = add_bbvv_sub_decay(hh_vbf_hbb_hvv_kvm1p21_k2v1p94_klm0p94, vv_decay_map["2q2nu"])  # noqa
 hh_vbf_hbb_hvv2q2nu_kvm1p6_k2v2p72_klm1p36 = add_bbvv_sub_decay(hh_vbf_hbb_hvv_kvm1p6_k2v2p72_klm1p36, vv_decay_map["2q2nu"])  # noqa
 hh_vbf_hbb_hvv2q2nu_kvm1p83_k2v3p57_klm3p39 = add_bbvv_sub_decay(hh_vbf_hbb_hvv_kvm1p83_k2v3p57_klm3p39, vv_decay_map["2q2nu"])  # noqa
-hh_vbf_hbb_hvv2q2nu_kvm2p12_k2v3p87_klm5p96 = add_bbvv_sub_decay(hh_vbf_hbb_hvv_kvm2p12_k2v3p87_klm5p96, vv_decay_map["2q2nu"])  # noqa
+hh_vbf_hbb_hvv2q2nu_kv2p12_k2v3p87_klm5p96 = add_bbvv_sub_decay(hh_vbf_hbb_hvv_kv2p12_k2v3p87_klm5p96, vv_decay_map["2q2nu"])  # noqa
 
 hh_ggf_hbb_hvv4nu = add_bbvv_sub_decay(hh_ggf_hbb_hvv, vv_decay_map["4nu"], add_production_mode_parent=False)
 hh_ggf_hbb_hvv4nu_kl0_kt1 = add_bbvv_sub_decay(hh_ggf_hbb_hvv_kl0_kt1, vv_decay_map["4nu"])
@@ -475,7 +475,7 @@ hh_vbf_hbb_hvv4nu_kvm0p962_k2v0p959_klm1p43 = add_bbvv_sub_decay(hh_vbf_hbb_hvv_
 hh_vbf_hbb_hvv4nu_kvm1p21_k2v1p94_klm0p94 = add_bbvv_sub_decay(hh_vbf_hbb_hvv_kvm1p21_k2v1p94_klm0p94, vv_decay_map["4nu"])  # noqa
 hh_vbf_hbb_hvv4nu_kvm1p6_k2v2p72_klm1p36 = add_bbvv_sub_decay(hh_vbf_hbb_hvv_kvm1p6_k2v2p72_klm1p36, vv_decay_map["4nu"])  # noqa
 hh_vbf_hbb_hvv4nu_kvm1p83_k2v3p57_klm3p39 = add_bbvv_sub_decay(hh_vbf_hbb_hvv_kvm1p83_k2v3p57_klm3p39, vv_decay_map["4nu"])  # noqa
-hh_vbf_hbb_hvv4nu_kvm2p12_k2v3p87_klm5p96 = add_bbvv_sub_decay(hh_vbf_hbb_hvv_kvm2p12_k2v3p87_klm5p96, vv_decay_map["4nu"])  # noqa
+hh_vbf_hbb_hvv4nu_kv2p12_k2v3p87_klm5p96 = add_bbvv_sub_decay(hh_vbf_hbb_hvv_kv2p12_k2v3p87_klm5p96, vv_decay_map["4nu"])  # noqa
 
 hh_ggf_hbb_hvv4l = add_bbvv_sub_decay(hh_ggf_hbb_hvv, vv_decay_map["4l"], add_production_mode_parent=False)
 hh_ggf_hbb_hvv4l_kl0_kt1 = add_bbvv_sub_decay(hh_ggf_hbb_hvv_kl0_kt1, vv_decay_map["4l"])
@@ -498,7 +498,7 @@ hh_vbf_hbb_hvv4l_kvm0p962_k2v0p959_klm1p43 = add_bbvv_sub_decay(hh_vbf_hbb_hvv_k
 hh_vbf_hbb_hvv4l_kvm1p21_k2v1p94_klm0p94 = add_bbvv_sub_decay(hh_vbf_hbb_hvv_kvm1p21_k2v1p94_klm0p94, vv_decay_map["4l"])  # noqa
 hh_vbf_hbb_hvv4l_kvm1p6_k2v2p72_klm1p36 = add_bbvv_sub_decay(hh_vbf_hbb_hvv_kvm1p6_k2v2p72_klm1p36, vv_decay_map["4l"])  # noqa
 hh_vbf_hbb_hvv4l_kvm1p83_k2v3p57_klm3p39 = add_bbvv_sub_decay(hh_vbf_hbb_hvv_kvm1p83_k2v3p57_klm3p39, vv_decay_map["4l"])  # noqa
-hh_vbf_hbb_hvv4l_kvm2p12_k2v3p87_klm5p96 = add_bbvv_sub_decay(hh_vbf_hbb_hvv_kvm2p12_k2v3p87_klm5p96, vv_decay_map["4l"])  # noqa
+hh_vbf_hbb_hvv4l_kv2p12_k2v3p87_klm5p96 = add_bbvv_sub_decay(hh_vbf_hbb_hvv_kv2p12_k2v3p87_klm5p96, vv_decay_map["4l"])  # noqa
 
 hh_ggf_hbb_hvv2l2q = add_bbvv_sub_decay(hh_ggf_hbb_hvv, vv_decay_map["2l2q"], add_production_mode_parent=False)
 hh_ggf_hbb_hvv2l2q_kl0_kt1 = add_bbvv_sub_decay(hh_ggf_hbb_hvv_kl0_kt1, vv_decay_map["2l2q"])
@@ -521,7 +521,7 @@ hh_vbf_hbb_hvv2l2q_kvm0p962_k2v0p959_klm1p43 = add_bbvv_sub_decay(hh_vbf_hbb_hvv
 hh_vbf_hbb_hvv2l2q_kvm1p21_k2v1p94_klm0p94 = add_bbvv_sub_decay(hh_vbf_hbb_hvv_kvm1p21_k2v1p94_klm0p94, vv_decay_map["2l2q"])  # noqa
 hh_vbf_hbb_hvv2l2q_kvm1p6_k2v2p72_klm1p36 = add_bbvv_sub_decay(hh_vbf_hbb_hvv_kvm1p6_k2v2p72_klm1p36, vv_decay_map["2l2q"])  # noqa
 hh_vbf_hbb_hvv2l2q_kvm1p83_k2v3p57_klm3p39 = add_bbvv_sub_decay(hh_vbf_hbb_hvv_kvm1p83_k2v3p57_klm3p39, vv_decay_map["2l2q"])  # noqa
-hh_vbf_hbb_hvv2l2q_kvm2p12_k2v3p87_klm5p96 = add_bbvv_sub_decay(hh_vbf_hbb_hvv_kvm2p12_k2v3p87_klm5p96, vv_decay_map["2l2q"])  # noqa
+hh_vbf_hbb_hvv2l2q_kv2p12_k2v3p87_klm5p96 = add_bbvv_sub_decay(hh_vbf_hbb_hvv_kv2p12_k2v3p87_klm5p96, vv_decay_map["2l2q"])  # noqa
 
 ####################################################################################################
 #
@@ -550,7 +550,7 @@ hh_vbf_hbb_hww2l2nu_kvm0p962_k2v0p959_klm1p43 = add_bbvv_sub_decay(hh_vbf_hbb_hw
 hh_vbf_hbb_hww2l2nu_kvm1p21_k2v1p94_klm0p94 = add_bbvv_sub_decay(hh_vbf_hbb_hww_kvm1p21_k2v1p94_klm0p94, ww_decay_map["2l2nu"])  # noqa
 hh_vbf_hbb_hww2l2nu_kvm1p6_k2v2p72_klm1p36 = add_bbvv_sub_decay(hh_vbf_hbb_hww_kvm1p6_k2v2p72_klm1p36, ww_decay_map["2l2nu"])  # noqa
 hh_vbf_hbb_hww2l2nu_kvm1p83_k2v3p57_klm3p39 = add_bbvv_sub_decay(hh_vbf_hbb_hww_kvm1p83_k2v3p57_klm3p39, ww_decay_map["2l2nu"])  # noqa
-hh_vbf_hbb_hww2l2nu_kvm2p12_k2v3p87_klm5p96 = add_bbvv_sub_decay(hh_vbf_hbb_hww_kvm2p12_k2v3p87_klm5p96, ww_decay_map["2l2nu"])  # noqa
+hh_vbf_hbb_hww2l2nu_kv2p12_k2v3p87_klm5p96 = add_bbvv_sub_decay(hh_vbf_hbb_hww_kv2p12_k2v3p87_klm5p96, ww_decay_map["2l2nu"])  # noqa
 
 hh_ggf_hbb_hwwqqlnu = add_bbvv_sub_decay(hh_ggf_hbb_hww, ww_decay_map["qqlnu"])
 hh_ggf_hbb_hwwqqlnu_kl0_kt1 = add_bbvv_sub_decay(hh_ggf_hbb_hww_kl0_kt1, ww_decay_map["qqlnu"])
@@ -573,7 +573,7 @@ hh_vbf_hbb_hwwqqlnu_kvm0p962_k2v0p959_klm1p43 = add_bbvv_sub_decay(hh_vbf_hbb_hw
 hh_vbf_hbb_hwwqqlnu_kvm1p21_k2v1p94_klm0p94 = add_bbvv_sub_decay(hh_vbf_hbb_hww_kvm1p21_k2v1p94_klm0p94, ww_decay_map["qqlnu"])  # noqa
 hh_vbf_hbb_hwwqqlnu_kvm1p6_k2v2p72_klm1p36 = add_bbvv_sub_decay(hh_vbf_hbb_hww_kvm1p6_k2v2p72_klm1p36, ww_decay_map["qqlnu"])  # noqa
 hh_vbf_hbb_hwwqqlnu_kvm1p83_k2v3p57_klm3p39 = add_bbvv_sub_decay(hh_vbf_hbb_hww_kvm1p83_k2v3p57_klm3p39, ww_decay_map["qqlnu"])  # noqa
-hh_vbf_hbb_hwwqqlnu_kvm2p12_k2v3p87_klm5p96 = add_bbvv_sub_decay(hh_vbf_hbb_hww_kvm2p12_k2v3p87_klm5p96, ww_decay_map["qqlnu"])  # noqa
+hh_vbf_hbb_hwwqqlnu_kv2p12_k2v3p87_klm5p96 = add_bbvv_sub_decay(hh_vbf_hbb_hww_kv2p12_k2v3p87_klm5p96, ww_decay_map["qqlnu"])  # noqa
 
 hh_ggf_hbb_hww4q = add_bbvv_sub_decay(hh_ggf_hbb_hww, ww_decay_map["4q"])
 hh_ggf_hbb_hww4q_kl0_kt1 = add_bbvv_sub_decay(hh_ggf_hbb_hww_kl0_kt1, ww_decay_map["4q"])
@@ -596,7 +596,7 @@ hh_vbf_hbb_hww4q_kvm0p962_k2v0p959_klm1p43 = add_bbvv_sub_decay(hh_vbf_hbb_hww_k
 hh_vbf_hbb_hww4q_kvm1p21_k2v1p94_klm0p94 = add_bbvv_sub_decay(hh_vbf_hbb_hww_kvm1p21_k2v1p94_klm0p94, ww_decay_map["4q"])  # noqa
 hh_vbf_hbb_hww4q_kvm1p6_k2v2p72_klm1p36 = add_bbvv_sub_decay(hh_vbf_hbb_hww_kvm1p6_k2v2p72_klm1p36, ww_decay_map["4q"])  # noqa
 hh_vbf_hbb_hww4q_kvm1p83_k2v3p57_klm3p39 = add_bbvv_sub_decay(hh_vbf_hbb_hww_kvm1p83_k2v3p57_klm3p39, ww_decay_map["4q"])  # noqa
-hh_vbf_hbb_hww4q_kvm2p12_k2v3p87_klm5p96 = add_bbvv_sub_decay(hh_vbf_hbb_hww_kvm2p12_k2v3p87_klm5p96, ww_decay_map["4q"])  # noqa
+hh_vbf_hbb_hww4q_kv2p12_k2v3p87_klm5p96 = add_bbvv_sub_decay(hh_vbf_hbb_hww_kv2p12_k2v3p87_klm5p96, ww_decay_map["4q"])  # noqa
 
 ####################################################################################################
 #
@@ -625,7 +625,7 @@ hh_vbf_hbb_hzz2l2nu_kvm0p962_k2v0p959_klm1p43 = add_bbvv_sub_decay(hh_vbf_hbb_hz
 hh_vbf_hbb_hzz2l2nu_kvm1p21_k2v1p94_klm0p94 = add_bbvv_sub_decay(hh_vbf_hbb_hzz_kvm1p21_k2v1p94_klm0p94, zz_decay_map["2l2nu"])  # noqa
 hh_vbf_hbb_hzz2l2nu_kvm1p6_k2v2p72_klm1p36 = add_bbvv_sub_decay(hh_vbf_hbb_hzz_kvm1p6_k2v2p72_klm1p36, zz_decay_map["2l2nu"])  # noqa
 hh_vbf_hbb_hzz2l2nu_kvm1p83_k2v3p57_klm3p39 = add_bbvv_sub_decay(hh_vbf_hbb_hzz_kvm1p83_k2v3p57_klm3p39, zz_decay_map["2l2nu"])  # noqa
-hh_vbf_hbb_hzz2l2nu_kvm2p12_k2v3p87_klm5p96 = add_bbvv_sub_decay(hh_vbf_hbb_hzz_kvm2p12_k2v3p87_klm5p96, zz_decay_map["2l2nu"])  # noqa
+hh_vbf_hbb_hzz2l2nu_kv2p12_k2v3p87_klm5p96 = add_bbvv_sub_decay(hh_vbf_hbb_hzz_kv2p12_k2v3p87_klm5p96, zz_decay_map["2l2nu"])  # noqa
 
 hh_ggf_hbb_hzz4q = add_bbvv_sub_decay(hh_ggf_hbb_hzz, zz_decay_map["4q"])
 hh_ggf_hbb_hzz4q_kl0_kt1 = add_bbvv_sub_decay(hh_ggf_hbb_hzz_kl0_kt1, zz_decay_map["4q"])
@@ -648,7 +648,7 @@ hh_vbf_hbb_hzz4q_kvm0p962_k2v0p959_klm1p43 = add_bbvv_sub_decay(hh_vbf_hbb_hzz_k
 hh_vbf_hbb_hzz4q_kvm1p21_k2v1p94_klm0p94 = add_bbvv_sub_decay(hh_vbf_hbb_hzz_kvm1p21_k2v1p94_klm0p94, zz_decay_map["4q"])  # noqa
 hh_vbf_hbb_hzz4q_kvm1p6_k2v2p72_klm1p36 = add_bbvv_sub_decay(hh_vbf_hbb_hzz_kvm1p6_k2v2p72_klm1p36, zz_decay_map["4q"])  # noqa
 hh_vbf_hbb_hzz4q_kvm1p83_k2v3p57_klm3p39 = add_bbvv_sub_decay(hh_vbf_hbb_hzz_kvm1p83_k2v3p57_klm3p39, zz_decay_map["4q"])  # noqa
-hh_vbf_hbb_hzz4q_kvm2p12_k2v3p87_klm5p96 = add_bbvv_sub_decay(hh_vbf_hbb_hzz_kvm2p12_k2v3p87_klm5p96, zz_decay_map["4q"])  # noqa
+hh_vbf_hbb_hzz4q_kv2p12_k2v3p87_klm5p96 = add_bbvv_sub_decay(hh_vbf_hbb_hzz_kv2p12_k2v3p87_klm5p96, zz_decay_map["4q"])  # noqa
 
 hh_ggf_hbb_hzz2q2nu = add_bbvv_sub_decay(hh_ggf_hbb_hzz, zz_decay_map["2q2nu"])
 hh_ggf_hbb_hzz2q2nu_kl0_kt1 = add_bbvv_sub_decay(hh_ggf_hbb_hzz_kl0_kt1, zz_decay_map["2q2nu"])
@@ -671,7 +671,7 @@ hh_vbf_hbb_hzz2q2nu_kvm0p962_k2v0p959_klm1p43 = add_bbvv_sub_decay(hh_vbf_hbb_hz
 hh_vbf_hbb_hzz2q2nu_kvm1p21_k2v1p94_klm0p94 = add_bbvv_sub_decay(hh_vbf_hbb_hzz_kvm1p21_k2v1p94_klm0p94, zz_decay_map["2q2nu"])  # noqa
 hh_vbf_hbb_hzz2q2nu_kvm1p6_k2v2p72_klm1p36 = add_bbvv_sub_decay(hh_vbf_hbb_hzz_kvm1p6_k2v2p72_klm1p36, zz_decay_map["2q2nu"])  # noqa
 hh_vbf_hbb_hzz2q2nu_kvm1p83_k2v3p57_klm3p39 = add_bbvv_sub_decay(hh_vbf_hbb_hzz_kvm1p83_k2v3p57_klm3p39, zz_decay_map["2q2nu"])  # noqa
-hh_vbf_hbb_hzz2q2nu_kvm2p12_k2v3p87_klm5p96 = add_bbvv_sub_decay(hh_vbf_hbb_hzz_kvm2p12_k2v3p87_klm5p96, zz_decay_map["2q2nu"])  # noqa
+hh_vbf_hbb_hzz2q2nu_kv2p12_k2v3p87_klm5p96 = add_bbvv_sub_decay(hh_vbf_hbb_hzz_kv2p12_k2v3p87_klm5p96, zz_decay_map["2q2nu"])  # noqa
 
 hh_ggf_hbb_hzz4nu = add_bbvv_sub_decay(hh_ggf_hbb_hzz, zz_decay_map["4nu"])
 hh_ggf_hbb_hzz4nu_kl0_kt1 = add_bbvv_sub_decay(hh_ggf_hbb_hzz_kl0_kt1, zz_decay_map["4nu"])
@@ -694,7 +694,7 @@ hh_vbf_hbb_hzz4nu_kvm0p962_k2v0p959_klm1p43 = add_bbvv_sub_decay(hh_vbf_hbb_hzz_
 hh_vbf_hbb_hzz4nu_kvm1p21_k2v1p94_klm0p94 = add_bbvv_sub_decay(hh_vbf_hbb_hzz_kvm1p21_k2v1p94_klm0p94, zz_decay_map["4nu"])  # noqa
 hh_vbf_hbb_hzz4nu_kvm1p6_k2v2p72_klm1p36 = add_bbvv_sub_decay(hh_vbf_hbb_hzz_kvm1p6_k2v2p72_klm1p36, zz_decay_map["4nu"])  # noqa
 hh_vbf_hbb_hzz4nu_kvm1p83_k2v3p57_klm3p39 = add_bbvv_sub_decay(hh_vbf_hbb_hzz_kvm1p83_k2v3p57_klm3p39, zz_decay_map["4nu"])  # noqa
-hh_vbf_hbb_hzz4nu_kvm2p12_k2v3p87_klm5p96 = add_bbvv_sub_decay(hh_vbf_hbb_hzz_kvm2p12_k2v3p87_klm5p96, zz_decay_map["4nu"])  # noqa
+hh_vbf_hbb_hzz4nu_kv2p12_k2v3p87_klm5p96 = add_bbvv_sub_decay(hh_vbf_hbb_hzz_kv2p12_k2v3p87_klm5p96, zz_decay_map["4nu"])  # noqa
 
 hh_ggf_hbb_hzz4l = add_bbvv_sub_decay(hh_ggf_hbb_hzz, zz_decay_map["4l"])
 hh_ggf_hbb_hzz4l_kl0_kt1 = add_bbvv_sub_decay(hh_ggf_hbb_hzz_kl0_kt1, zz_decay_map["4l"])
@@ -717,7 +717,7 @@ hh_vbf_hbb_hzz4l_kvm0p962_k2v0p959_klm1p43 = add_bbvv_sub_decay(hh_vbf_hbb_hzz_k
 hh_vbf_hbb_hzz4l_kvm1p21_k2v1p94_klm0p94 = add_bbvv_sub_decay(hh_vbf_hbb_hzz_kvm1p21_k2v1p94_klm0p94, zz_decay_map["4l"])  # noqa
 hh_vbf_hbb_hzz4l_kvm1p6_k2v2p72_klm1p36 = add_bbvv_sub_decay(hh_vbf_hbb_hzz_kvm1p6_k2v2p72_klm1p36, zz_decay_map["4l"])  # noqa
 hh_vbf_hbb_hzz4l_kvm1p83_k2v3p57_klm3p39 = add_bbvv_sub_decay(hh_vbf_hbb_hzz_kvm1p83_k2v3p57_klm3p39, zz_decay_map["4l"])  # noqa
-hh_vbf_hbb_hzz4l_kvm2p12_k2v3p87_klm5p96 = add_bbvv_sub_decay(hh_vbf_hbb_hzz_kvm2p12_k2v3p87_klm5p96, zz_decay_map["4l"])  # noqa
+hh_vbf_hbb_hzz4l_kv2p12_k2v3p87_klm5p96 = add_bbvv_sub_decay(hh_vbf_hbb_hzz_kv2p12_k2v3p87_klm5p96, zz_decay_map["4l"])  # noqa
 
 hh_ggf_hbb_hzz2l2q = add_bbvv_sub_decay(hh_ggf_hbb_hzz, zz_decay_map["2l2q"])
 hh_ggf_hbb_hzz2l2q_kl0_kt1 = add_bbvv_sub_decay(hh_ggf_hbb_hzz_kl0_kt1, zz_decay_map["2l2q"])
@@ -740,7 +740,7 @@ hh_vbf_hbb_hzz2l2q_kvm0p962_k2v0p959_klm1p43 = add_bbvv_sub_decay(hh_vbf_hbb_hzz
 hh_vbf_hbb_hzz2l2q_kvm1p21_k2v1p94_klm0p94 = add_bbvv_sub_decay(hh_vbf_hbb_hzz_kvm1p21_k2v1p94_klm0p94, zz_decay_map["2l2q"])  # noqa
 hh_vbf_hbb_hzz2l2q_kvm1p6_k2v2p72_klm1p36 = add_bbvv_sub_decay(hh_vbf_hbb_hzz_kvm1p6_k2v2p72_klm1p36, zz_decay_map["2l2q"])  # noqa
 hh_vbf_hbb_hzz2l2q_kvm1p83_k2v3p57_klm3p39 = add_bbvv_sub_decay(hh_vbf_hbb_hzz_kvm1p83_k2v3p57_klm3p39, zz_decay_map["2l2q"])  # noqa
-hh_vbf_hbb_hzz2l2q_kvm2p12_k2v3p87_klm5p96 = add_bbvv_sub_decay(hh_vbf_hbb_hzz_kvm2p12_k2v3p87_klm5p96, zz_decay_map["2l2q"])  # noqa
+hh_vbf_hbb_hzz2l2q_kv2p12_k2v3p87_klm5p96 = add_bbvv_sub_decay(hh_vbf_hbb_hzz_kv2p12_k2v3p87_klm5p96, zz_decay_map["2l2q"])  # noqa
 
 #
 # Assign cross sections to hbb_hvv sub-processes by adding the hbb_hww and hbb_hzz sub-process cross sections

--- a/cmsdb/processes/hh2ml.py
+++ b/cmsdb/processes/hh2ml.py
@@ -13,19 +13,19 @@ __all__ = [
     "hh_vbf_htt_htt_kvm0p012_k2v0p03_kl10p2", "hh_vbf_htt_htt_kvm0p758_k2v1p44_klm19p3",
     "hh_vbf_htt_htt_kvm0p962_k2v0p959_klm1p43", "hh_vbf_htt_htt_kvm1p21_k2v1p94_klm0p94",
     "hh_vbf_htt_htt_kvm1p6_k2v2p72_klm1p36", "hh_vbf_htt_htt_kvm1p83_k2v3p57_klm3p39",
-    "hh_vbf_htt_htt_kvm2p12_k2v3p87_klm5p96",
+    "hh_vbf_htt_htt_kv2p12_k2v3p87_klm5p96",
     "hh_vbf_hvv_hvv",
     "hh_vbf_hvv_hvv_kv1_k2v0_kl1", "hh_vbf_hvv_hvv_kv1_k2v1_kl1", "hh_vbf_hvv_hvv_kv1p74_k2v1p37_kl14p4",
     "hh_vbf_hvv_hvv_kvm0p012_k2v0p03_kl10p2", "hh_vbf_hvv_hvv_kvm0p758_k2v1p44_klm19p3",
     "hh_vbf_hvv_hvv_kvm0p962_k2v0p959_klm1p43", "hh_vbf_hvv_hvv_kvm1p21_k2v1p94_klm0p94",
     "hh_vbf_hvv_hvv_kvm1p6_k2v2p72_klm1p36", "hh_vbf_hvv_hvv_kvm1p83_k2v3p57_klm3p39",
-    "hh_vbf_hvv_hvv_kvm2p12_k2v3p87_klm5p96",
+    "hh_vbf_hvv_hvv_kv2p12_k2v3p87_klm5p96",
     "hh_vbf_htt_hvv",
     "hh_vbf_htt_hvv_kv1_k2v0_kl1", "hh_vbf_htt_hvv_kv1_k2v1_kl1", "hh_vbf_htt_hvv_kv1p74_k2v1p37_kl14p4",
     "hh_vbf_htt_hvv_kvm0p012_k2v0p03_kl10p2", "hh_vbf_htt_hvv_kvm0p758_k2v1p44_klm19p3",
     "hh_vbf_htt_hvv_kvm0p962_k2v0p959_klm1p43", "hh_vbf_htt_hvv_kvm1p21_k2v1p94_klm0p94",
     "hh_vbf_htt_hvv_kvm1p6_k2v2p72_klm1p36", "hh_vbf_htt_hvv_kvm1p83_k2v3p57_klm3p39",
-    "hh_vbf_htt_hvv_kvm2p12_k2v3p87_klm5p96",
+    "hh_vbf_htt_hvv_kv2p12_k2v3p87_klm5p96",
 ]
 
 import cmsdb.constants as const
@@ -36,7 +36,7 @@ from cmsdb.processes.hh import (
     hh_vbf,
     hh_vbf_kv1_k2v1_kl1, hh_vbf_kv1_k2v0_kl1, hh_vbf_kv1p74_k2v1p37_kl14p4, hh_vbf_kvm0p012_k2v0p03_kl10p2,
     hh_vbf_kvm0p758_k2v1p44_klm19p3, hh_vbf_kvm0p962_k2v0p959_klm1p43, hh_vbf_kvm1p21_k2v1p94_klm0p94,
-    hh_vbf_kvm1p6_k2v2p72_klm1p36, hh_vbf_kvm1p83_k2v3p57_klm3p39, hh_vbf_kvm2p12_k2v3p87_klm5p96,
+    hh_vbf_kvm1p6_k2v2p72_klm1p36, hh_vbf_kvm1p83_k2v3p57_klm3p39, hh_vbf_kv2p12_k2v3p87_klm5p96,
 )
 from cmsdb.util import multiply_xsecs
 
@@ -211,11 +211,11 @@ hh_vbf_htt_htt_kvm1p83_k2v3p57_klm3p39 = hh_vbf_kvm1p83_k2v3p57_klm3p39.add_proc
     xsecs=multiply_xsecs(hh_vbf_kvm1p83_k2v3p57_klm3p39, const.br_hh.tttt),
 )
 
-hh_vbf_htt_htt_kvm2p12_k2v3p87_klm5p96 = hh_vbf_kvm2p12_k2v3p87_klm5p96.add_process(
-    name="hh_vbf_htt_htt_kvm2p12_k2v3p87_klm5p96",
+hh_vbf_htt_htt_kv2p12_k2v3p87_klm5p96 = hh_vbf_kv2p12_k2v3p87_klm5p96.add_process(
+    name="hh_vbf_htt_htt_kv2p12_k2v3p87_klm5p96",
     id=95010,
-    label=r"$HH_{vbf} \rightarrow 4\tau$ ($\kappa_{V}=-2.12$, $\kappa_{2V}=3.87$, $\kappa_{\lambda}=-5.96$)",
-    xsecs=multiply_xsecs(hh_vbf_kvm2p12_k2v3p87_klm5p96, const.br_hh.tttt),
+    label=r"$HH_{vbf} \rightarrow 4\tau$ ($\kappa_{V}=2.12$, $\kappa_{2V}=3.87$, $\kappa_{\lambda}=-5.96$)",
+    xsecs=multiply_xsecs(hh_vbf_kv2p12_k2v3p87_klm5p96, const.br_hh.tttt),
 )
 
 #
@@ -292,11 +292,11 @@ hh_vbf_hvv_hvv_kvm1p83_k2v3p57_klm3p39 = hh_vbf_kvm1p83_k2v3p57_klm3p39.add_proc
     xsecs=multiply_xsecs(hh_vbf_kvm1p83_k2v3p57_klm3p39, const.br_hh.vvvv),
 )
 
-hh_vbf_hvv_hvv_kvm2p12_k2v3p87_klm5p96 = hh_vbf_kvm2p12_k2v3p87_klm5p96.add_process(
-    name="hh_vbf_hvv_hvv_kvm2p12_k2v3p87_klm5p96",
+hh_vbf_hvv_hvv_kv2p12_k2v3p87_klm5p96 = hh_vbf_kv2p12_k2v3p87_klm5p96.add_process(
+    name="hh_vbf_hvv_hvv_kv2p12_k2v3p87_klm5p96",
     id=96010,
-    label=r"$HH_{vbf} \rightarrow 4V$ ($\kappa_{V}=-2.12$, $\kappa_{2V}=3.87$, $\kappa_{\lambda}=-5.96$)",
-    xsecs=multiply_xsecs(hh_vbf_kvm2p12_k2v3p87_klm5p96, const.br_hh.vvvv),
+    label=r"$HH_{vbf} \rightarrow 4V$ ($\kappa_{V}=2.12$, $\kappa_{2V}=3.87$, $\kappa_{\lambda}=-5.96$)",
+    xsecs=multiply_xsecs(hh_vbf_kv2p12_k2v3p87_klm5p96, const.br_hh.vvvv),
 )
 
 #
@@ -373,9 +373,9 @@ hh_vbf_htt_hvv_kvm1p83_k2v3p57_klm3p39 = hh_vbf_kvm1p83_k2v3p57_klm3p39.add_proc
     xsecs=multiply_xsecs(hh_vbf_kvm1p83_k2v3p57_klm3p39, const.br_hh.ttvv),
 )
 
-hh_vbf_htt_hvv_kvm2p12_k2v3p87_klm5p96 = hh_vbf_kvm2p12_k2v3p87_klm5p96.add_process(
-    name="hh_vbf_htt_hvv_kvm2p12_k2v3p87_klm5p96",
+hh_vbf_htt_hvv_kv2p12_k2v3p87_klm5p96 = hh_vbf_kv2p12_k2v3p87_klm5p96.add_process(
+    name="hh_vbf_htt_hvv_kv2p12_k2v3p87_klm5p96",
     id=97010,
-    label=r"$HH_{vbf} \rightarrow \tau\tau VV$ ($\kappa_{V}=-2.12$, $\kappa_{2V}=3.87$, $\kappa_{\lambda}=-5.96$)",
-    xsecs=multiply_xsecs(hh_vbf_kvm2p12_k2v3p87_klm5p96, const.br_hh.ttvv),
+    label=r"$HH_{vbf} \rightarrow \tau\tau VV$ ($\kappa_{V}=2.12$, $\kappa_{2V}=3.87$, $\kappa_{\lambda}=-5.96$)",
+    xsecs=multiply_xsecs(hh_vbf_kv2p12_k2v3p87_klm5p96, const.br_hh.ttvv),
 )


### PR DESCRIPTION
This PR is critical for HH VBF interpretations.

The names of all central samples with a value of e.g. "CV-m2p12" are factually wrong. The value of -2.12 was actually never used. The corresponding gridpacks contained +2.12 instead. This was fixed in recent productions that use the same gridpacks but now exhibit the correct label of `CV_2p12` ([example](https://cmsweb.cern.ch/das/request?view=list&limit=50&instance=prod%2Fglobal&input=dataset%3D%2FVBFHHto2B2Tau_CV_2p12_C2V_3p87_C3_m5p96_TuneCP5_13p6TeV_madgraph-pythia8%2FRun3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2%2FMINIAODSIM), also note the change from `-` to `_`).

As a result, most dataset names, process names and process labels are wrong in these cases, but are fixed by this PR. The only thing missing is a potential change of the inclusive VBF HH cross section for this coupling scenario that I marked inline. @nprouvost Could you check what the VBF formula produces for this point?