### PR TITLE
Fix trigger bits in bbVV 22+23 samples

### DIFF
--- a/cmsdb/campaigns/run3_2022_postEE_nano_uhh_v14_trg_v15/__init__.py
+++ b/cmsdb/campaigns/run3_2022_postEE_nano_uhh_v14_trg_v15/__init__.py
@@ -44,3 +44,4 @@ import cmsdb.campaigns.run3_2022_postEE_nano_uhh_v14_trg_v15.top  # noqa
 import cmsdb.campaigns.run3_2022_postEE_nano_uhh_v14_trg_v15.ewk  # noqa
 import cmsdb.campaigns.run3_2022_postEE_nano_uhh_v14_trg_v15.higgs  # noqa
 import cmsdb.campaigns.run3_2022_postEE_nano_uhh_v14_trg_v15.hh2bbtautau  # noqa
+import cmsdb.campaigns.run3_2022_postEE_nano_uhh_v14_trg_v15.hh2bbvv  # noqa

--- a/cmsdb/campaigns/run3_2022_postEE_nano_uhh_v14_trg_v15/hh2bbvv.py
+++ b/cmsdb/campaigns/run3_2022_postEE_nano_uhh_v14_trg_v15/hh2bbvv.py
@@ -1,0 +1,691 @@
+# coding: utf-8
+
+"""
+HH -> bbVV datasets for the 2022 postEE data-taking campaign with datasets at NanoAOD tier in
+version 14, created with custom content at UHH.
+"""
+
+import cmsdb.processes as procs
+from cmsdb.campaigns.run3_2022_postEE_nano_uhh_v14 import campaign_run3_2022_postEE_nano_uhh_v14 as cpn
+
+
+#
+# ggf -> HH
+#
+
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvv_kl0_kt1_powheg",
+    id=15005346,
+    processes=[procs.hh_ggf_hbb_hvv_kl0_kt1],
+    keys=[
+        "/GluGlutoHHto2B2V_kl-0p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=773_497,
+    aux={
+        "merging_factors": {
+            "nominal": 38,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvv_kl1_kt1_powheg",
+    id=14857478,
+    processes=[procs.hh_ggf_hbb_hvv_kl1_kt1],
+    keys=[
+        "/GluGlutoHHto2B2V_kl-1p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v3/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=769_320,
+    aux={
+        "merging_factors": {
+            "nominal": 27,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvv_kl2p45_kt1_powheg",
+    id=14951678,
+    processes=[procs.hh_ggf_hbb_hvv_kl2p45_kt1],
+    keys=[
+        "/GluGlutoHHto2B2V_kl-2p45_kt-1p00_c2-0p00_LHEweights_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=4,
+    n_events=1_391_397,
+    aux={
+        "merging_factors": {
+            "nominal": 58,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvv_kl5_kt1_powheg",
+    id=15005095,
+    processes=[procs.hh_ggf_hbb_hvv_kl5_kt1],
+    keys=[
+        "/GluGlutoHHto2B2V_kl-5p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=779_997,
+    aux={
+        "merging_factors": {
+            "nominal": 24,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvv2l2nu_kl0_kt1_powheg",
+    id=15023163,
+    processes=[procs.hh_ggf_hbb_hvv2l2nu_kl0_kt1],
+    keys=[
+        "/GluGlutoHHto2B2Vto2L2Nu_kl-0p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=300_095,
+    aux={
+        "merging_factors": {
+            "nominal": 54,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvv2l2nu_kl1_kt1_powheg",
+    id=14857783,
+    processes=[procs.hh_ggf_hbb_hvv2l2nu_kl1_kt1],
+    keys=[
+        "/GluGlutoHHto2B2Vto2L2Nu_kl-1p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=305_348,
+    aux={
+        "merging_factors": {
+            "nominal": 66,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvv2l2nu_kl2p45_kt1_powheg",
+    id=14951243,
+    processes=[procs.hh_ggf_hbb_hvv2l2nu_kl2p45_kt1],
+    keys=[
+        "/GluGlutoHHto2B2Vto2L2Nu_kl-2p45_kt-1p00_c2-0p00_LHEweights_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=348_334,
+    aux={
+        "merging_factors": {
+            "nominal": 104,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvv2l2nu_kl5_kt1_powheg",
+    id=15007969,
+    processes=[procs.hh_ggf_hbb_hvv2l2nu_kl5_kt1],
+    keys=[
+        "/GluGlutoHHto2B2Vto2L2Nu_kl-5p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=309_321,
+    aux={
+        "merging_factors": {
+            "nominal": 49,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvvqqlnu_kl0_kt1_powheg",
+    id=15023098,
+    processes=[procs.hh_ggf_hbb_hvvqqlnu_kl0_kt1],
+    keys=[
+        "/GluGlutoHHto2B2WtoLNu2Q_kl-0p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=305_209,
+    aux={
+        "merging_factors": {
+            "nominal": 59,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvvqqlnu_kl1_kt1_powheg",
+    id=14870895,
+    processes=[procs.hh_ggf_hbb_hvvqqlnu_kl1_kt1],
+    keys=[
+        "/GluGlutoHHto2B2WtoLNu2Q_kl-1p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v3/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=307_250,
+    aux={
+        "merging_factors": {
+            "nominal": 39,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvvqqlnu_kl2p45_kt1_powheg",
+    id=14954833,
+    processes=[procs.hh_ggf_hbb_hvvqqlnu_kl2p45_kt1],
+    keys=[
+        "/GluGlutoHHto2B2WtoLNu2Q_kl-2p45_kt-1p00_c2-0p00_LHEweights_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=347_820,
+    aux={
+        "merging_factors": {
+            "nominal": 78,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvvqqlnu_kl5_kt1_powheg",
+    id=15005102,
+    processes=[procs.hh_ggf_hbb_hvvqqlnu_kl5_kt1],
+    keys=[
+        "/GluGlutoHHto2B2WtoLNu2Q_kl-5p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=310_405,
+    aux={
+        "merging_factors": {
+            "nominal": 40,
+        },
+    },
+)
+
+#
+# vbf -> HH
+#
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv_kv1p74_k2v1p37_kl14p4_madgraph",
+    id=14879968,
+    processes=[procs.hh_vbf_hbb_hvv_kv1p74_k2v1p37_kl14p4],
+    keys=[
+        "/VBFHHto2B2V_CV-1p74_C2V-1p37_C3-14p4_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=762_723,
+    aux={
+        "merging_factors": {
+            "nominal": 21,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv_kvm0p012_k2v0p03_kl10p2_madgraph",
+    id=14879638,
+    processes=[procs.hh_vbf_hbb_hvv_kvm0p012_k2v0p03_kl10p2],
+    keys=[
+        "/VBFHHto2B2V_CV-m0p012_C2V-0p030_C3-10p2_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=777_923,
+    aux={
+        "merging_factors": {
+            "nominal": 21,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv_kvm0p758_k2v1p44_klm19p3_madgraph",
+    id=14879353,
+    processes=[procs.hh_vbf_hbb_hvv_kvm0p758_k2v1p44_klm19p3],
+    keys=[
+        "/VBFHHto2B2V_CV-m0p758_C2V-1p44_C3-m19p3_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=779_998,
+    aux={
+        "merging_factors": {
+            "nominal": 19,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv_kvm0p962_k2v0p959_klm1p43_madgraph",
+    id=14879606,
+    processes=[procs.hh_vbf_hbb_hvv_kvm0p962_k2v0p959_klm1p43],
+    keys=[
+        "/VBFHHto2B2V_CV-m0p962_C2V-0p959_C3-m1p43_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=771_753,
+    aux={
+        "merging_factors": {
+            "nominal": 21,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv_kvm1p21_k2v1p94_klm0p94_madgraph",
+    id=14879617,
+    processes=[procs.hh_vbf_hbb_hvv_kvm1p21_k2v1p94_klm0p94],
+    keys=[
+        "/VBFHHto2B2V_CV-m1p21_C2V-1p94_C3-m0p94_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=779_298,
+    aux={
+        "merging_factors": {
+            "nominal": 21,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv_kvm1p6_k2v2p72_klm1p36_madgraph",
+    id=14879228,
+    processes=[procs.hh_vbf_hbb_hvv_kvm1p6_k2v2p72_klm1p36],
+    keys=[
+        "/VBFHHto2B2V_CV-m1p60_C2V-2p72_C3-m1p36_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=776_511,
+    aux={
+        "merging_factors": {
+            "nominal": 17,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv_kvm1p83_k2v3p57_klm3p39_madgraph",
+    id=14885011,
+    processes=[procs.hh_vbf_hbb_hvv_kvm1p83_k2v3p57_klm3p39],
+    keys=[
+        "/VBFHHto2B2V_CV-m1p83_C2V-3p57_C3-m3p39_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=779_309,
+    aux={
+        "merging_factors": {
+            "nominal": 19,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv_kv2p12_k2v3p87_klm5p96_madgraph",
+    id=14879463,
+    processes=[procs.hh_vbf_hbb_hvv_kv2p12_k2v3p87_klm5p96],
+    keys=[
+        "/VBFHHto2B2V_CV-m2p12_C2V-3p87_C3-m5p96_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=770_322,
+    aux={
+        "merging_factors": {
+            "nominal": 23,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv_kv1_k2v0_kl1_madgraph",
+    id=14852949,
+    processes=[procs.hh_vbf_hbb_hvv_kv1_k2v0_kl1],
+    keys=[
+        "/VBFHHto2B2V_CV_1_C2V_0_C3_1_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v3/NANOAODSIM",  # noqa
+    ],
+    n_files=9,
+    n_events=3_490_508,
+    aux={
+        "merging_factors": {
+            "nominal": 16,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv_kv1_k2v1_kl1_madgraph",
+    id=14855246,
+    processes=[procs.hh_vbf_hbb_hvv_kv1_k2v1_kl1],
+    keys=[
+        "/VBFHHto2B2V_CV_1_C2V_1_C3_1_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v3/NANOAODSIM",  # noqa
+    ],
+    n_files=8,
+    n_events=3_383_183,
+    aux={
+        "merging_factors": {
+            "nominal": 20,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv2l2nu_kv1p74_k2v1p37_kl14p4_madgraph",
+    id=14872997,
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kv1p74_k2v1p37_kl14p4],
+    keys=[
+        "/VBFHHto2B2Vto2L2Nu_CV-1p74_C2V-1p37_C3-14p4_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=3,
+    n_events=1_374_865,
+    aux={
+        "merging_factors": {
+            "nominal": 25,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv2l2nu_kvm0p012_k2v0p03_kl10p2_madgraph",
+    id=14875382,
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kvm0p012_k2v0p03_kl10p2],
+    keys=[
+        "/VBFHHto2B2Vto2L2Nu_CV-m0p012_C2V-0p030_C3-10p2_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=4,
+    n_events=1_395_818,
+    aux={
+        "merging_factors": {
+            "nominal": 15,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv2l2nu_kvm0p758_k2v1p44_klm19p3_madgraph",
+    id=14873947,
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kvm0p758_k2v1p44_klm19p3],
+    keys=[
+        "/VBFHHto2B2Vto2L2Nu_CV-m0p758_C2V-1p44_C3-m19p3_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=4,
+    n_events=1_398_564,
+    aux={
+        "merging_factors": {
+            "nominal": 14,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv2l2nu_kvm0p962_k2v0p959_klm1p43_madgraph",
+    id=14873587,
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kvm0p962_k2v0p959_klm1p43],
+    keys=[
+        "/VBFHHto2B2Vto2L2Nu_CV-m0p962_C2V-0p959_C3-m1p43_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=3,
+    n_events=1_399_278,
+    aux={
+        "merging_factors": {
+            "nominal": 19,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv2l2nu_kvm1p21_k2v1p94_klm0p94_madgraph",
+    id=14878907,
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kvm1p21_k2v1p94_klm0p94],
+    keys=[
+        "/VBFHHto2B2Vto2L2Nu_CV-m1p21_C2V-1p94_C3-m0p94_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=4,
+    n_events=1_393_766,
+    aux={
+        "merging_factors": {
+            "nominal": 16,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv2l2nu_kvm1p6_k2v2p72_klm1p36_madgraph",
+    id=14878643,
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kvm1p6_k2v2p72_klm1p36],
+    keys=[
+        "/VBFHHto2B2Vto2L2Nu_CV-m1p60_C2V-2p72_C3-m1p36_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=3,
+    n_events=1_339_267,
+    aux={
+        "merging_factors": {
+            "nominal": 20,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv2l2nu_kvm1p83_k2v3p57_klm3p39_madgraph",
+    id=14884554,
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kvm1p83_k2v3p57_klm3p39],
+    keys=[
+        "/VBFHHto2B2Vto2L2Nu_CV-m1p83_C2V-3p57_C3-m3p39_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=311_999,
+    aux={
+        "merging_factors": {
+            "nominal": 28,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv2l2nu_kv2p12_k2v3p87_klm5p96_madgraph",
+    id=14877427,
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kv2p12_k2v3p87_klm5p96],
+    keys=[
+        "/VBFHHto2B2Vto2L2Nu_CV-m2p12_C2V-3p87_C3-m5p96_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=3,
+    n_events=1_351_627,
+    aux={
+        "merging_factors": {
+            "nominal": 17,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv2l2nu_kv1_k2v0_kl1_madgraph",
+    id=14833033,
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kv1_k2v0_kl1],
+    keys=[
+        "/VBFHHto2B2Vto2L2Nu_CV_1_C2V_0_C3_1_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=4,
+    n_events=1_362_737,
+    aux={
+        "merging_factors": {
+            "nominal": 8,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv2l2nu_kv1_k2v1_kl1_madgraph",
+    id=14834952,
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kv1_k2v1_kl1],
+    keys=[
+        "/VBFHHto2B2Vto2L2Nu_CV_1_C2V_1_C3_1_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=3,
+    n_events=1_373_170,
+    aux={
+        "merging_factors": {
+            "nominal": 10,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvvqqlnu_kv1p74_k2v1p37_kl14p4_madgraph",
+    id=14875032,
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kv1p74_k2v1p37_kl14p4],
+    keys=[
+        "/VBFHHto2B2WtoLNu2Q_CV-1p74_C2V-1p37_C3-14p4_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=3,
+    n_events=1_351_966,
+    aux={
+        "merging_factors": {
+            "nominal": 25,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvvqqlnu_kvm0p012_k2v0p03_kl10p2_madgraph",
+    id=14870905,
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kvm0p012_k2v0p03_kl10p2],
+    keys=[
+        "/VBFHHto2B2WtoLNu2Q_CV-m0p012_C2V-0p030_C3-10p2_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=4,
+    n_events=1_396_491,
+    aux={
+        "merging_factors": {
+            "nominal": 19,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvvqqlnu_kvm0p758_k2v1p44_klm19p3_madgraph",
+    id=14870626,
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kvm0p758_k2v1p44_klm19p3],
+    keys=[
+        "/VBFHHto2B2WtoLNu2Q_CV-m0p758_C2V-1p44_C3-m19p3_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=4,
+    n_events=1_399_991,
+    aux={
+        "merging_factors": {
+            "nominal": 20,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvvqqlnu_kvm0p962_k2v0p959_klm1p43_madgraph",
+    id=14870929,
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kvm0p962_k2v0p959_klm1p43],
+    keys=[
+        "/VBFHHto2B2WtoLNu2Q_CV-m0p962_C2V-0p959_C3-m1p43_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=3,
+    n_events=1_393_093,
+    aux={
+        "merging_factors": {
+            "nominal": 25,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvvqqlnu_kvm1p21_k2v1p94_klm0p94_madgraph",
+    id=14877690,
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kvm1p21_k2v1p94_klm0p94],
+    keys=[
+        "/VBFHHto2B2WtoLNu2Q_CV-m1p21_C2V-1p94_C3-m0p94_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=4,
+    n_events=1_382_046,
+    aux={
+        "merging_factors": {
+            "nominal": 16,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvvqqlnu_kvm1p6_k2v2p72_klm1p36_madgraph",
+    id=14874153,
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kvm1p6_k2v2p72_klm1p36],
+    keys=[
+        "/VBFHHto2B2WtoLNu2Q_CV-m1p60_C2V-2p72_C3-m1p36_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=3,
+    n_events=1_391_467,
+    aux={
+        "merging_factors": {
+            "nominal": 24,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvvqqlnu_kvm1p83_k2v3p57_klm3p39_madgraph",
+    id=14885119,
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kvm1p83_k2v3p57_klm3p39],
+    keys=[
+        "/VBFHHto2B2WtoLNu2Q_CV-m1p83_C2V-3p57_C3-m3p39_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=300_800,
+    aux={
+        "merging_factors": {
+            "nominal": 26,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvvqqlnu_kv2p12_k2v3p87_klm5p96_madgraph",
+    id=14870853,
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kv2p12_k2v3p87_klm5p96],
+    keys=[
+        "/VBFHHto2B2WtoLNu2Q_CV-m2p12_C2V-3p87_C3-m5p96_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=3,
+    n_events=1_360_397,
+    aux={
+        "merging_factors": {
+            "nominal": 24,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvvqqlnu_kv1_k2v0_kl1_madgraph",
+    id=14833426,
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kv1_k2v0_kl1],
+    keys=[
+        "/VBFHHto2B2WtoLNu2Q_CV_1_C2V_0_C3_1_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=4,
+    n_events=1_369_163,
+    aux={
+        "merging_factors": {
+            "nominal": 11,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvvqqlnu_kv1_k2v1_kl1_madgraph",
+    id=14833171,
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kv1_k2v1_kl1],
+    keys=[
+        "/VBFHHto2B2WtoLNu2Q_CV_1_C2V_1_C3_1_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22EEMiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_postEE_v6-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=3,
+    n_events=1_331_379,
+    aux={
+        "merging_factors": {
+            "nominal": 14,
+        },
+    },
+)

--- a/cmsdb/campaigns/run3_2022_postEE_nano_uhh_v14_trg_v15/hh2bbvv.py
+++ b/cmsdb/campaigns/run3_2022_postEE_nano_uhh_v14_trg_v15/hh2bbvv.py
@@ -6,7 +6,7 @@ version 14, created with custom content at UHH.
 """
 
 import cmsdb.processes as procs
-from cmsdb.campaigns.run3_2022_postEE_nano_uhh_v14 import campaign_run3_2022_postEE_nano_uhh_v14 as cpn
+from cmsdb.campaigns.run3_2022_postEE_nano_uhh_v14_trg_v15 import campaign_run3_2022_postEE_nano_uhh_v14_trg_v15 as cpn
 
 
 #

--- a/cmsdb/campaigns/run3_2022_preEE_nano_uhh_v14_trg_v15/__init__.py
+++ b/cmsdb/campaigns/run3_2022_preEE_nano_uhh_v14_trg_v15/__init__.py
@@ -41,3 +41,4 @@ import cmsdb.campaigns.run3_2022_preEE_nano_uhh_v14_trg_v15.top  # noqa
 import cmsdb.campaigns.run3_2022_preEE_nano_uhh_v14_trg_v15.ewk  # noqa
 import cmsdb.campaigns.run3_2022_preEE_nano_uhh_v14_trg_v15.higgs  # noqa
 import cmsdb.campaigns.run3_2022_preEE_nano_uhh_v14_trg_v15.hh2bbtautau  # noqa
+import cmsdb.campaigns.run3_2022_preEE_nano_uhh_v14_trg_v15.hh2bbvv  # noqa

--- a/cmsdb/campaigns/run3_2022_preEE_nano_uhh_v14_trg_v15/hh2bbvv.py
+++ b/cmsdb/campaigns/run3_2022_preEE_nano_uhh_v14_trg_v15/hh2bbvv.py
@@ -1,0 +1,690 @@
+# coding: utf-8
+
+"""
+HH -> bbVV datasets for the 2022 preEE data-taking campaign with datasets at NanoAOD tier in
+version 14, created with custom content at UHH.
+"""
+
+import cmsdb.processes as procs
+from cmsdb.campaigns.run3_2022_preEE_nano_uhh_v14 import campaign_run3_2022_preEE_nano_uhh_v14 as cpn
+
+
+#
+# ggf -> HH
+#
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvv_kl0_kt1_powheg",
+    id=15005094,
+    processes=[procs.hh_ggf_hbb_hvv_kl0_kt1],
+    keys=[
+        "/GluGlutoHHto2B2V_kl-0p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=219_594,
+    aux={
+        "merging_factors": {
+            "nominal": 35,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvv_kl1_kt1_powheg",
+    id=14863904,
+    processes=[procs.hh_ggf_hbb_hvv_kl1_kt1],
+    keys=[
+        "/GluGlutoHHto2B2V_kl-1p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_v5-v3/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=229_178,
+    aux={
+        "merging_factors": {
+            "nominal": 50,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvv_kl2p45_kt1_powheg",
+    id=14953160,
+    processes=[procs.hh_ggf_hbb_hvv_kl2p45_kt1],
+    keys=[
+        "/GluGlutoHHto2B2V_kl-2p45_kt-1p00_c2-0p00_LHEweights_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=398_014,
+    aux={
+        "merging_factors": {
+            "nominal": 111,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvv_kl5_kt1_powheg",
+    id=15005189,
+    processes=[procs.hh_ggf_hbb_hvv_kl5_kt1],
+    keys=[
+        "/GluGlutoHHto2B2V_kl-5p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=219_487,
+    aux={
+        "merging_factors": {
+            "nominal": 40,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvv2l2nu_kl0_kt1_powheg",
+    id=15005093,
+    processes=[procs.hh_ggf_hbb_hvv2l2nu_kl0_kt1],
+    keys=[
+        "/GluGlutoHHto2B2Vto2L2Nu_kl-0p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=88_000,
+    aux={
+        "merging_factors": {
+            "nominal": 15,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvv2l2nu_kl1_kt1_powheg",
+    id=14843883,
+    processes=[procs.hh_ggf_hbb_hvv2l2nu_kl1_kt1],
+    keys=[
+        "/GluGlutoHHto2B2Vto2L2Nu_kl-1p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_v5-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=91_700,
+    aux={
+        "merging_factors": {
+            "nominal": 24,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvv2l2nu_kl2p45_kt1_powheg",
+    id=14952639,
+    processes=[procs.hh_ggf_hbb_hvv2l2nu_kl2p45_kt1],
+    keys=[
+        "/GluGlutoHHto2B2Vto2L2Nu_kl-2p45_kt-1p00_c2-0p00_LHEweights_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=99_913,
+    aux={
+        "merging_factors": {
+            "nominal": 46,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvv2l2nu_kl5_kt1_powheg",
+    id=15001978,
+    processes=[procs.hh_ggf_hbb_hvv2l2nu_kl5_kt1],
+    keys=[
+        "/GluGlutoHHto2B2Vto2L2Nu_kl-5p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=87_544,
+    aux={
+        "merging_factors": {
+            "nominal": 34,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvvqqlnu_kl0_kt1_powheg",
+    id=15006240,
+    processes=[procs.hh_ggf_hbb_hvvqqlnu_kl0_kt1],
+    keys=[
+        "/GluGlutoHHto2B2WtoLNu2Q_kl-0p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=86_758,
+    aux={
+        "merging_factors": {
+            "nominal": 30,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvvqqlnu_kl1_kt1_powheg",
+    id=14868357,
+    processes=[procs.hh_ggf_hbb_hvvqqlnu_kl1_kt1],
+    keys=[
+        "/GluGlutoHHto2B2WtoLNu2Q_kl-1p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=91_699,
+    aux={
+        "merging_factors": {
+            "nominal": 32,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvvqqlnu_kl2p45_kt1_powheg",
+    id=14953155,
+    processes=[procs.hh_ggf_hbb_hvvqqlnu_kl2p45_kt1],
+    keys=[
+        "/GluGlutoHHto2B2WtoLNu2Q_kl-2p45_kt-1p00_c2-0p00_LHEweights_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=99_103,
+    aux={
+        "merging_factors": {
+            "nominal": 38,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvvqqlnu_kl5_kt1_powheg",
+    id=15006631,
+    processes=[procs.hh_ggf_hbb_hvvqqlnu_kl5_kt1],
+    keys=[
+        "/GluGlutoHHto2B2WtoLNu2Q_kl-5p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=87_595,
+    aux={
+        "merging_factors": {
+            "nominal": 32,
+        },
+    },
+)
+
+#
+# vbf -> HH
+#
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv_kv1p74_k2v1p37_kl14p4_madgraph",
+    id=14877312,
+    processes=[procs.hh_vbf_hbb_hvv_kv1p74_k2v1p37_kl14p4],
+    keys=[
+        "/VBFHHto2B2V_CV-1p74_C2V-1p37_C3-14p4_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22MiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=219_300,
+    aux={
+        "merging_factors": {
+            "nominal": 24,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv_kvm0p012_k2v0p03_kl10p2_madgraph",
+    id=14876249,
+    processes=[procs.hh_vbf_hbb_hvv_kvm0p012_k2v0p03_kl10p2],
+    keys=[
+        "/VBFHHto2B2V_CV-m0p012_C2V-0p030_C3-10p2_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22MiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=219_999,
+    aux={
+        "merging_factors": {
+            "nominal": 25,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv_kvm0p758_k2v1p44_klm19p3_madgraph",
+    id=14877934,
+    processes=[procs.hh_vbf_hbb_hvv_kvm0p758_k2v1p44_klm19p3],
+    keys=[
+        "/VBFHHto2B2V_CV-m0p758_C2V-1p44_C3-m19p3_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22MiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=219_307,
+    aux={
+        "merging_factors": {
+            "nominal": 23,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv_kvm0p962_k2v0p959_klm1p43_madgraph",
+    id=14877520,
+    processes=[procs.hh_vbf_hbb_hvv_kvm0p962_k2v0p959_klm1p43],
+    keys=[
+        "/VBFHHto2B2V_CV-m0p962_C2V-0p959_C3-m1p43_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22MiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=220_000,
+    aux={
+        "merging_factors": {
+            "nominal": 22,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv_kvm1p21_k2v1p94_klm0p94_madgraph",
+    id=14878394,
+    processes=[procs.hh_vbf_hbb_hvv_kvm1p21_k2v1p94_klm0p94],
+    keys=[
+        "/VBFHHto2B2V_CV-m1p21_C2V-1p94_C3-m0p94_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22MiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=217_965,
+    aux={
+        "merging_factors": {
+            "nominal": 28,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv_kvm1p6_k2v2p72_klm1p36_madgraph",
+    id=14877525,
+    processes=[procs.hh_vbf_hbb_hvv_kvm1p6_k2v2p72_klm1p36],
+    keys=[
+        "/VBFHHto2B2V_CV-m1p60_C2V-2p72_C3-m1p36_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22MiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=215_824,
+    aux={
+        "merging_factors": {
+            "nominal": 26,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv_kvm1p83_k2v3p57_klm3p39_madgraph",
+    id=14965307,
+    processes=[procs.hh_vbf_hbb_hvv_kvm1p83_k2v3p57_klm3p39],
+    keys=[
+        "/VBFHHto2B2V_CV-m1p83_C2V-3p57_C3-m3p39_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22MiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=219_317,
+    aux={
+        "merging_factors": {
+            "nominal": 30,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv_kv2p12_k2v3p87_klm5p96_madgraph",
+    id=14878390,
+    processes=[procs.hh_vbf_hbb_hvv_kv2p12_k2v3p87_klm5p96],
+    keys=[
+        "/VBFHHto2B2V_CV-m2p12_C2V-3p87_C3-m5p96_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22MiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=219_289,
+    aux={
+        "merging_factors": {
+            "nominal": 27,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv_kv1_k2v0_kl1_madgraph",
+    id=14861695,
+    processes=[procs.hh_vbf_hbb_hvv_kv1_k2v0_kl1],
+    keys=[
+        "/VBFHHto2B2V_CV_1_C2V_0_C3_1_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22MiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_v5-v3/NANOAODSIM",  # noqa
+    ],
+    n_files=3,
+    n_events=995_923,
+    aux={
+        "merging_factors": {
+            "nominal": 19,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv_kv1_k2v1_kl1_madgraph",
+    id=14868430,
+    processes=[procs.hh_vbf_hbb_hvv_kv1_k2v1_kl1],
+    keys=[
+        "/VBFHHto2B2V_CV_1_C2V_1_C3_1_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22MiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_v5-v3/NANOAODSIM",  # noqa
+    ],
+    n_files=3,
+    n_events=997_227,
+    aux={
+        "merging_factors": {
+            "nominal": 15,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv2l2nu_kv1p74_k2v1p37_kl14p4_madgraph",
+    id=14876166,
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kv1p74_k2v1p37_kl14p4],
+    keys=[
+        "/VBFHHto2B2Vto2L2Nu_CV-1p74_C2V-1p37_C3-14p4_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22MiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=399_999,
+    aux={
+        "merging_factors": {
+            "nominal": 28,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv2l2nu_kvm0p012_k2v0p03_kl10p2_madgraph",
+    id=14877648,
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kvm0p012_k2v0p03_kl10p2],
+    keys=[
+        "/VBFHHto2B2Vto2L2Nu_CV-m0p012_C2V-0p030_C3-10p2_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22MiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=398_627,
+    aux={
+        "merging_factors": {
+            "nominal": 29,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv2l2nu_kvm0p758_k2v1p44_klm19p3_madgraph",
+    id=14879110,
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kvm0p758_k2v1p44_klm19p3],
+    keys=[
+        "/VBFHHto2B2Vto2L2Nu_CV-m0p758_C2V-1p44_C3-m19p3_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22MiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=397_845,
+    aux={
+        "merging_factors": {
+            "nominal": 32,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv2l2nu_kvm0p962_k2v0p959_klm1p43_madgraph",
+    id=14878409,
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kvm0p962_k2v0p959_klm1p43],
+    keys=[
+        "/VBFHHto2B2Vto2L2Nu_CV-m0p962_C2V-0p959_C3-m1p43_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22MiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=399_995,
+    aux={
+        "merging_factors": {
+            "nominal": 38,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv2l2nu_kvm1p21_k2v1p94_klm0p94_madgraph",
+    id=14878358,
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kvm1p21_k2v1p94_klm0p94],
+    keys=[
+        "/VBFHHto2B2Vto2L2Nu_CV-m1p21_C2V-1p94_C3-m0p94_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22MiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=396_574,
+    aux={
+        "merging_factors": {
+            "nominal": 32,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv2l2nu_kvm1p6_k2v2p72_klm1p36_madgraph",
+    id=14877851,
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kvm1p6_k2v2p72_klm1p36],
+    keys=[
+        "/VBFHHto2B2Vto2L2Nu_CV-m1p60_C2V-2p72_C3-m1p36_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22MiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=397_200,
+    aux={
+        "merging_factors": {
+            "nominal": 26,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv2l2nu_kvm1p83_k2v3p57_klm3p39_madgraph",
+    id=14960980,
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kvm1p83_k2v3p57_klm3p39],
+    keys=[
+        "/VBFHHto2B2Vto2L2Nu_CV-m1p83_C2V-3p57_C3-m3p39_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22MiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=87_999,
+    aux={
+        "merging_factors": {
+            "nominal": 7,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv2l2nu_kv2p12_k2v3p87_klm5p96_madgraph",
+    id=14877654,
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kv2p12_k2v3p87_klm5p96],
+    keys=[
+        "/VBFHHto2B2Vto2L2Nu_CV-m2p12_C2V-3p87_C3-m5p96_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22MiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=399_998,
+    aux={
+        "merging_factors": {
+            "nominal": 32,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv2l2nu_kv1_k2v0_kl1_madgraph",
+    id=14791641,
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kv1_k2v0_kl1],
+    keys=[
+        "/VBFHHto2B2Vto2L2Nu_CV_1_C2V_0_C3_1_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22MiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=393_727,
+    aux={
+        "merging_factors": {
+            "nominal": 17,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv2l2nu_kv1_k2v1_kl1_madgraph",
+    id=14790732,
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kv1_k2v1_kl1],
+    keys=[
+        "/VBFHHto2B2Vto2L2Nu_CV_1_C2V_1_C3_1_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22MiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=390_211,
+    aux={
+        "merging_factors": {
+            "nominal": 23,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvvqqlnu_kv1p74_k2v1p37_kl14p4_madgraph",
+    id=14878357,
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kv1p74_k2v1p37_kl14p4],
+    keys=[
+        "/VBFHHto2B2WtoLNu2Q_CV-1p74_C2V-1p37_C3-14p4_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22MiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=397_210,
+    aux={
+        "merging_factors": {
+            "nominal": 33,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvvqqlnu_kvm0p012_k2v0p03_kl10p2_madgraph",
+    id=14878908,
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kvm0p012_k2v0p03_kl10p2],
+    keys=[
+        "/VBFHHto2B2WtoLNu2Q_CV-m0p012_C2V-0p030_C3-10p2_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22MiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=393_777,
+    aux={
+        "merging_factors": {
+            "nominal": 31,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvvqqlnu_kvm0p758_k2v1p44_klm19p3_madgraph",
+    id=14875920,
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kvm0p758_k2v1p44_klm19p3],
+    keys=[
+        "/VBFHHto2B2WtoLNu2Q_CV-m0p758_C2V-1p44_C3-m19p3_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22MiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=381_664,
+    aux={
+        "merging_factors": {
+            "nominal": 29,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvvqqlnu_kvm0p962_k2v0p959_klm1p43_madgraph",
+    id=14877650,
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kvm0p962_k2v0p959_klm1p43],
+    keys=[
+        "/VBFHHto2B2WtoLNu2Q_CV-m0p962_C2V-0p959_C3-m1p43_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22MiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=397_909,
+    aux={
+        "merging_factors": {
+            "nominal": 31,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvvqqlnu_kvm1p21_k2v1p94_klm0p94_madgraph",
+    id=14878393,
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kvm1p21_k2v1p94_klm0p94],
+    keys=[
+        "/VBFHHto2B2WtoLNu2Q_CV-m1p21_C2V-1p94_C3-m0p94_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22MiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=393_851,
+    aux={
+        "merging_factors": {
+            "nominal": 30,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvvqqlnu_kvm1p6_k2v2p72_klm1p36_madgraph",
+    id=14875615,
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kvm1p6_k2v2p72_klm1p36],
+    keys=[
+        "/VBFHHto2B2WtoLNu2Q_CV-m1p60_C2V-2p72_C3-m1p36_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22MiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=398_680,
+    aux={
+        "merging_factors": {
+            "nominal": 31,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvvqqlnu_kvm1p83_k2v3p57_klm3p39_madgraph",
+    id=14964627,
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kvm1p83_k2v3p57_klm3p39],
+    keys=[
+        "/VBFHHto2B2WtoLNu2Q_CV-m1p83_C2V-3p57_C3-m3p39_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22MiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=87_280,
+    aux={
+        "merging_factors": {
+            "nominal": 3,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvvqqlnu_kv2p12_k2v3p87_klm5p96_madgraph",
+    id=14877660,
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kv2p12_k2v3p87_klm5p96],
+    keys=[
+        "/VBFHHto2B2WtoLNu2Q_CV-m2p12_C2V-3p87_C3-m5p96_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22MiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=399_286,
+    aux={
+        "merging_factors": {
+            "nominal": 30,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvvqqlnu_kv1_k2v0_kl1_madgraph",
+    id=14793259,
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kv1_k2v0_kl1],
+    keys=[
+        "/VBFHHto2B2WtoLNu2Q_CV_1_C2V_0_C3_1_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22MiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=397_940,
+    aux={
+        "merging_factors": {
+            "nominal": 25,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvvqqlnu_kv1_k2v1_kl1_madgraph",
+    id=14791562,
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kv1_k2v1_kl1],
+    keys=[
+        "/VBFHHto2B2WtoLNu2Q_CV_1_C2V_1_C3_1_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer22MiniAODv4_NanoAODv14UHH-130X_mcRun3_2022_realistic_v5-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=392_767,
+    aux={
+        "merging_factors": {
+            "nominal": 16,
+        },
+    },
+)

--- a/cmsdb/campaigns/run3_2022_preEE_nano_uhh_v14_trg_v15/hh2bbvv.py
+++ b/cmsdb/campaigns/run3_2022_preEE_nano_uhh_v14_trg_v15/hh2bbvv.py
@@ -6,7 +6,7 @@ version 14, created with custom content at UHH.
 """
 
 import cmsdb.processes as procs
-from cmsdb.campaigns.run3_2022_preEE_nano_uhh_v14 import campaign_run3_2022_preEE_nano_uhh_v14 as cpn
+from cmsdb.campaigns.run3_2022_preEE_nano_uhh_v14_trg_v15 import campaign_run3_2022_preEE_nano_uhh_v14_trg_v15 as cpn
 
 
 #

--- a/cmsdb/campaigns/run3_2023_postBPix_nano_uhh_v14_trg_v15/__init__.py
+++ b/cmsdb/campaigns/run3_2023_postBPix_nano_uhh_v14_trg_v15/__init__.py
@@ -45,3 +45,4 @@ import cmsdb.campaigns.run3_2023_postBPix_nano_uhh_v14_trg_v15.top  # noqa
 import cmsdb.campaigns.run3_2023_postBPix_nano_uhh_v14_trg_v15.ewk  # noqa
 import cmsdb.campaigns.run3_2023_postBPix_nano_uhh_v14_trg_v15.higgs  # noqa
 import cmsdb.campaigns.run3_2023_postBPix_nano_uhh_v14_trg_v15.hh2bbtautau  # noqa
+import cmsdb.campaigns.run3_2023_postBPix_nano_uhh_v14_trg_v15.hh2bbvv  # noqa

--- a/cmsdb/campaigns/run3_2023_postBPix_nano_uhh_v14_trg_v15/hh2bbvv.py
+++ b/cmsdb/campaigns/run3_2023_postBPix_nano_uhh_v14_trg_v15/hh2bbvv.py
@@ -1,0 +1,690 @@
+# coding: utf-8
+
+"""
+HH -> bbVV datasets for the 2023 postBPix data-taking campaign with datasets at NanoAOD tier in
+version 14, created with custom content at UHH.
+"""
+
+import cmsdb.processes as procs
+from cmsdb.campaigns.run3_2023_postBPix_nano_uhh_v14 import campaign_run3_2023_postBPix_nano_uhh_v14 as cpn
+
+
+#
+# ggf -> HH
+#
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvv_kl0_kt1_powheg",
+    id=14961393,
+    processes=[procs.hh_ggf_hbb_hvv_kl0_kt1],
+    keys=[
+        "/GluGlutoHHto2B2V_kl-0p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=332_449,
+    aux={
+        "merging_factors": {
+            "nominal": 82,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvv_kl1_kt1_powheg",
+    id=14959449,
+    processes=[procs.hh_ggf_hbb_hvv_kl1_kt1],
+    keys=[
+        "/GluGlutoHHto2B2V_kl-1p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=332_657,
+    aux={
+        "merging_factors": {
+            "nominal": 43,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvv_kl2p45_kt1_powheg",
+    id=14949056,
+    processes=[procs.hh_ggf_hbb_hvv_kl2p45_kt1],
+    keys=[
+        "/GluGlutoHHto2B2V_kl-2p45_kt-1p00_c2-0p00_LHEweights_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v6-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=594_432,
+    aux={
+        "merging_factors": {
+            "nominal": 50,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvv_kl5_kt1_powheg",
+    id=14960745,
+    processes=[procs.hh_ggf_hbb_hvv_kl5_kt1],
+    keys=[
+        "/GluGlutoHHto2B2V_kl-5p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=330_076,
+    aux={
+        "merging_factors": {
+            "nominal": 78,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvv2l2nu_kl0_kt1_powheg",
+    id=14961724,
+    processes=[procs.hh_ggf_hbb_hvv2l2nu_kl0_kt1],
+    keys=[
+        "/GluGlutoHHto2B2Vto2L2Nu_kl-0p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=133_333,
+    aux={
+        "merging_factors": {
+            "nominal": 24,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvv2l2nu_kl1_kt1_powheg",
+    id=14960914,
+    processes=[procs.hh_ggf_hbb_hvv2l2nu_kl1_kt1],
+    keys=[
+        "/GluGlutoHHto2B2Vto2L2Nu_kl-1p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=133_195,
+    aux={
+        "merging_factors": {
+            "nominal": 23,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvv2l2nu_kl2p45_kt1_powheg",
+    id=14932795,
+    processes=[procs.hh_ggf_hbb_hvv2l2nu_kl2p45_kt1],
+    keys=[
+        "/GluGlutoHHto2B2Vto2L2Nu_kl-2p45_kt-1p00_c2-0p00_LHEweights_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=149_854,
+    aux={
+        "merging_factors": {
+            "nominal": 60,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvv2l2nu_kl5_kt1_powheg",
+    id=14965529,
+    processes=[procs.hh_ggf_hbb_hvv2l2nu_kl5_kt1],
+    keys=[
+        "/GluGlutoHHto2B2Vto2L2Nu_kl-5p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=132_740,
+    aux={
+        "merging_factors": {
+            "nominal": 29,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvvqqlnu_kl0_kt1_powheg",
+    id=14961530,
+    processes=[procs.hh_ggf_hbb_hvvqqlnu_kl0_kt1],
+    keys=[
+        "/GluGlutoHHto2B2WtoLNu2Q_kl-0p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=133_332,
+    aux={
+        "merging_factors": {
+            "nominal": 8,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvvqqlnu_kl1_kt1_powheg",
+    id=14854289,
+    processes=[procs.hh_ggf_hbb_hvvqqlnu_kl1_kt1],
+    keys=[
+        "/GluGlutoHHto2B2WtoLNu2Q_kl-1p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v2-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=495_374,
+    aux={
+        "merging_factors": {
+            "nominal": 30,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvvqqlnu_kl2p45_kt1_powheg",
+    id=14945175,
+    processes=[procs.hh_ggf_hbb_hvvqqlnu_kl2p45_kt1],
+    keys=[
+        "/GluGlutoHHto2B2WtoLNu2Q_kl-2p45_kt-1p00_c2-0p00_LHEweights_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=149_445,
+    aux={
+        "merging_factors": {
+            "nominal": 38,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvvqqlnu_kl5_kt1_powheg",
+    id=14964065,
+    processes=[procs.hh_ggf_hbb_hvvqqlnu_kl5_kt1],
+    keys=[
+        "/GluGlutoHHto2B2WtoLNu2Q_kl-5p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=132_897,
+    aux={
+        "merging_factors": {
+            "nominal": 60,
+        },
+    },
+)
+
+#
+# vbf -> HH
+#
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv_kv1_k2v0_kl1_madgraph",
+    id=14961674,
+    processes=[procs.hh_vbf_hbb_hvv_kv1_k2v0_kl1],
+    keys=[
+        "/VBFHHto2B2V_CV_1_C2V_0_C3_1_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=333_331,
+    aux={
+        "merging_factors": {
+            "nominal": 11,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv_kv1_k2v1_kl1_madgraph",
+    id=14964539,
+    processes=[procs.hh_vbf_hbb_hvv_kv1_k2v1_kl1],
+    keys=[
+        "/VBFHHto2B2V_CV_1_C2V_1_C3_1_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=333_328,
+    aux={
+        "merging_factors": {
+            "nominal": 17,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv_kv1p74_k2v1p37_kl14p4_madgraph",
+    id=14960968,
+    processes=[procs.hh_vbf_hbb_hvv_kv1p74_k2v1p37_kl14p4],
+    keys=[
+        "/VBFHHto2B2V_CV_1p74_C2V_1p37_C3_14p4_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=330_331,
+    aux={
+        "merging_factors": {
+            "nominal": 11,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv_kvm0p012_k2v0p03_kl10p2_madgraph",
+    id=14964892,
+    processes=[procs.hh_vbf_hbb_hvv_kvm0p012_k2v0p03_kl10p2],
+    keys=[
+        "/VBFHHto2B2V_CV_m0p012_C2V_0p030_C3_10p2_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=333_330,
+    aux={
+        "merging_factors": {
+            "nominal": 12,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv_kvm0p758_k2v1p44_klm19p3_madgraph",
+    id=14961054,
+    processes=[procs.hh_vbf_hbb_hvv_kvm0p758_k2v1p44_klm19p3],
+    keys=[
+        "/VBFHHto2B2V_CV_m0p758_C2V_1p44_C3_m19p3_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=333_331,
+    aux={
+        "merging_factors": {
+            "nominal": 13,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv_kvm0p962_k2v0p959_klm1p43_madgraph",
+    id=14963895,
+    processes=[procs.hh_vbf_hbb_hvv_kvm0p962_k2v0p959_klm1p43],
+    keys=[
+        "/VBFHHto2B2V_CV_m0p962_C2V_0p959_C3_m1p43_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=333_333,
+    aux={
+        "merging_factors": {
+            "nominal": 8,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv_kvm1p21_k2v1p94_klm0p94_madgraph",
+    id=14964889,
+    processes=[procs.hh_vbf_hbb_hvv_kvm1p21_k2v1p94_klm0p94],
+    keys=[
+        "/VBFHHto2B2V_CV_m1p21_C2V_1p94_C3_m0p94_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=327_332,
+    aux={
+        "merging_factors": {
+            "nominal": 9,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv_kvm1p6_k2v2p72_klm1p36_madgraph",
+    id=14963851,
+    processes=[procs.hh_vbf_hbb_hvv_kvm1p6_k2v2p72_klm1p36],
+    keys=[
+        "/VBFHHto2B2V_CV_m1p60_C2V_2p72_C3_m1p36_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=330_331,
+    aux={
+        "merging_factors": {
+            "nominal": 8,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv_kvm1p83_k2v3p57_klm3p39_madgraph",
+    id=14964811,
+    processes=[procs.hh_vbf_hbb_hvv_kvm1p83_k2v3p57_klm3p39],
+    keys=[
+        "/VBFHHto2B2V_CV_m1p83_C2V_3p57_C3_m3p39_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=333_333,
+    aux={
+        "merging_factors": {
+            "nominal": 9,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv_kv2p12_k2v3p87_klm5p96_madgraph",
+    id=14965636,
+    processes=[procs.hh_vbf_hbb_hvv_kv2p12_k2v3p87_klm5p96],
+    keys=[
+        "/VBFHHto2B2V_CV_m2p12_C2V_3p87_C3_m5p96_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=333_329,
+    aux={
+        "merging_factors": {
+            "nominal": 27,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv2l2nu_kv1_k2v0_kl1_madgraph",
+    id=14965557,
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kv1_k2v0_kl1],
+    keys=[
+        "/VBFHHto2B2Vto2L2Nu_CV_1_C2V_0_C3_1_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=133_333,
+    aux={
+        "merging_factors": {
+            "nominal": 5,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv2l2nu_kv1_k2v1_kl1_madgraph",
+    id=14961576,
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kv1_k2v1_kl1],
+    keys=[
+        "/VBFHHto2B2Vto2L2Nu_CV_1_C2V_1_C3_1_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=133_333,
+    aux={
+        "merging_factors": {
+            "nominal": 4,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv2l2nu_kv1p74_k2v1p37_kl14p4_madgraph",
+    id=14965657,
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kv1p74_k2v1p37_kl14p4],
+    keys=[
+        "/VBFHHto2B2Vto2L2Nu_CV_1p74_C2V_1p37_C3_14p4_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=133_332,
+    aux={
+        "merging_factors": {
+            "nominal": 11,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv2l2nu_kvm0p012_k2v0p03_kl10p2_madgraph",
+    id=14961192,
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kvm0p012_k2v0p03_kl10p2],
+    keys=[
+        "/VBFHHto2B2Vto2L2Nu_CV_m0p012_C2V_0p030_C3_10p2_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=133_332,
+    aux={
+        "merging_factors": {
+            "nominal": 5,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv2l2nu_kvm0p758_k2v1p44_klm19p3_madgraph",
+    id=14965547,
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kvm0p758_k2v1p44_klm19p3],
+    keys=[
+        "/VBFHHto2B2Vto2L2Nu_CV_m0p758_C2V_1p44_C3_m19p3_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=133_333,
+    aux={
+        "merging_factors": {
+            "nominal": 7,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv2l2nu_kvm0p962_k2v0p959_klm1p43_madgraph",
+    id=15026752,
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kvm0p962_k2v0p959_klm1p43],
+    keys=[
+        "/VBFHHto2B2Vto2L2Nu_CV_m0p962_C2V_0p959_C3_m1p43_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v6-v3/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=133_333,
+    aux={
+        "merging_factors": {
+            "nominal": 5,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv2l2nu_kvm1p21_k2v1p94_klm0p94_madgraph",
+    id=14960794,
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kvm1p21_k2v1p94_klm0p94],
+    keys=[
+        "/VBFHHto2B2Vto2L2Nu_CV_m1p21_C2V_1p94_C3_m0p94_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=133_333,
+    aux={
+        "merging_factors": {
+            "nominal": 6,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv2l2nu_kvm1p6_k2v2p72_klm1p36_madgraph",
+    id=14963055,
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kvm1p6_k2v2p72_klm1p36],
+    keys=[
+        "/VBFHHto2B2Vto2L2Nu_CV_m1p60_C2V_2p72_C3_m1p36_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=130_333,
+    aux={
+        "merging_factors": {
+            "nominal": 8,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv2l2nu_kvm1p83_k2v3p57_klm3p39_madgraph",
+    id=14965620,
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kvm1p83_k2v3p57_klm3p39],
+    keys=[
+        "/VBFHHto2B2Vto2L2Nu_CV_m1p83_C2V_3p57_C3_m3p39_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=133_333,
+    aux={
+        "merging_factors": {
+            "nominal": 12,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv2l2nu_kv2p12_k2v3p87_klm5p96_madgraph",
+    id=14965499,
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kv2p12_k2v3p87_klm5p96],
+    keys=[
+        "/VBFHHto2B2Vto2L2Nu_CV_m2p12_C2V_3p87_C3_m5p96_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=133_333,
+    aux={
+        "merging_factors": {
+            "nominal": 10,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvvqqlnu_kv1_k2v0_kl1_madgraph",
+    id=14964571,
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kv1_k2v0_kl1],
+    keys=[
+        "/VBFHHto2B2WtoLNu2Q_CV_1_C2V_0_C3_1_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=133_332,
+    aux={
+        "merging_factors": {
+            "nominal": 7,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvvqqlnu_kv1_k2v1_kl1_madgraph",
+    id=14964752,
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kv1_k2v1_kl1],
+    keys=[
+        "/VBFHHto2B2WtoLNu2Q_CV_1_C2V_1_C3_1_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=133_332,
+    aux={
+        "merging_factors": {
+            "nominal": 5,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvvqqlnu_kv1p74_k2v1p37_kl14p4_madgraph",
+    id=14961082,
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kv1p74_k2v1p37_kl14p4],
+    keys=[
+        "/VBFHHto2B2WtoLNu2Q_CV_1p74_C2V_1p37_C3_14p4_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=133_332,
+    aux={
+        "merging_factors": {
+            "nominal": 4,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvvqqlnu_kvm0p012_k2v0p03_kl10p2_madgraph",
+    id=14965539,
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kvm0p012_k2v0p03_kl10p2],
+    keys=[
+        "/VBFHHto2B2WtoLNu2Q_CV_m0p012_C2V_0p030_C3_10p2_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=133_328,
+    aux={
+        "merging_factors": {
+            "nominal": 5,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvvqqlnu_kvm0p758_k2v1p44_klm19p3_madgraph",
+    id=14964672,
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kvm0p758_k2v1p44_klm19p3],
+    keys=[
+        "/VBFHHto2B2WtoLNu2Q_CV_m0p758_C2V_1p44_C3_m19p3_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=133_332,
+    aux={
+        "merging_factors": {
+            "nominal": 7,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvvqqlnu_kvm0p962_k2v0p959_klm1p43_madgraph",
+    id=14964567,
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kvm0p962_k2v0p959_klm1p43],
+    keys=[
+        "/VBFHHto2B2WtoLNu2Q_CV_m0p962_C2V_0p959_C3_m1p43_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=133_333,
+    aux={
+        "merging_factors": {
+            "nominal": 15,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvvqqlnu_kvm1p21_k2v1p94_klm0p94_madgraph",
+    id=14962400,
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kvm1p21_k2v1p94_klm0p94],
+    keys=[
+        "/VBFHHto2B2WtoLNu2Q_CV_m1p21_C2V_1p94_C3_m0p94_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=133_332,
+    aux={
+        "merging_factors": {
+            "nominal": 13,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvvqqlnu_kvm1p6_k2v2p72_klm1p36_madgraph",
+    id=14961664,
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kvm1p6_k2v2p72_klm1p36],
+    keys=[
+        "/VBFHHto2B2WtoLNu2Q_CV_m1p60_C2V_2p72_C3_m1p36_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=133_473,
+    aux={
+        "merging_factors": {
+            "nominal": 5,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvvqqlnu_kvm1p83_k2v3p57_klm3p39_madgraph",
+    id=14964559,
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kvm1p83_k2v3p57_klm3p39],
+    keys=[
+        "/VBFHHto2B2WtoLNu2Q_CV_m1p83_C2V_3p57_C3_m3p39_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=130_332,
+    aux={
+        "merging_factors": {
+            "nominal": 7,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvvqqlnu_kv2p12_k2v3p87_klm5p96_madgraph",
+    id=14960963,
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kv2p12_k2v3p87_klm5p96],
+    keys=[
+        "/VBFHHto2B2WtoLNu2Q_CV_m2p12_C2V_3p87_C3_m5p96_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23BPixMiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_postBPix_v6-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=133_331,
+    aux={
+        "merging_factors": {
+            "nominal": 4,
+        },
+    },
+)

--- a/cmsdb/campaigns/run3_2023_postBPix_nano_uhh_v14_trg_v15/hh2bbvv.py
+++ b/cmsdb/campaigns/run3_2023_postBPix_nano_uhh_v14_trg_v15/hh2bbvv.py
@@ -6,7 +6,7 @@ version 14, created with custom content at UHH.
 """
 
 import cmsdb.processes as procs
-from cmsdb.campaigns.run3_2023_postBPix_nano_uhh_v14 import campaign_run3_2023_postBPix_nano_uhh_v14 as cpn
+from cmsdb.campaigns.run3_2023_postBPix_nano_uhh_v14_trg_v15 import campaign_run3_2023_postBPix_nano_uhh_v14_trg_v15 as cpn
 
 
 #

--- a/cmsdb/campaigns/run3_2023_postBPix_nano_uhh_v14_trg_v15/hh2bbvv.py
+++ b/cmsdb/campaigns/run3_2023_postBPix_nano_uhh_v14_trg_v15/hh2bbvv.py
@@ -6,7 +6,7 @@ version 14, created with custom content at UHH.
 """
 
 import cmsdb.processes as procs
-from cmsdb.campaigns.run3_2023_postBPix_nano_uhh_v14_trg_v15 import campaign_run3_2023_postBPix_nano_uhh_v14_trg_v15 as cpn
+from cmsdb.campaigns.run3_2023_postBPix_nano_uhh_v14_trg_v15 import campaign_run3_2023_postBPix_nano_uhh_v14_trg_v15 as cpn  # noqa: E501
 
 
 #

--- a/cmsdb/campaigns/run3_2023_preBPix_nano_uhh_v14_trg_v15/__init__.py
+++ b/cmsdb/campaigns/run3_2023_preBPix_nano_uhh_v14_trg_v15/__init__.py
@@ -45,3 +45,4 @@ import cmsdb.campaigns.run3_2023_preBPix_nano_uhh_v14_trg_v15.top  # noqa
 import cmsdb.campaigns.run3_2023_preBPix_nano_uhh_v14_trg_v15.ewk  # noqa
 import cmsdb.campaigns.run3_2023_preBPix_nano_uhh_v14_trg_v15.higgs  # noqa
 import cmsdb.campaigns.run3_2023_preBPix_nano_uhh_v14_trg_v15.hh2bbtautau  # noqa
+import cmsdb.campaigns.run3_2023_preBPix_nano_uhh_v14_trg_v15.hh2bbvv  # noqa

--- a/cmsdb/campaigns/run3_2023_preBPix_nano_uhh_v14_trg_v15/hh2bbvv.py
+++ b/cmsdb/campaigns/run3_2023_preBPix_nano_uhh_v14_trg_v15/hh2bbvv.py
@@ -6,7 +6,7 @@ version 14, created with custom content at UHH.
 """
 
 import cmsdb.processes as procs
-from cmsdb.campaigns.run3_2023_preBPix_nano_uhh_v14_trg_v15 import campaign_run3_2023_preBPix_nano_uhh_v14_trg_v15 as cpn
+from cmsdb.campaigns.run3_2023_preBPix_nano_uhh_v14_trg_v15 import campaign_run3_2023_preBPix_nano_uhh_v14_trg_v15 as cpn  # noqa: E501
 
 
 #

--- a/cmsdb/campaigns/run3_2023_preBPix_nano_uhh_v14_trg_v15/hh2bbvv.py
+++ b/cmsdb/campaigns/run3_2023_preBPix_nano_uhh_v14_trg_v15/hh2bbvv.py
@@ -1,0 +1,690 @@
+# coding: utf-8
+
+"""
+HH -> bbVV datasets for the 2023 preBPix data-taking campaign with datasets at NanoAOD tier in
+version 14, created with custom content at UHH.
+"""
+
+import cmsdb.processes as procs
+from cmsdb.campaigns.run3_2023_preBPix_nano_uhh_v14 import campaign_run3_2023_preBPix_nano_uhh_v14 as cpn
+
+
+#
+# ggf -> HH
+#
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvv_kl0_kt1_powheg",
+    id=14961400,
+    processes=[procs.hh_ggf_hbb_hvv_kl0_kt1],
+    keys=[
+        "/GluGlutoHHto2B2V_kl-0p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=661_694,
+    aux={
+        "merging_factors": {
+            "nominal": 73,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvv_kl1_kt1_powheg",
+    id=14961348,
+    processes=[procs.hh_ggf_hbb_hvv_kl1_kt1],
+    keys=[
+        "/GluGlutoHHto2B2V_kl-1p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v15-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=666_665,
+    aux={
+        "merging_factors": {
+            "nominal": 27,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvv_kl2p45_kt1_powheg",
+    id=14940643,
+    processes=[procs.hh_ggf_hbb_hvv_kl2p45_kt1],
+    keys=[
+        "/GluGlutoHHto2B2V_kl-2p45_kt-1p00_c2-0p00_LHEweights_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v15-v3/NANOAODSIM",  # noqa
+    ],
+    n_files=3,
+    n_events=1_192_340,
+    aux={
+        "merging_factors": {
+            "nominal": 61,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvv_kl5_kt1_powheg",
+    id=14960677,
+    processes=[procs.hh_ggf_hbb_hvv_kl5_kt1],
+    keys=[
+        "/GluGlutoHHto2B2V_kl-5p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=663_764,
+    aux={
+        "merging_factors": {
+            "nominal": 74,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvv2l2nu_kl0_kt1_powheg",
+    id=14963911,
+    processes=[procs.hh_ggf_hbb_hvv2l2nu_kl0_kt1],
+    keys=[
+        "/GluGlutoHHto2B2Vto2L2Nu_kl-0p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v15-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=266_667,
+    aux={
+        "merging_factors": {
+            "nominal": 62,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvv2l2nu_kl1_kt1_powheg",
+    id=14961107,
+    processes=[procs.hh_ggf_hbb_hvv2l2nu_kl1_kt1],
+    keys=[
+        "/GluGlutoHHto2B2Vto2L2Nu_kl-1p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v15-v1/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=266_483,
+    aux={
+        "merging_factors": {
+            "nominal": 37,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvv2l2nu_kl2p45_kt1_powheg",
+    id=14932680,
+    processes=[procs.hh_ggf_hbb_hvv2l2nu_kl2p45_kt1],
+    keys=[
+        "/GluGlutoHHto2B2Vto2L2Nu_kl-2p45_kt-1p00_c2-0p00_LHEweights_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v15-v4/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=299_375,
+    aux={
+        "merging_factors": {
+            "nominal": 71,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvv2l2nu_kl5_kt1_powheg",
+    id=14964738,
+    processes=[procs.hh_ggf_hbb_hvv2l2nu_kl5_kt1],
+    keys=[
+        "/GluGlutoHHto2B2Vto2L2Nu_kl-5p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=265_999,
+    aux={
+        "merging_factors": {
+            "nominal": 41,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvvqqlnu_kl0_kt1_powheg",
+    id=14965393,
+    processes=[procs.hh_ggf_hbb_hvvqqlnu_kl0_kt1],
+    keys=[
+        "/GluGlutoHHto2B2WtoLNu2Q_kl-0p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=261_556,
+    aux={
+        "merging_factors": {
+            "nominal": 45,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvvqqlnu_kl1_kt1_powheg",
+    id=14960636,
+    processes=[procs.hh_ggf_hbb_hvvqqlnu_kl1_kt1],
+    keys=[
+        "/GluGlutoHHto2B2WtoLNu2Q_kl-1p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=266_489,
+    aux={
+        "merging_factors": {
+            "nominal": 56,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvvqqlnu_kl2p45_kt1_powheg",
+    id=14940820,
+    processes=[procs.hh_ggf_hbb_hvvqqlnu_kl2p45_kt1],
+    keys=[
+        "/GluGlutoHHto2B2WtoLNu2Q_kl-2p45_kt-1p00_c2-0p00_LHEweights_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v15-v4/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=299_199,
+    aux={
+        "merging_factors": {
+            "nominal": 48,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvvqqlnu_kl5_kt1_powheg",
+    id=14961727,
+    processes=[procs.hh_ggf_hbb_hvvqqlnu_kl5_kt1],
+    keys=[
+        "/GluGlutoHHto2B2WtoLNu2Q_kl-5p00_kt-1p00_c2-0p00_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=266_232,
+    aux={
+        "merging_factors": {
+            "nominal": 45,
+        },
+    },
+)
+
+#
+# vbf -> HH
+#
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv_kv1_k2v0_kl1_madgraph",
+    id=14961134,
+    processes=[procs.hh_vbf_hbb_hvv_kv1_k2v0_kl1],
+    keys=[
+        "/VBFHHto2B2V_CV_1_C2V_0_C3_1_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=666_664,
+    aux={
+        "merging_factors": {
+            "nominal": 9,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv_kv1_k2v1_kl1_madgraph",
+    id=14964018,
+    processes=[procs.hh_vbf_hbb_hvv_kv1_k2v1_kl1],
+    keys=[
+        "/VBFHHto2B2V_CV_1_C2V_1_C3_1_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=660_666,
+    aux={
+        "merging_factors": {
+            "nominal": 14,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv_kv1p74_k2v1p37_kl14p4_madgraph",
+    id=14966808,
+    processes=[procs.hh_vbf_hbb_hvv_kv1p74_k2v1p37_kl14p4],
+    keys=[
+        "/VBFHHto2B2V_CV_1p74_C2V_1p37_C3_14p4_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=648_665,
+    aux={
+        "merging_factors": {
+            "nominal": 17,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv_kvm0p012_k2v0p03_kl10p2_madgraph",
+    id=14964326,
+    processes=[procs.hh_vbf_hbb_hvv_kvm0p012_k2v0p03_kl10p2],
+    keys=[
+        "/VBFHHto2B2V_CV_m0p012_C2V_0p030_C3_10p2_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=663_663,
+    aux={
+        "merging_factors": {
+            "nominal": 8,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv_kvm0p758_k2v1p44_klm19p3_madgraph",
+    id=14964513,
+    processes=[procs.hh_vbf_hbb_hvv_kvm0p758_k2v1p44_klm19p3],
+    keys=[
+        "/VBFHHto2B2V_CV_m0p758_C2V_1p44_C3_m19p3_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=660_664,
+    aux={
+        "merging_factors": {
+            "nominal": 7,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv_kvm0p962_k2v0p959_klm1p43_madgraph",
+    id=14967713,
+    processes=[procs.hh_vbf_hbb_hvv_kvm0p962_k2v0p959_klm1p43],
+    keys=[
+        "/VBFHHto2B2V_CV_m0p962_C2V_0p959_C3_m1p43_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=651_662,
+    aux={
+        "merging_factors": {
+            "nominal": 13,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv_kvm1p21_k2v1p94_klm0p94_madgraph",
+    id=14966837,
+    processes=[procs.hh_vbf_hbb_hvv_kvm1p21_k2v1p94_klm0p94],
+    keys=[
+        "/VBFHHto2B2V_CV_m1p21_C2V_1p94_C3_m0p94_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=666_664,
+    aux={
+        "merging_factors": {
+            "nominal": 17,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv_kvm1p6_k2v2p72_klm1p36_madgraph",
+    id=14965344,
+    processes=[procs.hh_vbf_hbb_hvv_kvm1p6_k2v2p72_klm1p36],
+    keys=[
+        "/VBFHHto2B2V_CV_m1p60_C2V_2p72_C3_m1p36_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=663_662,
+    aux={
+        "merging_factors": {
+            "nominal": 9,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv_kvm1p83_k2v3p57_klm3p39_madgraph",
+    id=14964511,
+    processes=[procs.hh_vbf_hbb_hvv_kvm1p83_k2v3p57_klm3p39],
+    keys=[
+        "/VBFHHto2B2V_CV_m1p83_C2V_3p57_C3_m3p39_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=666_663,
+    aux={
+        "merging_factors": {
+            "nominal": 9,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv_kv2p12_k2v3p87_klm5p96_madgraph",
+    id=14966434,
+    processes=[procs.hh_vbf_hbb_hvv_kv2p12_k2v3p87_klm5p96],
+    keys=[
+        "/VBFHHto2B2V_CV_m2p12_C2V_3p87_C3_m5p96_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=2,
+    n_events=663_665,
+    aux={
+        "merging_factors": {
+            "nominal": 18,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv2l2nu_kv1_k2v0_kl1_madgraph",
+    id=14964661,
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kv1_k2v0_kl1],
+    keys=[
+        "/VBFHHto2B2Vto2L2Nu_CV_1_C2V_0_C3_1_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=263_666,
+    aux={
+        "merging_factors": {
+            "nominal": 8,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv2l2nu_kv1_k2v1_kl1_madgraph",
+    id=14965470,
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kv1_k2v1_kl1],
+    keys=[
+        "/VBFHHto2B2Vto2L2Nu_CV_1_C2V_1_C3_1_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=260_666,
+    aux={
+        "merging_factors": {
+            "nominal": 13,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv2l2nu_kv1p74_k2v1p37_kl14p4_madgraph",
+    id=14967619,
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kv1p74_k2v1p37_kl14p4],
+    keys=[
+        "/VBFHHto2B2Vto2L2Nu_CV_1p74_C2V_1p37_C3_14p4_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=266_666,
+    aux={
+        "merging_factors": {
+            "nominal": 16,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv2l2nu_kvm0p012_k2v0p03_kl10p2_madgraph",
+    id=14964871,
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kvm0p012_k2v0p03_kl10p2],
+    keys=[
+        "/VBFHHto2B2Vto2L2Nu_CV_m0p012_C2V_0p030_C3_10p2_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=266_667,
+    aux={
+        "merging_factors": {
+            "nominal": 10,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv2l2nu_kvm0p758_k2v1p44_klm19p3_madgraph",
+    id=14962861,
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kvm0p758_k2v1p44_klm19p3],
+    keys=[
+        "/VBFHHto2B2Vto2L2Nu_CV_m0p758_C2V_1p44_C3_m19p3_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=260_666,
+    aux={
+        "merging_factors": {
+            "nominal": 15,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv2l2nu_kvm0p962_k2v0p959_klm1p43_madgraph",
+    id=14967622,
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kvm0p962_k2v0p959_klm1p43],
+    keys=[
+        "/VBFHHto2B2Vto2L2Nu_CV_m0p962_C2V_0p959_C3_m1p43_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=266_666,
+    aux={
+        "merging_factors": {
+            "nominal": 12,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv2l2nu_kvm1p21_k2v1p94_klm0p94_madgraph",
+    id=14966286,
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kvm1p21_k2v1p94_klm0p94],
+    keys=[
+        "/VBFHHto2B2Vto2L2Nu_CV_m1p21_C2V_1p94_C3_m0p94_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=266_666,
+    aux={
+        "merging_factors": {
+            "nominal": 18,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv2l2nu_kvm1p6_k2v2p72_klm1p36_madgraph",
+    id=14964577,
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kvm1p6_k2v2p72_klm1p36],
+    keys=[
+        "/VBFHHto2B2Vto2L2Nu_CV_m1p60_C2V_2p72_C3_m1p36_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=263_666,
+    aux={
+        "merging_factors": {
+            "nominal": 7,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv2l2nu_kvm1p83_k2v3p57_klm3p39_madgraph",
+    id=14968357,
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kvm1p83_k2v3p57_klm3p39],
+    keys=[
+        "/VBFHHto2B2Vto2L2Nu_CV_m1p83_C2V_3p57_C3_m3p39_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=266_667,
+    aux={
+        "merging_factors": {
+            "nominal": 10,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv2l2nu_kv2p12_k2v3p87_klm5p96_madgraph",
+    id=14966238,
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kv2p12_k2v3p87_klm5p96],
+    keys=[
+        "/VBFHHto2B2Vto2L2Nu_CV_m2p12_C2V_3p87_C3_m5p96_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=266_666,
+    aux={
+        "merging_factors": {
+            "nominal": 12,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvvqqlnu_kv1_k2v0_kl1_madgraph",
+    id=14964333,
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kv1_k2v0_kl1],
+    keys=[
+        "/VBFHHto2B2WtoLNu2Q_CV_1_C2V_0_C3_1_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=266_663,
+    aux={
+        "merging_factors": {
+            "nominal": 10,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvvqqlnu_kv1_k2v1_kl1_madgraph",
+    id=14963812,
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kv1_k2v1_kl1],
+    keys=[
+        "/VBFHHto2B2WtoLNu2Q_CV_1_C2V_1_C3_1_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=266_665,
+    aux={
+        "merging_factors": {
+            "nominal": 7,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvvqqlnu_kv1p74_k2v1p37_kl14p4_madgraph",
+    id=14968350,
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kv1p74_k2v1p37_kl14p4],
+    keys=[
+        "/VBFHHto2B2WtoLNu2Q_CV_1p74_C2V_1p37_C3_14p4_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=266_663,
+    aux={
+        "merging_factors": {
+            "nominal": 10,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvvqqlnu_kvm0p012_k2v0p03_kl10p2_madgraph",
+    id=14966289,
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kvm0p012_k2v0p03_kl10p2],
+    keys=[
+        "/VBFHHto2B2WtoLNu2Q_CV_m0p012_C2V_0p030_C3_10p2_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=266_661,
+    aux={
+        "merging_factors": {
+            "nominal": 10,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvvqqlnu_kvm0p758_k2v1p44_klm19p3_madgraph",
+    id=14961034,
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kvm0p758_k2v1p44_klm19p3],
+    keys=[
+        "/VBFHHto2B2WtoLNu2Q_CV_m0p758_C2V_1p44_C3_m19p3_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=260_665,
+    aux={
+        "merging_factors": {
+            "nominal": 14,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvvqqlnu_kvm0p962_k2v0p959_klm1p43_madgraph",
+    id=14966265,
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kvm0p962_k2v0p959_klm1p43],
+    keys=[
+        "/VBFHHto2B2WtoLNu2Q_CV_m0p962_C2V_0p959_C3_m1p43_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=266_664,
+    aux={
+        "merging_factors": {
+            "nominal": 15,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvvqqlnu_kvm1p21_k2v1p94_klm0p94_madgraph",
+    id=14966379,
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kvm1p21_k2v1p94_klm0p94],
+    keys=[
+        "/VBFHHto2B2WtoLNu2Q_CV_m1p21_C2V_1p94_C3_m0p94_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=266_664,
+    aux={
+        "merging_factors": {
+            "nominal": 12,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvvqqlnu_kvm1p6_k2v2p72_klm1p36_madgraph",
+    id=14966838,
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kvm1p6_k2v2p72_klm1p36],
+    keys=[
+        "/VBFHHto2B2WtoLNu2Q_CV_m1p60_C2V_2p72_C3_m1p36_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=266_663,
+    aux={
+        "merging_factors": {
+            "nominal": 19,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvvqqlnu_kvm1p83_k2v3p57_klm3p39_madgraph",
+    id=14964445,
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kvm1p83_k2v3p57_klm3p39],
+    keys=[
+        "/VBFHHto2B2WtoLNu2Q_CV_m1p83_C2V_3p57_C3_m3p39_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=266_663,
+    aux={
+        "merging_factors": {
+            "nominal": 8,
+        },
+    },
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvvqqlnu_kv2p12_k2v3p87_klm5p96_madgraph",
+    id=14966353,
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kv2p12_k2v3p87_klm5p96],
+    keys=[
+        "/VBFHHto2B2WtoLNu2Q_CV_m2p12_C2V_3p87_C3_m5p96_TuneCP5_13p6TeV_madgraph-pythia8/Run3Summer23MiniAODv4_NanoAODv14UHH-130X_mcRun3_2023_realistic_v15-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=1,
+    n_events=263_665,
+    aux={
+        "merging_factors": {
+            "nominal": 16,
+        },
+    },
+)

--- a/cmsdb/campaigns/run3_2023_preBPix_nano_uhh_v14_trg_v15/hh2bbvv.py
+++ b/cmsdb/campaigns/run3_2023_preBPix_nano_uhh_v14_trg_v15/hh2bbvv.py
@@ -6,7 +6,7 @@ version 14, created with custom content at UHH.
 """
 
 import cmsdb.processes as procs
-from cmsdb.campaigns.run3_2023_preBPix_nano_uhh_v14 import campaign_run3_2023_preBPix_nano_uhh_v14 as cpn
+from cmsdb.campaigns.run3_2023_preBPix_nano_uhh_v14_trg_v15 import campaign_run3_2023_preBPix_nano_uhh_v14_trg_v15 as cpn
 
 
 #

--- a/cmsdb/campaigns/run3_2024_nano_v15/hh2bbvv.py
+++ b/cmsdb/campaigns/run3_2024_nano_v15/hh2bbvv.py
@@ -12,22 +12,468 @@ HH -> bbVV datasets for the 2024 data-taking campaign with datasets at NanoAOD t
 # ggf -> HH
 #
 
-# todo
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvv_kl0_kt1_powheg",
+    id=15437554,
+    processes=[procs.hh_ggf_hbb_hvv_kl0_kt1],
+    keys=[
+        "/GluGlutoHHto2B2V_Par-c2-0p00-kl-0p00-kt-1p00_TuneCP5_13p6TeV_powheg-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=274,
+    n_events=2_965_710,
+)
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvv_kl1_kt1_powheg",
+    id=15436466,
+    processes=[procs.hh_ggf_hbb_hvv_kl1_kt1],
+    keys=[
+        "/GluGlutoHHto2B2V_Par-c2-0p00-kl-1p00-kt-1p00_TuneCP5_13p6TeV_powheg-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=215,
+    n_events=2_939_801,
+)
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvv_kl2p45_kt1_powheg",
+    id=15537077,
+    processes=[procs.hh_ggf_hbb_hvv_kl2p45_kt1],
+    keys=[
+        "/GluGlutoHHto2B2V_Par-c2-0p00-kl-2p45-kt-1p00_TuneCP5_13p6TeV_powheg-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=222,
+    n_events=2_999_715,
+)
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvv_kl5_kt1_powheg",
+    id=15440011,
+    processes=[procs.hh_ggf_hbb_hvv_kl5_kt1],
+    keys=[
+        "/GluGlutoHHto2B2V_Par-c2-0p00-kl-5p00-kt-1p00_TuneCP5_13p6TeV_powheg-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=275,
+    n_events=2_922_905,
+)
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvv2l2nu_kl0_kt1_powheg",
+    id=15541102,
+    processes=[procs.hh_ggf_hbb_hvv2l2nu_kl0_kt1],
+    keys=[
+        "/GluGlutoHHto2B2Vto2L2Nu_Par-c2-0p00-kl-0p00-kt-1p00_TuneCP5_13p6TeV_powheg-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=91,
+    n_events=1_166_397,
+)
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvv2l2nu_kl1_kt1_powheg",
+    id=15436982,
+    processes=[procs.hh_ggf_hbb_hvv2l2nu_kl1_kt1],
+    keys=[
+        "/GluGlutoHHto2B2Vto2L2Nu_Par-c2-0p00-kl-1p00-kt-1p00_TuneCP5_13p6TeV_powheg-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=155,
+    n_events=1_174_326,
+)
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvv2l2nu_kl2p45_kt1_powheg",
+    id=15432921,
+    processes=[procs.hh_ggf_hbb_hvv2l2nu_kl2p45_kt1],
+    keys=[
+        "/GluGlutoHHto2B2Vto2L2Nu_Par-c2-0p00-kl-2p45-kt-1p00_TuneCP5_13p6TeV_powheg-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=260,
+    n_events=1_172_869,
+)
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvv2l2nu_kl5_kt1_powheg",
+    id=15436066,
+    processes=[procs.hh_ggf_hbb_hvv2l2nu_kl5_kt1],
+    keys=[
+        "/GluGlutoHHto2B2Vto2L2Nu_Par-c2-0p00-kl-5p00-kt-1p00_TuneCP5_13p6TeV_powheg-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=127,
+    n_events=1_166_472,
+)
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvvqqlnu_kl0_kt1_powheg",
+    id=15546871,
+    processes=[procs.hh_ggf_hbb_hvvqqlnu_kl0_kt1],
+    keys=[
+        "/GluGlutoHHto2B2WtoLNu2Q_Par-c2-0p00-kl-0p00-kt-1p00_TuneCP5_13p6TeV_powheg-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=82,
+    n_events=1_185_085,
+)
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvvqqlnu_kl1_kt1_powheg",
+    id=15542842,
+    processes=[procs.hh_ggf_hbb_hvvqqlnu_kl1_kt1],
+    keys=[
+        "/GluGlutoHHto2B2WtoLNu2Q_Par-c2-0p00-kl-1p00-kt-1p00_TuneCP5_13p6TeV_powheg-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=61,
+    n_events=1_199_991,
+)
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvvqqlnu_kl2p45_kt1_powheg",
+    id=15547178,
+    processes=[procs.hh_ggf_hbb_hvvqqlnu_kl2p45_kt1],
+    keys=[
+        "/GluGlutoHHto2B2WtoLNu2Q_Par-c2-0p00-kl-2p45-kt-1p00_TuneCP5_13p6TeV_powheg-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=65,
+    n_events=1_199_990,
+)
+
+cpn.add_dataset(
+    name="hh_ggf_hbb_hvvqqlnu_kl5_kt1_powheg",
+    id=15545302,
+    processes=[procs.hh_ggf_hbb_hvvqqlnu_kl5_kt1],
+    keys=[
+        "/GluGlutoHHto2B2WtoLNu2Q_Par-c2-0p00-kl-5p00-kt-1p00_TuneCP5_13p6TeV_powheg-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=140,
+    n_events=1_191_631,
+)
 
 #
 # vbf -> HH
 #
 
-# todo
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv_kv1_k2v0_kl1_madgraph",
+    id=15548541,
+    processes=[procs.hh_vbf_hbb_hvv_kv1_k2v0_kl1],
+    keys=[
+        "/VBFHHto2B2V_Par-CV-1-C2V-0-C3-1_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=77,
+    n_events=2_998_988,
+)
 
-#
-# ggf -> graviton -> HH
-#
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv_kv1_k2v1_kl1_madgraph",
+    id=15540098,
+    processes=[procs.hh_vbf_hbb_hvv_kv1_k2v1_kl1],
+    keys=[
+        "/VBFHHto2B2V_Par-CV-1-C2V-1-C3-1_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=66,
+    n_events=2_948_988,
+)
 
-# todo
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv_kv1p74_k2v1p37_kl14p4_madgraph",
+    id=15539859,
+    processes=[procs.hh_vbf_hbb_hvv_kv1p74_k2v1p37_kl14p4],
+    keys=[
+        "/VBFHHto2B2V_Par-CV-1p74-C2V-1p37-C3-14p4_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=59,
+    n_events=2_995_992,
+)
 
-#
-# ggf -> radion -> HH
-#
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv_kvm0p012_k2v0p03_kl10p2_madgraph",
+    id=15551051,
+    processes=[procs.hh_vbf_hbb_hvv_kvm0p012_k2v0p03_kl10p2],
+    keys=[
+        "/VBFHHto2B2V_Par-CV-m0p012-C2V-0p030-C3-10p2_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=86,
+    n_events=2_877_982,
+)
 
-# todo
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv_kvm0p758_k2v1p44_klm19p3_madgraph",
+    id=15551186,
+    processes=[procs.hh_vbf_hbb_hvv_kvm0p758_k2v1p44_klm19p3],
+    keys=[
+        "/VBFHHto2B2V_Par-CV-m0p758-C2V-1p44-C3-m19p3_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=52,
+    n_events=2_991_985,
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv_kvm0p962_k2v0p959_klm1p43_madgraph",
+    id=15540857,
+    processes=[procs.hh_vbf_hbb_hvv_kvm0p962_k2v0p959_klm1p43],
+    keys=[
+        "/VBFHHto2B2V_Par-CV-m0p962-C2V-0p959-C3-m1p43_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=47,
+    n_events=2_987_985,
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv_kvm1p21_k2v1p94_klm0p94_madgraph",
+    id=15546606,
+    processes=[procs.hh_vbf_hbb_hvv_kvm1p21_k2v1p94_klm0p94],
+    keys=[
+        "/VBFHHto2B2V_Par-CV-m1p21-C2V-1p94-C3-m0p94_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=85,
+    n_events=2_999_993,
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv_kvm1p6_k2v2p72_klm1p36_madgraph",
+    id=15536739,
+    processes=[procs.hh_vbf_hbb_hvv_kvm1p6_k2v2p72_klm1p36],
+    keys=[
+        "/VBFHHto2B2V_Par-CV-m1p60-C2V-2p72-C3-m1p36_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=62,
+    n_events=2_999_986,
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv_kvm1p83_k2v3p57_klm3p39_madgraph",
+    id=15541021,
+    processes=[procs.hh_vbf_hbb_hvv_kvm1p83_k2v3p57_klm3p39],
+    keys=[
+        "/VBFHHto2B2V_Par-CV-m1p83-C2V-3p57-C3-m3p39_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=63,
+    n_events=2_995_986,
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv_kv2p12_k2v3p87_klm5p96_madgraph",
+    id=15538779,
+    processes=[procs.hh_vbf_hbb_hvv_kv2p12_k2v3p87_klm5p96],
+    keys=[
+        "/VBFHHto2B2V_Par-CV-2p12-C2V-3p87-C3-m5p96_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=48,
+    n_events=2_999_985,
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv2l2nu_kv1_k2v0_kl1_madgraph",
+    id=15534650,
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kv1_k2v0_kl1],
+    keys=[
+        "/VBFHHto2B2Vto2L2Nu_Par-CV-1-C2V-0-C3-1_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=28,
+    n_events=1_199_995,
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv2l2nu_kv1_k2v1_kl1_madgraph",
+    id=15432384,
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kv1_k2v1_kl1],
+    keys=[
+        "/VBFHHto2B2Vto2L2Nu_Par-CV-1-C2V-1-C3-1_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=31,
+    n_events=1_199_996,
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv2l2nu_kv1p74_k2v1p37_kl14p4_madgraph",
+    id=15539885,
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kv1p74_k2v1p37_kl14p4],
+    keys=[
+        "/VBFHHto2B2Vto2L2Nu_Par-CV-1p74-C2V-1p37-C3-14p4_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=33,
+    n_events=1_199_996,
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv2l2nu_kvm0p012_k2v0p03_kl10p2_madgraph",
+    id=15541590,
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kvm0p012_k2v0p03_kl10p2],
+    keys=[
+        "/VBFHHto2B2Vto2L2Nu_Par-CV-m0p012-C2V-0p030-C3-10p2_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=49,
+    n_events=1_199_993,
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv2l2nu_kvm0p758_k2v1p44_klm19p3_madgraph",
+    id=15436549,
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kvm0p758_k2v1p44_klm19p3],
+    keys=[
+        "/VBFHHto2B2Vto2L2Nu_Par-CV-m0p758-C2V-1p44-C3-m19p3_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=11,
+    n_events=1_199_997,
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv2l2nu_kvm0p962_k2v0p959_klm1p43_madgraph",
+    id=15435128,
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kvm0p962_k2v0p959_klm1p43],
+    keys=[
+        "/VBFHHto2B2Vto2L2Nu_Par-CV-m0p962-C2V-0p959-C3-m1p43_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=25,
+    n_events=1_198_995,
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv2l2nu_kvm1p21_k2v1p94_klm0p94_madgraph",
+    id=15534643,
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kvm1p21_k2v1p94_klm0p94],
+    keys=[
+        "/VBFHHto2B2Vto2L2Nu_Par-CV-m1p21-C2V-1p94-C3-m0p94_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=32,
+    n_events=1_199_993,
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv2l2nu_kvm1p6_k2v2p72_klm1p36_madgraph",
+    id=15468816,
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kvm1p6_k2v2p72_klm1p36],
+    keys=[
+        "/VBFHHto2B2Vto2L2Nu_Par-CV-m1p60-C2V-2p72-C3-m1p36_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=39,
+    n_events=1_199_997,
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv2l2nu_kvm1p83_k2v3p57_klm3p39_madgraph",
+    id=15445359,
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kvm1p83_k2v3p57_klm3p39],
+    keys=[
+        "/VBFHHto2B2Vto2L2Nu_Par-CV-m1p83-C2V-3p57-C3-m3p39_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=33,
+    n_events=1_199_998,
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvv2l2nu_kv2p12_k2v3p87_klm5p96_madgraph",
+    id=15437989,
+    processes=[procs.hh_vbf_hbb_hvv2l2nu_kv2p12_k2v3p87_klm5p96],
+    keys=[
+        "/VBFHHto2B2Vto2L2Nu_Par-CV-2p12-C2V-3p87-C3-m5p96_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=11,
+    n_events=1_196_998,
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvvqqlnu_kv1_k2v0_kl1_madgraph",
+    id=15557086,
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kv1_k2v0_kl1],
+    keys=[
+        "/VBFHHto2B2WtoLNu2Q_Par-CV-1-C2V-0-C3-1_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=56,
+    n_events=1_194_987,
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvvqqlnu_kv1_k2v1_kl1_madgraph",
+    id=15549582,
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kv1_k2v1_kl1],
+    keys=[
+        "/VBFHHto2B2WtoLNu2Q_Par-CV-1-C2V-1-C3-1_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=59,
+    n_events=1_198_992,
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvvqqlnu_kv1p74_k2v1p37_kl14p4_madgraph",
+    id=15542760,
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kv1p74_k2v1p37_kl14p4],
+    keys=[
+        "/VBFHHto2B2WtoLNu2Q_Par-CV-1p74-C2V-1p37-C3-14p4_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=29,
+    n_events=1_199_989,
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvvqqlnu_kvm0p012_k2v0p03_kl10p2_madgraph",
+    id=15542535,
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kvm0p012_k2v0p03_kl10p2],
+    keys=[
+        "/VBFHHto2B2WtoLNu2Q_Par-CV-m0p012-C2V-0p030-C3-10p2_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=30,
+    n_events=1_197_993,
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvvqqlnu_kvm0p758_k2v1p44_klm19p3_madgraph",
+    id=15542177,
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kvm0p758_k2v1p44_klm19p3],
+    keys=[
+        "/VBFHHto2B2WtoLNu2Q_Par-CV-m0p758-C2V-1p44-C3-m19p3_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=25,
+    n_events=1_199_993,
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvvqqlnu_kvm0p962_k2v0p959_klm1p43_madgraph",
+    id=15542253,
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kvm0p962_k2v0p959_klm1p43],
+    keys=[
+        "/VBFHHto2B2WtoLNu2Q_Par-CV-m0p962-C2V-0p959-C3-m1p43_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=53,
+    n_events=1_199_982,
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvvqqlnu_kvm1p21_k2v1p94_klm0p94_madgraph",
+    id=15549539,
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kvm1p21_k2v1p94_klm0p94],
+    keys=[
+        "/VBFHHto2B2WtoLNu2Q_Par-CV-m1p21-C2V-1p94-C3-m0p94_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=53,
+    n_events=1_199_988,
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvvqqlnu_kvm1p6_k2v2p72_klm1p36_madgraph",
+    id=15542530,
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kvm1p6_k2v2p72_klm1p36],
+    keys=[
+        "/VBFHHto2B2WtoLNu2Q_Par-CV-m1p60-C2V-2p72-C3-m1p36_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=49,
+    n_events=1_199_981,
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvvqqlnu_kvm1p83_k2v3p57_klm3p39_madgraph",
+    id=15556458,
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kvm1p83_k2v3p57_klm3p39],
+    keys=[
+        "/VBFHHto2B2WtoLNu2Q_Par-CV-m1p83-C2V-3p57-C3-m3p39_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=54,
+    n_events=1_197_988,
+)
+
+cpn.add_dataset(
+    name="hh_vbf_hbb_hvvqqlnu_kv2p12_k2v3p87_klm5p96_madgraph",
+    id=15546327,
+    processes=[procs.hh_vbf_hbb_hvvqqlnu_kv2p12_k2v3p87_klm5p96],
+    keys=[
+        "/VBFHHto2B2WtoLNu2Q_Par-CV-2p12-C2V-3p87-C3-m5p96_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=48,
+    n_events=1_199_990,
+)

--- a/cmsdb/campaigns/run3_2024_nano_v15/hh2bbvv.py
+++ b/cmsdb/campaigns/run3_2024_nano_v15/hh2bbvv.py
@@ -4,8 +4,8 @@
 HH -> bbVV datasets for the 2024 data-taking campaign with datasets at NanoAOD tier in version 15.
 """
 
-# import cmsdb.processes as procs
-# from cmsdb.campaigns.run3_2024_nano_v15 import campaign_run3_2024_nano_v15 as cpn
+import cmsdb.processes as procs
+from cmsdb.campaigns.run3_2024_nano_v15 import campaign_run3_2024_nano_v15 as cpn
 
 
 #


### PR DESCRIPTION
Adds in the bbVV samples for 2022+2023, reprocessed with the fixed trigger bits to be able to use them in the bbtautau analysis.