### PR TITLE
Added Double Muon Datasets

### DIFF
--- a/cmsdb/campaigns/run3_2022_preEE_nano_v12/data.py
+++ b/cmsdb/campaigns/run3_2022_preEE_nano_v12/data.py
@@ -16,6 +16,51 @@ from cmsdb.campaigns.run3_2022_preEE_nano_v12 import campaign_run3_2022_preEE_na
 
 
 cpn.add_dataset(
+    name="data_doublemu_a",
+    id=14783253,
+    is_data=True,
+    processes=[procs.data_doublemu],
+    keys=[
+        "/DoubleMuon/Run2022A-22Sep2023-v1/NANOAOD",  # noqa
+    ],
+    n_files=4,
+    n_events=25309,
+    aux={
+        "era": "A",
+    },
+)
+
+cpn.add_dataset(
+    name="data_doublemu_b",
+    id=14784149,
+    is_data=True,
+    processes=[procs.data_doublemu],
+    keys=[
+        "/DoubleMuon/Run2022B-22Sep2023-v1/NANOAOD",  # noqa
+    ],
+    n_files=7,
+    n_events=929009,
+    aux={
+        "era": "B",
+    },
+)
+
+cpn.add_dataset(
+    name="data_doublemu_c",
+    id=14784138,
+    is_data=True,
+    processes=[procs.data_doublemu],
+    keys=[
+        "/DoubleMuon/Run2022C-22Sep2023-v1/NANOAOD",  # noqa
+    ],
+    n_files=12,
+    n_events=4646904,
+    aux={
+        "era": "C",
+    },
+)
+
+cpn.add_dataset(
     name="data_mu_c",
     id=14784127,
     is_data=True,

--- a/cmsdb/processes/data.py
+++ b/cmsdb/processes/data.py
@@ -73,6 +73,13 @@ data_muoneg = data.add_process(
     label=r"Data $\mu e/\gamma$",
 )
 
+data_doublemu = data.add_process(
+    name="data_doublemu",
+    id=80,
+    is_data=True,
+    label=r"Data $\mu$",
+)
+
 data_jetht = data.add_process(
     name="data_jetht",
     id=100,

--- a/cmsdb/processes/data.py
+++ b/cmsdb/processes/data.py
@@ -7,7 +7,7 @@ Data process definitions.
 __all__ = [
     "data", "data_e", "data_mu",
     "data_tau", "data_met", "data_pho",
-    "data_egamma", "data_muoneg", "data_jetht", "data_jethtmet", "data_doublemu"
+    "data_egamma", "data_muoneg", "data_jetht", "data_jethtmet", "data_doublemu",
 ]
 
 from order import Process

--- a/cmsdb/processes/data.py
+++ b/cmsdb/processes/data.py
@@ -7,7 +7,7 @@ Data process definitions.
 __all__ = [
     "data", "data_e", "data_mu",
     "data_tau", "data_met", "data_pho",
-    "data_egamma", "data_muoneg", "data_jetht", "data_jethtmet",
+    "data_egamma", "data_muoneg", "data_jetht", "data_jethtmet", "data_doublemu"
 ]
 
 from order import Process


### PR DESCRIPTION
For the beginning Era C in 2022 the double and single muon datasets were separated. The double muon datasets have been added to the existing single muon datasets now. 