### PR TITLE
Add 2025 and 2026 data datasets

### DIFF
--- a/cmsdb/campaigns/run3_2025_nano_v15/__init__.py
+++ b/cmsdb/campaigns/run3_2025_nano_v15/__init__.py
@@ -1,0 +1,56 @@
+# coding: utf-8
+
+"""
+Common, analysis independent definition of the 2025 data-taking campaign with datasets at NanoAOD tier in version 15,
+fetched to local storage via rucio.
+"""
+
+from order import Campaign
+
+from cmsdb.util import transfer_datasets
+from cmsdb.campaigns.run3_2024_nano_v15 import campaign_run3_2024_nano_v15 as cpn24
+
+
+#
+# campaign
+#
+
+campaign_run3_2025_nano_v15 = cpn24.copy()
+campaign_run3_2025_nano_v15.name = "run3_2025_nano_v15"
+campaign_run3_2025_nano_v15.id = 32025115  # (run)3(year)2025(part)1(version)15
+campaign_run3_2025_nano_v15.set_aux("year", 2025)
+
+# remove 'data_' datasets from the 2024 campaign
+for ds in campaign_run3_2025_nano_v15.datasets.names():
+    if ds.startswith("data_"):
+        campaign_run3_2025_nano_v15.remove_dataset(ds)
+
+# trailing imports to load datasets
+import cmsdb.campaigns.run3_2025_nano_v15.data  # noqa
+
+
+#
+# variant of the campaign with datasets fetched to local resources via rucio
+# (the main difference is the "custom" aux entry with additional info that can be interpreted by analyses)
+#
+
+campaign_run3_2025_nano_local_v15 = Campaign(
+    name="run3_2025_nano_local_v15",
+    id=10 * campaign_run3_2025_nano_v15.id,  # adds trailing 0
+    ecm=campaign_run3_2025_nano_v15.ecm,
+    bx=campaign_run3_2025_nano_v15.bx,
+    aux={
+        **campaign_run3_2025_nano_v15.aux,
+        "custom": {
+            "name": "run3_2025_nano_local_v15",
+            "creator": "rucio",
+            "locations": {
+                "desy": "davs://dcache-cms-webdav-wan.desy.de:2880/pnfs/desy.de/cms/tier2",
+                "cern": "root://eoscms.cern.ch/eos/cms",
+            },
+        },
+    },
+    tags=campaign_run3_2025_nano_v15.tags,
+)
+
+transfer_datasets(campaign_run3_2025_nano_v15, campaign_run3_2025_nano_local_v15)

--- a/cmsdb/campaigns/run3_2025_nano_v15/__init__.py
+++ b/cmsdb/campaigns/run3_2025_nano_v15/__init__.py
@@ -7,26 +7,34 @@ fetched to local storage via rucio.
 
 from order import Campaign
 
+from cmsdb.campaigns.run3_2024_nano_v15 import campaign_run3_2024_nano_v15
 from cmsdb.util import transfer_datasets
-from cmsdb.campaigns.run3_2024_nano_v15 import campaign_run3_2024_nano_v15 as cpn24
-
 
 #
 # campaign
 #
 
-campaign_run3_2025_nano_v15 = cpn24.copy()
-campaign_run3_2025_nano_v15.name = "run3_2025_nano_v15"
-campaign_run3_2025_nano_v15.id = 32025115  # (run)3(year)2025(part)1(version)15
-campaign_run3_2025_nano_v15.set_aux("year", 2025)
+campaign_run3_2025_nano_v15 = Campaign(
+    name="run3_2025_nano_v15",
+    id=32025115,  # (run)3(year)2025(part)1(version)15
+    ecm=13.6,
+    bx=25,
+    aux={
+        "tier": "NanoAOD",
+        "run": 3,
+        "year": 2025,
+        "version": 15,
+        "postfix": "",
+    },
+    tags=set(),
+)
 
-# remove 'data_' datasets from the 2024 campaign
-for ds in campaign_run3_2025_nano_v15.datasets.names():
-    if ds.startswith("data_"):
-        campaign_run3_2025_nano_v15.remove_dataset(ds)
 
 # trailing imports to load datasets
 import cmsdb.campaigns.run3_2025_nano_v15.data  # noqa
+
+# transfer all but data from the 2024 campaign
+transfer_datasets(campaign_run3_2024_nano_v15, campaign_run3_2025_nano_v15, skip_fn=lambda d: d.is_data)
 
 
 #
@@ -45,8 +53,14 @@ campaign_run3_2025_nano_local_v15 = Campaign(
             "name": "run3_2025_nano_local_v15",
             "creator": "rucio",
             "locations": {
-                "desy": "davs://dcache-cms-webdav-wan.desy.de:2880/pnfs/desy.de/cms/tier2",
-                "cern": "root://eoscms.cern.ch/eos/cms",
+                "desy": {
+                    "site": "T2_DE_DESY",
+                    "uri": "davs://dcache-cms-webdav-wan.desy.de:2880/pnfs/desy.de/cms/tier2",
+                },
+                "cern": {
+                    "site": "T2_CH_CERN",
+                    "uri": "root://eoscms.cern.ch/eos/cms",
+                },
             },
         },
     },

--- a/cmsdb/campaigns/run3_2025_nano_v15/data.py
+++ b/cmsdb/campaigns/run3_2025_nano_v15/data.py
@@ -1,0 +1,539 @@
+# coding: utf-8
+
+"""
+Recorded datasets for the 2025 data-taking campaign with datasets at NanoAOD tier in version 15.
+"""
+
+import cmsdb.processes as procs
+from cmsdb.campaigns.run3_2025_nano_v15 import campaign_run3_2025_nano_v15 as cpn
+
+
+#
+# JetMET datasets
+#
+
+cpn.add_dataset(
+    name="data_jethtmet_b",
+    id=15310763,
+    processes=[procs.data_jethtmet],
+    keys=[
+        "/JetMET0/Run2025B-PromptReco-v1/NANOAOD",  # noqa
+        "/JetMET1/Run2025B-PromptReco-v1/NANOAOD",  # noqa
+    ],
+    n_files=91 + 92,
+    n_events=13561943 + 13551058,
+    is_data=True,
+    aux={
+        "era": "B",
+    }
+)
+
+cpn.add_dataset(
+    name="data_jethtmet_c",
+    id=15337395,
+    processes=[procs.data_jethtmet],
+    keys=[
+        "/JetMET0/Run2025C-PromptReco-v1/NANOAOD",  # noqa
+        "/JetMET1/Run2025C-PromptReco-v1/NANOAOD",  # noqa
+        "/JetMET0/Run2025C-PromptReco-v2/NANOAOD",  # noqa
+        "/JetMET1/Run2025C-PromptReco-v2/NANOAOD",  # noqa
+    ],
+    n_files=524 + 530 + 290 + 282,
+    n_events=155327920 + 155309595 + 81725663 + 81736350,
+    is_data=True,
+    aux={
+        "era": "C",
+    }
+)
+
+cpn.add_dataset(
+    name="data_jethtmet_d",
+    id=15369835,
+    processes=[procs.data_jethtmet],
+    keys=[
+        "/JetMET0/Run2025D-PromptReco-v1/NANOAOD",  # noqa
+        "/JetMET1/Run2025D-PromptReco-v1/NANOAOD",  # noqa
+    ],
+    n_files=944 + 930,
+    n_events=257411297 + 257342455,
+    is_data=True,
+    aux={
+        "era": "D",
+    }
+)
+
+cpn.add_dataset(
+    name="data_jethtmet_e",
+    id=15396830,
+    processes=[procs.data_jethtmet],
+    keys=[
+        "/JetMET0/Run2025E-PromptReco-v1/NANOAOD",  # noqa
+        "/JetMET1/Run2025E-PromptReco-v1/NANOAOD",  # noqa
+    ],
+    n_files=484 + 492,
+    n_events=145280947 + 145256476,
+    is_data=True,
+    aux={
+        "era": "E",
+    }
+)
+
+cpn.add_dataset(
+    name="data_jethtmet_f",
+    id=15419644,
+    processes=[procs.data_jethtmet],
+    keys=[
+        "/JetMET0/Run2025F-PromptReco-v1/NANOAOD",  # noqa
+        "/JetMET1/Run2025F-PromptReco-v1/NANOAOD",  # noqa
+        "/JetMET0/Run2025F-PromptReco-v2/NANOAOD",  # noqa
+        "/JetMET1/Run2025F-PromptReco-v2/NANOAOD",  # noqa
+    ],
+    n_files=723 + 715 + 290 + 287,
+    n_events=200915960 + 200859929 + 76494690 + 76479375,
+    is_data=True,
+    aux={
+        "era": "F",
+    }
+)
+
+cpn.add_dataset(
+    name="data_jethtmet_g",
+    id=15426626,
+    processes=[procs.data_jethtmet],
+    keys=[
+        "/JetMET0/Run2025G-PromptReco-v1/NANOAOD",  # noqa
+        "/JetMET1/Run2025G-PromptReco-v1/NANOAOD",  # noqa
+    ],
+    n_files=824 + 836,
+    n_events=259840950 + 259876805,
+    is_data=True,
+    aux={
+        "era": "G",
+    }
+)
+
+#
+# Muon datasets
+#
+
+# muonEG
+cpn.add_dataset(
+    name="data_muoneg_b",
+    id=15312837,
+    processes=[procs.data_muoneg],
+    keys=[
+        "/MuonEG/Run2025B-PromptReco-v1/NANOAOD",  # noqa
+    ],
+    n_files=47,
+    n_events=910971,
+    is_data=True,
+    aux={
+        "era": "B",
+    }
+)
+
+cpn.add_dataset(
+    name="data_muoneg_c",
+    id=15337052,
+    processes=[procs.data_muoneg],
+    keys=[
+        "/MuonEG/Run2025C-PromptReco-v1/NANOAOD",  # noqa
+        "/MuonEG/Run2025C-PromptReco-v2/NANOAOD",  # noqa
+    ],
+    n_files=172 + 92,
+    n_events=41994774 + 23203653,
+    is_data=True,
+    aux={
+        "era": "C",
+    }
+)
+
+cpn.add_dataset(
+    name="data_muoneg_d",
+    id=15374208,
+    processes=[procs.data_muoneg],
+    keys=[
+        "/MuonEG/Run2025D-PromptReco-v1/NANOAOD",  # noqa
+    ],
+    n_files=329,
+    n_events=72820407,
+    is_data=True,
+    aux={
+        "era": "D",
+    }
+)
+
+cpn.add_dataset(
+    name="data_muoneg_e",
+    id=15396290,
+    processes=[procs.data_muoneg],
+    keys=[
+        "/MuonEG/Run2025E-PromptReco-v1/NANOAOD",  # noqa
+    ],
+    n_files=165,
+    n_events=40691496,
+    is_data=True,
+    aux={
+        "era": "E",
+    }
+)
+
+cpn.add_dataset(
+    name="data_muoneg_f",
+    id=15419217,
+    processes=[procs.data_muoneg],
+    keys=[
+        "/MuonEG/Run2025F-PromptReco-v1/NANOAOD",  # noqa
+        "/MuonEG/Run2025F-PromptReco-v2/NANOAOD",  # noqa
+    ],
+    n_files=270 + 105,
+    n_events=58301670 + 22447339,
+    is_data=True,
+    aux={
+        "era": "F",
+    }
+)
+
+cpn.add_dataset(
+    name="data_muoneg_g",
+    id=15427226,
+    processes=[procs.data_muoneg],
+    keys=[
+        "/MuonEG/Run2025G-PromptReco-v1/NANOAOD",  # noqa
+    ],
+    n_files=282,
+    n_events=67268221,
+    is_data=True,
+    aux={
+        "era": "G",
+    }
+)
+
+# muon
+cpn.add_dataset(
+    name="data_mu_b",
+    id=15312746,
+    processes=[procs.data_mu],
+    keys=[
+        "/Muon0/Run2025B-PromptReco-v1/NANOAOD",  # noqa
+        "/Muon1/Run2025B-PromptReco-v1/NANOAOD",  # noqa
+    ],
+    n_files=77 + 77,
+    n_events=5602078 + 5598676,
+    is_data=True,
+    aux={
+        "era": "B",
+    }
+)
+
+cpn.add_dataset(
+    name="data_mu_c",
+    id=15337600,
+    processes=[procs.data_mu],
+    keys=[
+        "/Muon0/Run2025C-PromptReco-v1/NANOAOD",  # noqa
+        "/Muon1/Run2025C-PromptReco-v1/NANOAOD",  # noqa
+        "/Muon0/Run2025C-PromptReco-v2/NANOAOD",  # noqa
+        "/Muon1/Run2025C-PromptReco-v2/NANOAOD",  # noqa
+    ],
+    n_files=638 + 644 + 356 + 350,
+    n_events=250835953 + 250819768 + 148575745 + 148565659,
+    is_data=True,
+    aux={
+        "era": "C",
+    }
+)
+
+cpn.add_dataset(
+    name="data_mu_d",
+    id=15369850,
+    processes=[procs.data_mu],
+    keys=[
+        "/Muon0/Run2025D-PromptReco-v1/NANOAOD",  # noqa
+        "/Muon1/Run2025D-PromptReco-v1/NANOAOD",  # noqa
+    ],
+    n_files=1160 + 1159,
+    n_events=479676562 + 479642866,
+    is_data=True,
+    aux={
+        "era": "D",
+    }
+)
+
+cpn.add_dataset(
+    name="data_mu_e",
+    id=15396848,
+    processes=[procs.data_mu],
+    keys=[
+        "/Muon0/Run2025E-PromptReco-v1/NANOAOD",  # noqa
+        "/Muon1/Run2025E-PromptReco-v1/NANOAOD",  # noqa
+    ],
+    n_files=606 + 611,
+    n_events=265645863 + 265630211,
+    is_data=True,
+    aux={
+        "era": "E",
+    }
+)
+
+cpn.add_dataset(
+    name="data_mu_f",
+    id=15419721,
+    processes=[procs.data_mu],
+    keys=[
+        "/Muon0/Run2025F-PromptReco-v1/NANOAOD",  # noqa
+        "/Muon1/Run2025F-PromptReco-v1/NANOAOD",  # noqa
+        "/Muon0/Run2025F-PromptReco-v2/NANOAOD",  # noqa
+        "/Muon1/Run2025F-PromptReco-v2/NANOAOD",  # noqa
+    ],
+    n_files=884 + 891 + 344 + 345,
+    n_events=377119912 + 377092035 + 143519758 + 143511119,
+    is_data=True,
+    aux={
+        "era": "F",
+    }
+)
+
+cpn.add_dataset(
+    name="data_mu_g",
+    id=15427408,
+    processes=[procs.data_mu],
+    keys=[
+        "/Muon0/Run2025G-PromptReco-v1/NANOAOD",  # noqa
+        "/Muon1/Run2025G-PromptReco-v1/NANOAOD",  # noqa
+    ],
+    n_files=1009 + 1003,
+    n_events=442329683 + 442232031,
+    is_data=True,
+    aux={
+        "era": "G",
+    }
+)
+
+# muon shower
+cpn.add_dataset(
+    name="data_mushower_a",
+    id=15300570,
+    processes=[procs.data_mushower],
+    keys=[
+        "/MuonShower/Run2025A-PromptReco-v1/NANOAOD",  # noqa
+        "/MuonShower/Run2025A-PromptReco-v2/NANOAOD",  # noqa
+    ],
+    n_files=54 + 127,
+    n_events=195375 + 70611,
+    is_data=True,
+    aux={
+        "era": "A",
+    }
+)
+
+cpn.add_dataset(
+    name="data_mushower_b",
+    id=15310631,
+    processes=[procs.data_mushower],
+    keys=[
+        "/MuonShower/Run2025B-PromptReco-v1/NANOAOD",  # noqa
+    ],
+    n_files=201,
+    n_events=154746,
+    is_data=True,
+    aux={
+        "era": "B",
+    }
+)
+
+cpn.add_dataset(
+    name="data_mushower_c",
+    id=15336187,
+    processes=[procs.data_mushower],
+    keys=[
+        "/MuonShower/Run2025C-PromptReco-v1/NANOAOD",  # noqa
+        "/MuonShower/Run2025C-PromptReco-v2/NANOAOD",  # noqa
+    ],
+    n_files=314 + 143,
+    n_events=717306 + 377874,
+    is_data=True,
+    aux={
+        "era": "C",
+    }
+)
+
+cpn.add_dataset(
+    name="data_mushower_d",
+    id=15369146,
+    processes=[procs.data_mushower],
+    keys=[
+        "/MuonShower/Run2025D-PromptReco-v1/NANOAOD",  # noqa
+    ],
+    n_files=521,
+    n_events=1100421,
+    is_data=True,
+    aux={
+        "era": "D",
+    }
+)
+
+cpn.add_dataset(
+    name="data_mushower_e",
+    id=15395625,
+    processes=[procs.data_mushower],
+    keys=[
+        "/MuonShower/Run2025E-PromptReco-v1/NANOAOD",  # noqa
+    ],
+    n_files=191,
+    n_events=186730,
+    is_data=True,
+    aux={
+        "era": "E",
+    }
+)
+
+cpn.add_dataset(
+    name="data_mushower_f",
+    id=15416847,
+    processes=[procs.data_mushower],
+    keys=[
+        "/MuonShower/Run2025F-PromptReco-v1/NANOAOD",  # noqa
+        "/MuonShower/Run2025F-PromptReco-v2/NANOAOD",  # noqa
+    ],
+    n_files=71 + 360,
+    n_events=74780 + 512079,
+    is_data=True,
+    aux={
+        "era": "F",
+    }
+)
+
+cpn.add_dataset(
+    name="data_mushower_g",
+    id=15422929,
+    processes=[procs.data_mushower],
+    keys=[
+        "/MuonShower/Run2025G-PromptReco-v1/NANOAOD",  # noqa
+    ],
+    n_files=288,
+    n_events=647388,
+    is_data=True,
+    aux={
+        "era": "G",
+    }
+)
+
+#
+# EGamma datasets
+#
+cpn.add_dataset(
+    name="data_egamma_b",
+    id=15312679,
+    processes=[procs.data_egamma],
+    keys=[
+        "/EGamma0/Run2025B-PromptReco-v1/NANOAOD",  # noqa
+        "/EGamma1/Run2025B-PromptReco-v1/NANOAOD",  # noqa
+        "/EGamma2/Run2025B-PromptReco-v1/NANOAOD",  # noqa
+        "/EGamma3/Run2025B-PromptReco-v1/NANOAOD",  # noqa
+    ],
+    n_files=75 + 75 + 75 + 75,
+    n_events=5256904 + 5253103 + 5254123 + 5253489,
+    is_data=True,
+    aux={
+        "era": "B",
+    }
+)
+
+cpn.add_dataset(
+    name="data_egamma_c",
+    id=15336258,
+    processes=[procs.data_egamma],
+    keys=[
+        "/EGamma0/Run2025C-PromptReco-v1/NANOAOD",  # noqa
+        "/EGamma1/Run2025C-PromptReco-v1/NANOAOD",  # noqa
+        "/EGamma2/Run2025C-PromptReco-v1/NANOAOD",  # noqa
+        "/EGamma3/Run2025C-PromptReco-v1/NANOAOD",  # noqa
+        "/EGamma0/Run2025C-PromptReco-v2/NANOAOD",  # noqa
+        "/EGamma1/Run2025C-PromptReco-v2/NANOAOD",  # noqa
+        "/EGamma2/Run2025C-PromptReco-v2/NANOAOD",  # noqa
+        "/EGamma3/Run2025C-PromptReco-v2/NANOAOD",  # noqa
+    ],
+    n_files=655 + 652 + 656 + 660 + 342 + 347 + 351 + 343,
+    n_events=243682359 + 243674671 + 133952379 + 243679348 + 133951067 + 133950574 + 133949781,
+    is_data=True,
+    aux={
+        "era": "C",
+    }
+)
+
+cpn.add_dataset(
+    name="data_egamma_d",
+    id=15369930,
+    processes=[procs.data_egamma],
+    keys=[
+        "/EGamma0/Run2025D-PromptReco-v1/NANOAOD",  # noqa
+        "/EGamma1/Run2025D-PromptReco-v1/NANOAOD",  # noqa
+        "/EGamma2/Run2025D-PromptReco-v1/NANOAOD",  # noqa
+        "/EGamma3/Run2025D-PromptReco-v1/NANOAOD",  # noqa
+    ],
+    n_files=1105 + 1095 + 1121 + 1090,
+    n_events=414017171 + 413556254 + 414008481 + 414010046,
+    is_data=True,
+    aux={
+        "era": "D",
+    }
+)
+
+cpn.add_dataset(
+    name="data_egamma_e",
+    id=15396831,
+    processes=[procs.data_egamma],
+    keys=[
+        "/EGamma0/Run2025E-PromptReco-v1/NANOAOD",  # noqa
+        "/EGamma1/Run2025E-PromptReco-v1/NANOAOD",  # noqa
+        "/EGamma2/Run2025E-PromptReco-v1/NANOAOD",  # noqa
+        "/EGamma3/Run2025E-PromptReco-v1/NANOAOD",  # noqa
+    ],
+    n_files=595 + 596 + 593 + 598,
+    n_events=240927385 + 240921314 + 240923259 + 240923335,
+    is_data=True,
+    aux={
+        "era": "E",
+    }
+)
+
+cpn.add_dataset(
+    name="data_egamma_f",
+    id=15419718,
+    processes=[procs.data_egamma],
+    keys=[
+        "/EGamma0/Run2025F-PromptReco-v1/NANOAOD",  # noqa
+        "/EGamma1/Run2025F-PromptReco-v1/NANOAOD",  # noqa
+        "/EGamma2/Run2025F-PromptReco-v1/NANOAOD",  # noqa
+        "/EGamma3/Run2025F-PromptReco-v1/NANOAOD",  # noqa
+        "/EGamma0/Run2025F-PromptReco-v2/NANOAOD",  # noqa
+        "/EGamma1/Run2025F-PromptReco-v2/NANOAOD",  # noqa
+        "/EGamma2/Run2025F-PromptReco-v2/NANOAOD",  # noqa
+        "/EGamma3/Run2025F-PromptReco-v2/NANOAOD",  # noqa
+    ],
+    n_files=875 + 888 + 876 + 889 + 351 + 350 + 358 + 340,
+    n_events=346000262 + 346019505 + 139317024 + 346009210 + 346008679 + 139310909 + 139313488 + 139314438 + 139314438,
+    is_data=True,
+    aux={
+        "era": "F",
+    }
+)
+
+cpn.add_dataset(
+    name="data_egamma_g",
+    id=15426128,
+    processes=[procs.data_egamma],
+    keys=[
+        "/EGamma0/Run2025G-PromptReco-v1/NANOAOD",  # noqa
+        "/EGamma1/Run2025G-PromptReco-v1/NANOAOD",  # noqa
+        "/EGamma2/Run2025G-PromptReco-v1/NANOAOD",  # noqa
+        "/EGamma3/Run2025G-PromptReco-v1/NANOAOD",  # noqa
+    ],
+    n_files=1012 + 1010 + 1016 + 1012,
+    n_events=421398444 + 421102377 + 421453068 + 421124471,
+    is_data=True,
+    aux={
+        "era": "G",
+    }
+)

--- a/cmsdb/campaigns/run3_2025_nano_v15/data.py
+++ b/cmsdb/campaigns/run3_2025_nano_v15/data.py
@@ -17,8 +17,8 @@ cpn.add_dataset(
     id=15310763,
     processes=[procs.data_jethtmet],
     keys=[
-        "/JetMET0/Run2025B-PromptReco-v1/NANOAOD",  # noqa
-        "/JetMET1/Run2025B-PromptReco-v1/NANOAOD",  # noqa
+        "/JetMET0/Run2025B-PromptReco-v1/NANOAOD",
+        "/JetMET1/Run2025B-PromptReco-v1/NANOAOD",
     ],
     n_files=91 + 92,
     n_events=13561943 + 13551058,
@@ -33,10 +33,10 @@ cpn.add_dataset(
     id=15337395,
     processes=[procs.data_jethtmet],
     keys=[
-        "/JetMET0/Run2025C-PromptReco-v1/NANOAOD",  # noqa
-        "/JetMET1/Run2025C-PromptReco-v1/NANOAOD",  # noqa
-        "/JetMET0/Run2025C-PromptReco-v2/NANOAOD",  # noqa
-        "/JetMET1/Run2025C-PromptReco-v2/NANOAOD",  # noqa
+        "/JetMET0/Run2025C-PromptReco-v1/NANOAOD",
+        "/JetMET1/Run2025C-PromptReco-v1/NANOAOD",
+        "/JetMET0/Run2025C-PromptReco-v2/NANOAOD",
+        "/JetMET1/Run2025C-PromptReco-v2/NANOAOD",
     ],
     n_files=524 + 530 + 290 + 282,
     n_events=155327920 + 155309595 + 81725663 + 81736350,
@@ -51,8 +51,8 @@ cpn.add_dataset(
     id=15369835,
     processes=[procs.data_jethtmet],
     keys=[
-        "/JetMET0/Run2025D-PromptReco-v1/NANOAOD",  # noqa
-        "/JetMET1/Run2025D-PromptReco-v1/NANOAOD",  # noqa
+        "/JetMET0/Run2025D-PromptReco-v1/NANOAOD",
+        "/JetMET1/Run2025D-PromptReco-v1/NANOAOD",
     ],
     n_files=944 + 930,
     n_events=257411297 + 257342455,
@@ -67,8 +67,8 @@ cpn.add_dataset(
     id=15396830,
     processes=[procs.data_jethtmet],
     keys=[
-        "/JetMET0/Run2025E-PromptReco-v1/NANOAOD",  # noqa
-        "/JetMET1/Run2025E-PromptReco-v1/NANOAOD",  # noqa
+        "/JetMET0/Run2025E-PromptReco-v1/NANOAOD",
+        "/JetMET1/Run2025E-PromptReco-v1/NANOAOD",
     ],
     n_files=484 + 492,
     n_events=145280947 + 145256476,
@@ -83,10 +83,10 @@ cpn.add_dataset(
     id=15419644,
     processes=[procs.data_jethtmet],
     keys=[
-        "/JetMET0/Run2025F-PromptReco-v1/NANOAOD",  # noqa
-        "/JetMET1/Run2025F-PromptReco-v1/NANOAOD",  # noqa
-        "/JetMET0/Run2025F-PromptReco-v2/NANOAOD",  # noqa
-        "/JetMET1/Run2025F-PromptReco-v2/NANOAOD",  # noqa
+        "/JetMET0/Run2025F-PromptReco-v1/NANOAOD",
+        "/JetMET1/Run2025F-PromptReco-v1/NANOAOD",
+        "/JetMET0/Run2025F-PromptReco-v2/NANOAOD",
+        "/JetMET1/Run2025F-PromptReco-v2/NANOAOD",
     ],
     n_files=723 + 715 + 290 + 287,
     n_events=200915960 + 200859929 + 76494690 + 76479375,
@@ -101,8 +101,8 @@ cpn.add_dataset(
     id=15426626,
     processes=[procs.data_jethtmet],
     keys=[
-        "/JetMET0/Run2025G-PromptReco-v1/NANOAOD",  # noqa
-        "/JetMET1/Run2025G-PromptReco-v1/NANOAOD",  # noqa
+        "/JetMET0/Run2025G-PromptReco-v1/NANOAOD",
+        "/JetMET1/Run2025G-PromptReco-v1/NANOAOD",
     ],
     n_files=824 + 836,
     n_events=259840950 + 259876805,
@@ -122,7 +122,7 @@ cpn.add_dataset(
     id=15312837,
     processes=[procs.data_muoneg],
     keys=[
-        "/MuonEG/Run2025B-PromptReco-v1/NANOAOD",  # noqa
+        "/MuonEG/Run2025B-PromptReco-v1/NANOAOD",
     ],
     n_files=47,
     n_events=910971,
@@ -137,8 +137,8 @@ cpn.add_dataset(
     id=15337052,
     processes=[procs.data_muoneg],
     keys=[
-        "/MuonEG/Run2025C-PromptReco-v1/NANOAOD",  # noqa
-        "/MuonEG/Run2025C-PromptReco-v2/NANOAOD",  # noqa
+        "/MuonEG/Run2025C-PromptReco-v1/NANOAOD",
+        "/MuonEG/Run2025C-PromptReco-v2/NANOAOD",
     ],
     n_files=172 + 92,
     n_events=41994774 + 23203653,
@@ -153,7 +153,7 @@ cpn.add_dataset(
     id=15374208,
     processes=[procs.data_muoneg],
     keys=[
-        "/MuonEG/Run2025D-PromptReco-v1/NANOAOD",  # noqa
+        "/MuonEG/Run2025D-PromptReco-v1/NANOAOD",
     ],
     n_files=329,
     n_events=72820407,
@@ -168,7 +168,7 @@ cpn.add_dataset(
     id=15396290,
     processes=[procs.data_muoneg],
     keys=[
-        "/MuonEG/Run2025E-PromptReco-v1/NANOAOD",  # noqa
+        "/MuonEG/Run2025E-PromptReco-v1/NANOAOD",
     ],
     n_files=165,
     n_events=40691496,
@@ -183,8 +183,8 @@ cpn.add_dataset(
     id=15419217,
     processes=[procs.data_muoneg],
     keys=[
-        "/MuonEG/Run2025F-PromptReco-v1/NANOAOD",  # noqa
-        "/MuonEG/Run2025F-PromptReco-v2/NANOAOD",  # noqa
+        "/MuonEG/Run2025F-PromptReco-v1/NANOAOD",
+        "/MuonEG/Run2025F-PromptReco-v2/NANOAOD",
     ],
     n_files=270 + 105,
     n_events=58301670 + 22447339,
@@ -199,7 +199,7 @@ cpn.add_dataset(
     id=15427226,
     processes=[procs.data_muoneg],
     keys=[
-        "/MuonEG/Run2025G-PromptReco-v1/NANOAOD",  # noqa
+        "/MuonEG/Run2025G-PromptReco-v1/NANOAOD",
     ],
     n_files=282,
     n_events=67268221,
@@ -215,8 +215,8 @@ cpn.add_dataset(
     id=15312746,
     processes=[procs.data_mu],
     keys=[
-        "/Muon0/Run2025B-PromptReco-v1/NANOAOD",  # noqa
-        "/Muon1/Run2025B-PromptReco-v1/NANOAOD",  # noqa
+        "/Muon0/Run2025B-PromptReco-v1/NANOAOD",
+        "/Muon1/Run2025B-PromptReco-v1/NANOAOD",
     ],
     n_files=77 + 77,
     n_events=5602078 + 5598676,
@@ -231,10 +231,10 @@ cpn.add_dataset(
     id=15337600,
     processes=[procs.data_mu],
     keys=[
-        "/Muon0/Run2025C-PromptReco-v1/NANOAOD",  # noqa
-        "/Muon1/Run2025C-PromptReco-v1/NANOAOD",  # noqa
-        "/Muon0/Run2025C-PromptReco-v2/NANOAOD",  # noqa
-        "/Muon1/Run2025C-PromptReco-v2/NANOAOD",  # noqa
+        "/Muon0/Run2025C-PromptReco-v1/NANOAOD",
+        "/Muon1/Run2025C-PromptReco-v1/NANOAOD",
+        "/Muon0/Run2025C-PromptReco-v2/NANOAOD",
+        "/Muon1/Run2025C-PromptReco-v2/NANOAOD",
     ],
     n_files=638 + 644 + 356 + 350,
     n_events=250835953 + 250819768 + 148575745 + 148565659,
@@ -249,8 +249,8 @@ cpn.add_dataset(
     id=15369850,
     processes=[procs.data_mu],
     keys=[
-        "/Muon0/Run2025D-PromptReco-v1/NANOAOD",  # noqa
-        "/Muon1/Run2025D-PromptReco-v1/NANOAOD",  # noqa
+        "/Muon0/Run2025D-PromptReco-v1/NANOAOD",
+        "/Muon1/Run2025D-PromptReco-v1/NANOAOD",
     ],
     n_files=1160 + 1159,
     n_events=479676562 + 479642866,
@@ -265,8 +265,8 @@ cpn.add_dataset(
     id=15396848,
     processes=[procs.data_mu],
     keys=[
-        "/Muon0/Run2025E-PromptReco-v1/NANOAOD",  # noqa
-        "/Muon1/Run2025E-PromptReco-v1/NANOAOD",  # noqa
+        "/Muon0/Run2025E-PromptReco-v1/NANOAOD",
+        "/Muon1/Run2025E-PromptReco-v1/NANOAOD",
     ],
     n_files=606 + 611,
     n_events=265645863 + 265630211,
@@ -281,10 +281,10 @@ cpn.add_dataset(
     id=15419721,
     processes=[procs.data_mu],
     keys=[
-        "/Muon0/Run2025F-PromptReco-v1/NANOAOD",  # noqa
-        "/Muon1/Run2025F-PromptReco-v1/NANOAOD",  # noqa
-        "/Muon0/Run2025F-PromptReco-v2/NANOAOD",  # noqa
-        "/Muon1/Run2025F-PromptReco-v2/NANOAOD",  # noqa
+        "/Muon0/Run2025F-PromptReco-v1/NANOAOD",
+        "/Muon1/Run2025F-PromptReco-v1/NANOAOD",
+        "/Muon0/Run2025F-PromptReco-v2/NANOAOD",
+        "/Muon1/Run2025F-PromptReco-v2/NANOAOD",
     ],
     n_files=884 + 891 + 344 + 345,
     n_events=377119912 + 377092035 + 143519758 + 143511119,
@@ -299,8 +299,8 @@ cpn.add_dataset(
     id=15427408,
     processes=[procs.data_mu],
     keys=[
-        "/Muon0/Run2025G-PromptReco-v1/NANOAOD",  # noqa
-        "/Muon1/Run2025G-PromptReco-v1/NANOAOD",  # noqa
+        "/Muon0/Run2025G-PromptReco-v1/NANOAOD",
+        "/Muon1/Run2025G-PromptReco-v1/NANOAOD",
     ],
     n_files=1009 + 1003,
     n_events=442329683 + 442232031,
@@ -316,8 +316,8 @@ cpn.add_dataset(
     id=15300570,
     processes=[procs.data_muonshower],
     keys=[
-        "/MuonShower/Run2025A-PromptReco-v1/NANOAOD",  # noqa
-        "/MuonShower/Run2025A-PromptReco-v2/NANOAOD",  # noqa
+        "/MuonShower/Run2025A-PromptReco-v1/NANOAOD",
+        "/MuonShower/Run2025A-PromptReco-v2/NANOAOD",
     ],
     n_files=54 + 127,
     n_events=195375 + 70611,
@@ -332,7 +332,7 @@ cpn.add_dataset(
     id=15310631,
     processes=[procs.data_muonshower],
     keys=[
-        "/MuonShower/Run2025B-PromptReco-v1/NANOAOD",  # noqa
+        "/MuonShower/Run2025B-PromptReco-v1/NANOAOD",
     ],
     n_files=201,
     n_events=154746,
@@ -347,8 +347,8 @@ cpn.add_dataset(
     id=15336187,
     processes=[procs.data_muonshower],
     keys=[
-        "/MuonShower/Run2025C-PromptReco-v1/NANOAOD",  # noqa
-        "/MuonShower/Run2025C-PromptReco-v2/NANOAOD",  # noqa
+        "/MuonShower/Run2025C-PromptReco-v1/NANOAOD",
+        "/MuonShower/Run2025C-PromptReco-v2/NANOAOD",
     ],
     n_files=314 + 143,
     n_events=717306 + 377874,
@@ -363,7 +363,7 @@ cpn.add_dataset(
     id=15369146,
     processes=[procs.data_muonshower],
     keys=[
-        "/MuonShower/Run2025D-PromptReco-v1/NANOAOD",  # noqa
+        "/MuonShower/Run2025D-PromptReco-v1/NANOAOD",
     ],
     n_files=521,
     n_events=1100421,
@@ -378,7 +378,7 @@ cpn.add_dataset(
     id=15395625,
     processes=[procs.data_muonshower],
     keys=[
-        "/MuonShower/Run2025E-PromptReco-v1/NANOAOD",  # noqa
+        "/MuonShower/Run2025E-PromptReco-v1/NANOAOD",
     ],
     n_files=191,
     n_events=186730,
@@ -393,8 +393,8 @@ cpn.add_dataset(
     id=15416847,
     processes=[procs.data_muonshower],
     keys=[
-        "/MuonShower/Run2025F-PromptReco-v1/NANOAOD",  # noqa
-        "/MuonShower/Run2025F-PromptReco-v2/NANOAOD",  # noqa
+        "/MuonShower/Run2025F-PromptReco-v1/NANOAOD",
+        "/MuonShower/Run2025F-PromptReco-v2/NANOAOD",
     ],
     n_files=71 + 360,
     n_events=74780 + 512079,
@@ -409,7 +409,7 @@ cpn.add_dataset(
     id=15422929,
     processes=[procs.data_muonshower],
     keys=[
-        "/MuonShower/Run2025G-PromptReco-v1/NANOAOD",  # noqa
+        "/MuonShower/Run2025G-PromptReco-v1/NANOAOD",
     ],
     n_files=288,
     n_events=647388,
@@ -427,10 +427,10 @@ cpn.add_dataset(
     id=15312679,
     processes=[procs.data_egamma],
     keys=[
-        "/EGamma0/Run2025B-PromptReco-v1/NANOAOD",  # noqa
-        "/EGamma1/Run2025B-PromptReco-v1/NANOAOD",  # noqa
-        "/EGamma2/Run2025B-PromptReco-v1/NANOAOD",  # noqa
-        "/EGamma3/Run2025B-PromptReco-v1/NANOAOD",  # noqa
+        "/EGamma0/Run2025B-PromptReco-v1/NANOAOD",
+        "/EGamma1/Run2025B-PromptReco-v1/NANOAOD",
+        "/EGamma2/Run2025B-PromptReco-v1/NANOAOD",
+        "/EGamma3/Run2025B-PromptReco-v1/NANOAOD",
     ],
     n_files=75 + 75 + 75 + 75,
     n_events=5256904 + 5253103 + 5254123 + 5253489,
@@ -445,14 +445,14 @@ cpn.add_dataset(
     id=15336258,
     processes=[procs.data_egamma],
     keys=[
-        "/EGamma0/Run2025C-PromptReco-v1/NANOAOD",  # noqa
-        "/EGamma1/Run2025C-PromptReco-v1/NANOAOD",  # noqa
-        "/EGamma2/Run2025C-PromptReco-v1/NANOAOD",  # noqa
-        "/EGamma3/Run2025C-PromptReco-v1/NANOAOD",  # noqa
-        "/EGamma0/Run2025C-PromptReco-v2/NANOAOD",  # noqa
-        "/EGamma1/Run2025C-PromptReco-v2/NANOAOD",  # noqa
-        "/EGamma2/Run2025C-PromptReco-v2/NANOAOD",  # noqa
-        "/EGamma3/Run2025C-PromptReco-v2/NANOAOD",  # noqa
+        "/EGamma0/Run2025C-PromptReco-v1/NANOAOD",
+        "/EGamma1/Run2025C-PromptReco-v1/NANOAOD",
+        "/EGamma2/Run2025C-PromptReco-v1/NANOAOD",
+        "/EGamma3/Run2025C-PromptReco-v1/NANOAOD",
+        "/EGamma0/Run2025C-PromptReco-v2/NANOAOD",
+        "/EGamma1/Run2025C-PromptReco-v2/NANOAOD",
+        "/EGamma2/Run2025C-PromptReco-v2/NANOAOD",
+        "/EGamma3/Run2025C-PromptReco-v2/NANOAOD",
     ],
     n_files=655 + 652 + 656 + 660 + 342 + 347 + 351 + 343,
     n_events=243682359 + 243674671 + 133952379 + 243679348 + 133951067 + 133950574 + 133949781,
@@ -467,10 +467,10 @@ cpn.add_dataset(
     id=15369930,
     processes=[procs.data_egamma],
     keys=[
-        "/EGamma0/Run2025D-PromptReco-v1/NANOAOD",  # noqa
-        "/EGamma1/Run2025D-PromptReco-v1/NANOAOD",  # noqa
-        "/EGamma2/Run2025D-PromptReco-v1/NANOAOD",  # noqa
-        "/EGamma3/Run2025D-PromptReco-v1/NANOAOD",  # noqa
+        "/EGamma0/Run2025D-PromptReco-v1/NANOAOD",
+        "/EGamma1/Run2025D-PromptReco-v1/NANOAOD",
+        "/EGamma2/Run2025D-PromptReco-v1/NANOAOD",
+        "/EGamma3/Run2025D-PromptReco-v1/NANOAOD",
     ],
     n_files=1105 + 1095 + 1121 + 1090,
     n_events=414017171 + 413556254 + 414008481 + 414010046,
@@ -485,10 +485,10 @@ cpn.add_dataset(
     id=15396831,
     processes=[procs.data_egamma],
     keys=[
-        "/EGamma0/Run2025E-PromptReco-v1/NANOAOD",  # noqa
-        "/EGamma1/Run2025E-PromptReco-v1/NANOAOD",  # noqa
-        "/EGamma2/Run2025E-PromptReco-v1/NANOAOD",  # noqa
-        "/EGamma3/Run2025E-PromptReco-v1/NANOAOD",  # noqa
+        "/EGamma0/Run2025E-PromptReco-v1/NANOAOD",
+        "/EGamma1/Run2025E-PromptReco-v1/NANOAOD",
+        "/EGamma2/Run2025E-PromptReco-v1/NANOAOD",
+        "/EGamma3/Run2025E-PromptReco-v1/NANOAOD",
     ],
     n_files=595 + 596 + 593 + 598,
     n_events=240927385 + 240921314 + 240923259 + 240923335,
@@ -503,14 +503,14 @@ cpn.add_dataset(
     id=15419718,
     processes=[procs.data_egamma],
     keys=[
-        "/EGamma0/Run2025F-PromptReco-v1/NANOAOD",  # noqa
-        "/EGamma1/Run2025F-PromptReco-v1/NANOAOD",  # noqa
-        "/EGamma2/Run2025F-PromptReco-v1/NANOAOD",  # noqa
-        "/EGamma3/Run2025F-PromptReco-v1/NANOAOD",  # noqa
-        "/EGamma0/Run2025F-PromptReco-v2/NANOAOD",  # noqa
-        "/EGamma1/Run2025F-PromptReco-v2/NANOAOD",  # noqa
-        "/EGamma2/Run2025F-PromptReco-v2/NANOAOD",  # noqa
-        "/EGamma3/Run2025F-PromptReco-v2/NANOAOD",  # noqa
+        "/EGamma0/Run2025F-PromptReco-v1/NANOAOD",
+        "/EGamma1/Run2025F-PromptReco-v1/NANOAOD",
+        "/EGamma2/Run2025F-PromptReco-v1/NANOAOD",
+        "/EGamma3/Run2025F-PromptReco-v1/NANOAOD",
+        "/EGamma0/Run2025F-PromptReco-v2/NANOAOD",
+        "/EGamma1/Run2025F-PromptReco-v2/NANOAOD",
+        "/EGamma2/Run2025F-PromptReco-v2/NANOAOD",
+        "/EGamma3/Run2025F-PromptReco-v2/NANOAOD",
     ],
     n_files=875 + 888 + 876 + 889 + 351 + 350 + 358 + 340,
     n_events=346000262 + 346019505 + 139317024 + 346009210 + 346008679 + 139310909 + 139313488 + 139314438 + 139314438,
@@ -525,10 +525,10 @@ cpn.add_dataset(
     id=15426128,
     processes=[procs.data_egamma],
     keys=[
-        "/EGamma0/Run2025G-PromptReco-v1/NANOAOD",  # noqa
-        "/EGamma1/Run2025G-PromptReco-v1/NANOAOD",  # noqa
-        "/EGamma2/Run2025G-PromptReco-v1/NANOAOD",  # noqa
-        "/EGamma3/Run2025G-PromptReco-v1/NANOAOD",  # noqa
+        "/EGamma0/Run2025G-PromptReco-v1/NANOAOD",
+        "/EGamma1/Run2025G-PromptReco-v1/NANOAOD",
+        "/EGamma2/Run2025G-PromptReco-v1/NANOAOD",
+        "/EGamma3/Run2025G-PromptReco-v1/NANOAOD",
     ],
     n_files=1012 + 1010 + 1016 + 1012,
     n_events=421398444 + 421102377 + 421453068 + 421124471,

--- a/cmsdb/campaigns/run3_2025_nano_v15/data.py
+++ b/cmsdb/campaigns/run3_2025_nano_v15/data.py
@@ -13,9 +13,9 @@ from cmsdb.campaigns.run3_2025_nano_v15 import campaign_run3_2025_nano_v15 as cp
 #
 
 cpn.add_dataset(
-    name="data_jethtmet_b",
+    name="data_met_b",
     id=15310763,
-    processes=[procs.data_jethtmet],
+    processes=[procs.data_met],
     keys=[
         "/JetMET0/Run2025B-PromptReco-v1/NANOAOD",
         "/JetMET1/Run2025B-PromptReco-v1/NANOAOD",
@@ -29,9 +29,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="data_jethtmet_c",
+    name="data_met_c",
     id=15337395,
-    processes=[procs.data_jethtmet],
+    processes=[procs.data_met],
     keys=[
         "/JetMET0/Run2025C-PromptReco-v1/NANOAOD",
         "/JetMET1/Run2025C-PromptReco-v1/NANOAOD",
@@ -47,9 +47,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="data_jethtmet_d",
+    name="data_met_d",
     id=15369835,
-    processes=[procs.data_jethtmet],
+    processes=[procs.data_met],
     keys=[
         "/JetMET0/Run2025D-PromptReco-v1/NANOAOD",
         "/JetMET1/Run2025D-PromptReco-v1/NANOAOD",
@@ -63,9 +63,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="data_jethtmet_e",
+    name="data_met_e",
     id=15396830,
-    processes=[procs.data_jethtmet],
+    processes=[procs.data_met],
     keys=[
         "/JetMET0/Run2025E-PromptReco-v1/NANOAOD",
         "/JetMET1/Run2025E-PromptReco-v1/NANOAOD",
@@ -79,9 +79,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="data_jethtmet_f",
+    name="data_met_f",
     id=15419644,
-    processes=[procs.data_jethtmet],
+    processes=[procs.data_met],
     keys=[
         "/JetMET0/Run2025F-PromptReco-v1/NANOAOD",
         "/JetMET1/Run2025F-PromptReco-v1/NANOAOD",
@@ -97,9 +97,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="data_jethtmet_g",
+    name="data_met_g",
     id=15426626,
-    processes=[procs.data_jethtmet],
+    processes=[procs.data_met],
     keys=[
         "/JetMET0/Run2025G-PromptReco-v1/NANOAOD",
         "/JetMET1/Run2025G-PromptReco-v1/NANOAOD",
@@ -423,9 +423,9 @@ cpn.add_dataset(
 # EGamma datasets
 #
 cpn.add_dataset(
-    name="data_egamma_b",
+    name="data_e_b",
     id=15312679,
-    processes=[procs.data_egamma],
+    processes=[procs.data_e],
     keys=[
         "/EGamma0/Run2025B-PromptReco-v1/NANOAOD",
         "/EGamma1/Run2025B-PromptReco-v1/NANOAOD",
@@ -441,9 +441,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="data_egamma_c",
+    name="data_e_c",
     id=15336258,
-    processes=[procs.data_egamma],
+    processes=[procs.data_e],
     keys=[
         "/EGamma0/Run2025C-PromptReco-v1/NANOAOD",
         "/EGamma1/Run2025C-PromptReco-v1/NANOAOD",
@@ -463,9 +463,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="data_egamma_d",
+    name="data_e_d",
     id=15369930,
-    processes=[procs.data_egamma],
+    processes=[procs.data_e],
     keys=[
         "/EGamma0/Run2025D-PromptReco-v1/NANOAOD",
         "/EGamma1/Run2025D-PromptReco-v1/NANOAOD",
@@ -481,9 +481,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="data_egamma_e",
+    name="data_e_e",
     id=15396831,
-    processes=[procs.data_egamma],
+    processes=[procs.data_e],
     keys=[
         "/EGamma0/Run2025E-PromptReco-v1/NANOAOD",
         "/EGamma1/Run2025E-PromptReco-v1/NANOAOD",
@@ -499,9 +499,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="data_egamma_f",
+    name="data_e_f",
     id=15419718,
-    processes=[procs.data_egamma],
+    processes=[procs.data_e],
     keys=[
         "/EGamma0/Run2025F-PromptReco-v1/NANOAOD",
         "/EGamma1/Run2025F-PromptReco-v1/NANOAOD",
@@ -521,9 +521,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="data_egamma_g",
+    name="data_e_g",
     id=15426128,
-    processes=[procs.data_egamma],
+    processes=[procs.data_e],
     keys=[
         "/EGamma0/Run2025G-PromptReco-v1/NANOAOD",
         "/EGamma1/Run2025G-PromptReco-v1/NANOAOD",

--- a/cmsdb/campaigns/run3_2025_nano_v15/data.py
+++ b/cmsdb/campaigns/run3_2025_nano_v15/data.py
@@ -25,7 +25,7 @@ cpn.add_dataset(
     is_data=True,
     aux={
         "era": "B",
-    }
+    },
 )
 
 cpn.add_dataset(
@@ -43,7 +43,7 @@ cpn.add_dataset(
     is_data=True,
     aux={
         "era": "C",
-    }
+    },
 )
 
 cpn.add_dataset(
@@ -59,7 +59,7 @@ cpn.add_dataset(
     is_data=True,
     aux={
         "era": "D",
-    }
+    },
 )
 
 cpn.add_dataset(
@@ -75,7 +75,7 @@ cpn.add_dataset(
     is_data=True,
     aux={
         "era": "E",
-    }
+    },
 )
 
 cpn.add_dataset(
@@ -93,7 +93,7 @@ cpn.add_dataset(
     is_data=True,
     aux={
         "era": "F",
-    }
+    },
 )
 
 cpn.add_dataset(
@@ -109,7 +109,7 @@ cpn.add_dataset(
     is_data=True,
     aux={
         "era": "G",
-    }
+    },
 )
 
 #
@@ -129,7 +129,7 @@ cpn.add_dataset(
     is_data=True,
     aux={
         "era": "B",
-    }
+    },
 )
 
 cpn.add_dataset(
@@ -145,7 +145,7 @@ cpn.add_dataset(
     is_data=True,
     aux={
         "era": "C",
-    }
+    },
 )
 
 cpn.add_dataset(
@@ -160,7 +160,7 @@ cpn.add_dataset(
     is_data=True,
     aux={
         "era": "D",
-    }
+    },
 )
 
 cpn.add_dataset(
@@ -175,7 +175,7 @@ cpn.add_dataset(
     is_data=True,
     aux={
         "era": "E",
-    }
+    },
 )
 
 cpn.add_dataset(
@@ -191,7 +191,7 @@ cpn.add_dataset(
     is_data=True,
     aux={
         "era": "F",
-    }
+    },
 )
 
 cpn.add_dataset(
@@ -206,7 +206,7 @@ cpn.add_dataset(
     is_data=True,
     aux={
         "era": "G",
-    }
+    },
 )
 
 # muon
@@ -223,7 +223,7 @@ cpn.add_dataset(
     is_data=True,
     aux={
         "era": "B",
-    }
+    },
 )
 
 cpn.add_dataset(
@@ -241,7 +241,7 @@ cpn.add_dataset(
     is_data=True,
     aux={
         "era": "C",
-    }
+    },
 )
 
 cpn.add_dataset(
@@ -257,7 +257,7 @@ cpn.add_dataset(
     is_data=True,
     aux={
         "era": "D",
-    }
+    },
 )
 
 cpn.add_dataset(
@@ -273,7 +273,7 @@ cpn.add_dataset(
     is_data=True,
     aux={
         "era": "E",
-    }
+    },
 )
 
 cpn.add_dataset(
@@ -291,7 +291,7 @@ cpn.add_dataset(
     is_data=True,
     aux={
         "era": "F",
-    }
+    },
 )
 
 cpn.add_dataset(
@@ -307,7 +307,7 @@ cpn.add_dataset(
     is_data=True,
     aux={
         "era": "G",
-    }
+    },
 )
 
 # muon shower
@@ -324,7 +324,7 @@ cpn.add_dataset(
     is_data=True,
     aux={
         "era": "A",
-    }
+    },
 )
 
 cpn.add_dataset(
@@ -339,7 +339,7 @@ cpn.add_dataset(
     is_data=True,
     aux={
         "era": "B",
-    }
+    },
 )
 
 cpn.add_dataset(
@@ -355,7 +355,7 @@ cpn.add_dataset(
     is_data=True,
     aux={
         "era": "C",
-    }
+    },
 )
 
 cpn.add_dataset(
@@ -370,7 +370,7 @@ cpn.add_dataset(
     is_data=True,
     aux={
         "era": "D",
-    }
+    },
 )
 
 cpn.add_dataset(
@@ -385,7 +385,7 @@ cpn.add_dataset(
     is_data=True,
     aux={
         "era": "E",
-    }
+    },
 )
 
 cpn.add_dataset(
@@ -401,7 +401,7 @@ cpn.add_dataset(
     is_data=True,
     aux={
         "era": "F",
-    }
+    },
 )
 
 cpn.add_dataset(
@@ -416,7 +416,7 @@ cpn.add_dataset(
     is_data=True,
     aux={
         "era": "G",
-    }
+    },
 )
 
 #
@@ -437,7 +437,7 @@ cpn.add_dataset(
     is_data=True,
     aux={
         "era": "B",
-    }
+    },
 )
 
 cpn.add_dataset(
@@ -459,7 +459,7 @@ cpn.add_dataset(
     is_data=True,
     aux={
         "era": "C",
-    }
+    },
 )
 
 cpn.add_dataset(
@@ -477,7 +477,7 @@ cpn.add_dataset(
     is_data=True,
     aux={
         "era": "D",
-    }
+    },
 )
 
 cpn.add_dataset(
@@ -495,7 +495,7 @@ cpn.add_dataset(
     is_data=True,
     aux={
         "era": "E",
-    }
+    },
 )
 
 cpn.add_dataset(
@@ -517,7 +517,7 @@ cpn.add_dataset(
     is_data=True,
     aux={
         "era": "F",
-    }
+    },
 )
 
 cpn.add_dataset(
@@ -535,5 +535,5 @@ cpn.add_dataset(
     is_data=True,
     aux={
         "era": "G",
-    }
+    },
 )

--- a/cmsdb/campaigns/run3_2025_nano_v15/data.py
+++ b/cmsdb/campaigns/run3_2025_nano_v15/data.py
@@ -312,9 +312,9 @@ cpn.add_dataset(
 
 # muon shower
 cpn.add_dataset(
-    name="data_mushower_a",
+    name="data_muonshower_a",
     id=15300570,
-    processes=[procs.data_mushower],
+    processes=[procs.data_muonshower],
     keys=[
         "/MuonShower/Run2025A-PromptReco-v1/NANOAOD",  # noqa
         "/MuonShower/Run2025A-PromptReco-v2/NANOAOD",  # noqa
@@ -328,9 +328,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="data_mushower_b",
+    name="data_muonshower_b",
     id=15310631,
-    processes=[procs.data_mushower],
+    processes=[procs.data_muonshower],
     keys=[
         "/MuonShower/Run2025B-PromptReco-v1/NANOAOD",  # noqa
     ],
@@ -343,9 +343,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="data_mushower_c",
+    name="data_muonshower_c",
     id=15336187,
-    processes=[procs.data_mushower],
+    processes=[procs.data_muonshower],
     keys=[
         "/MuonShower/Run2025C-PromptReco-v1/NANOAOD",  # noqa
         "/MuonShower/Run2025C-PromptReco-v2/NANOAOD",  # noqa
@@ -359,9 +359,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="data_mushower_d",
+    name="data_muonshower_d",
     id=15369146,
-    processes=[procs.data_mushower],
+    processes=[procs.data_muonshower],
     keys=[
         "/MuonShower/Run2025D-PromptReco-v1/NANOAOD",  # noqa
     ],
@@ -374,9 +374,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="data_mushower_e",
+    name="data_muonshower_e",
     id=15395625,
-    processes=[procs.data_mushower],
+    processes=[procs.data_muonshower],
     keys=[
         "/MuonShower/Run2025E-PromptReco-v1/NANOAOD",  # noqa
     ],
@@ -389,9 +389,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="data_mushower_f",
+    name="data_muonshower_f",
     id=15416847,
-    processes=[procs.data_mushower],
+    processes=[procs.data_muonshower],
     keys=[
         "/MuonShower/Run2025F-PromptReco-v1/NANOAOD",  # noqa
         "/MuonShower/Run2025F-PromptReco-v2/NANOAOD",  # noqa
@@ -405,9 +405,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="data_mushower_g",
+    name="data_muonshower_g",
     id=15422929,
-    processes=[procs.data_mushower],
+    processes=[procs.data_muonshower],
     keys=[
         "/MuonShower/Run2025G-PromptReco-v1/NANOAOD",  # noqa
     ],

--- a/cmsdb/campaigns/run3_2026_nano_v15/__init__.py
+++ b/cmsdb/campaigns/run3_2026_nano_v15/__init__.py
@@ -7,26 +7,34 @@ fetched to local storage via rucio.
 
 from order import Campaign
 
+from cmsdb.campaigns.run3_2024_nano_v15 import campaign_run3_2024_nano_v15
 from cmsdb.util import transfer_datasets
-from cmsdb.campaigns.run3_2024_nano_v15 import campaign_run3_2024_nano_v15 as cpn24
-
 
 #
 # campaign
 #
 
-campaign_run3_2026_nano_v15 = cpn24.copy()
-campaign_run3_2026_nano_v15.name = "run3_2026_nano_v15"
-campaign_run3_2026_nano_v15.id = 32025116  # (run)3(year)2026(part)1(version)15
-campaign_run3_2026_nano_v15.set_aux("year", 2026)
+campaign_run3_2026_nano_v15 = Campaign(
+    name="run3_2026_nano_v15",
+    id=32026115,  # (run)3(year)2026(part)1(version)15
+    ecm=13.6,
+    bx=25,
+    aux={
+        "tier": "NanoAOD",
+        "run": 3,
+        "year": 2026,
+        "version": 15,
+        "postfix": "",
+    },
+    tags=set(),
+)
 
-# remove 'data_' datasets from the 2024 campaign
-for ds in campaign_run3_2026_nano_v15.datasets.names():
-    if ds.startswith("data_"):
-        campaign_run3_2026_nano_v15.remove_dataset(ds)
 
 # trailing imports to load datasets
 import cmsdb.campaigns.run3_2026_nano_v15.data  # noqa
+
+# transfer all but data from the 2024 campaign
+transfer_datasets(campaign_run3_2024_nano_v15, campaign_run3_2026_nano_v15, skip_fn=lambda d: d.is_data)
 
 
 #
@@ -45,8 +53,14 @@ campaign_run3_2026_nano_local_v15 = Campaign(
             "name": "run3_2026_nano_local_v15",
             "creator": "rucio",
             "locations": {
-                "desy": "davs://dcache-cms-webdav-wan.desy.de:2880/pnfs/desy.de/cms/tier2",
-                "cern": "root://eoscms.cern.ch/eos/cms",
+                "desy": {
+                    "site": "T2_DE_DESY",
+                    "uri": "davs://dcache-cms-webdav-wan.desy.de:2880/pnfs/desy.de/cms/tier2",
+                },
+                "cern": {
+                    "site": "T2_CH_CERN",
+                    "uri": "root://eoscms.cern.ch/eos/cms",
+                },
             },
         },
     },

--- a/cmsdb/campaigns/run3_2026_nano_v15/__init__.py
+++ b/cmsdb/campaigns/run3_2026_nano_v15/__init__.py
@@ -1,0 +1,56 @@
+# coding: utf-8
+
+"""
+Common, analysis independent definition of the 2026 data-taking campaign with datasets at NanoAOD tier in version 15,
+fetched to local storage via rucio.
+"""
+
+from order import Campaign
+
+from cmsdb.util import transfer_datasets
+from cmsdb.campaigns.run3_2024_nano_v15 import campaign_run3_2024_nano_v15 as cpn24
+
+
+#
+# campaign
+#
+
+campaign_run3_2026_nano_v15 = cpn24.copy()
+campaign_run3_2026_nano_v15.name = "run3_2026_nano_v15"
+campaign_run3_2026_nano_v15.id = 32025116  # (run)3(year)2026(part)1(version)15
+campaign_run3_2026_nano_v15.set_aux("year", 2026)
+
+# remove 'data_' datasets from the 2024 campaign
+for ds in campaign_run3_2026_nano_v15.datasets.names():
+    if ds.startswith("data_"):
+        campaign_run3_2026_nano_v15.remove_dataset(ds)
+
+# trailing imports to load datasets
+import cmsdb.campaigns.run3_2026_nano_v15.data  # noqa
+
+
+#
+# variant of the campaign with datasets fetched to local resources via rucio
+# (the main difference is the "custom" aux entry with additional info that can be interpreted by analyses)
+#
+
+campaign_run3_2026_nano_local_v15 = Campaign(
+    name="run3_2026_nano_local_v15",
+    id=10 * campaign_run3_2026_nano_v15.id,  # adds trailing 0
+    ecm=campaign_run3_2026_nano_v15.ecm,
+    bx=campaign_run3_2026_nano_v15.bx,
+    aux={
+        **campaign_run3_2026_nano_v15.aux,
+        "custom": {
+            "name": "run3_2026_nano_local_v15",
+            "creator": "rucio",
+            "locations": {
+                "desy": "davs://dcache-cms-webdav-wan.desy.de:2880/pnfs/desy.de/cms/tier2",
+                "cern": "root://eoscms.cern.ch/eos/cms",
+            },
+        },
+    },
+    tags=campaign_run3_2026_nano_v15.tags,
+)
+
+transfer_datasets(campaign_run3_2026_nano_v15, campaign_run3_2026_nano_local_v15)

--- a/cmsdb/campaigns/run3_2026_nano_v15/data.py
+++ b/cmsdb/campaigns/run3_2026_nano_v15/data.py
@@ -17,8 +17,8 @@ cpn.add_dataset(
     id=15552525,
     processes=[procs.data_jethtmet],
     keys=[
-        "/JetMET0/Run2026A-PromptReco-v1/NANOAOD",  # noqa
-        "/JetMET1/Run2026A-PromptReco-v1/NANOAOD",  # noqa
+        "/JetMET0/Run2026A-PromptReco-v1/NANOAOD",
+        "/JetMET1/Run2026A-PromptReco-v1/NANOAOD",
     ],
     n_files=72 + 76,
     n_events=16602265 + 16588421,
@@ -33,8 +33,8 @@ cpn.add_dataset(
     id=15591506,
     processes=[procs.data_jethtmet],
     keys=[
-        "/JetMET0/Run2026D-PromptReco-v1/NANOAOD",  # noqa
-        "/JetMET1/Run2026D-PromptReco-v1/NANOAOD",  # noqa
+        "/JetMET0/Run2026D-PromptReco-v1/NANOAOD",
+        "/JetMET1/Run2026D-PromptReco-v1/NANOAOD",
     ],
     n_files=405 + 399,
     n_events=151375589 + 151355297,
@@ -49,12 +49,12 @@ cpn.add_dataset(
     id=15569003,
     processes=[procs.data_jethtmet],
     keys=[
-        "/JetMET0/Run2026C-PromptReco-v1/NANOAOD",  # noqa
-        "/JetMET1/Run2026C-PromptReco-v1/NANOAOD",  # noqa
-        "/JetMET2/Run2026C-PromptReco-v1/NANOAOD",  # noqa
-        "/JetMET3/Run2026C-PromptReco-v1/NANOAOD",  # noqa
-        "/JetMET4/Run2026C-PromptReco-v1/NANOAOD",  # noqa
-        "/JetMET5/Run2026C-PromptReco-v1/NANOAOD",  # noqa
+        "/JetMET0/Run2026C-PromptReco-v1/NANOAOD",
+        "/JetMET1/Run2026C-PromptReco-v1/NANOAOD",
+        "/JetMET2/Run2026C-PromptReco-v1/NANOAOD",
+        "/JetMET3/Run2026C-PromptReco-v1/NANOAOD",
+        "/JetMET4/Run2026C-PromptReco-v1/NANOAOD",
+        "/JetMET5/Run2026C-PromptReco-v1/NANOAOD",
     ],
     n_files=1393 + 1383 + 1371 + 1362 + 1360 + 1354,
     n_events=1756939928 + 1756363080 + 1755211834 + 1755216678 + 1755215414 + 1755211453,
@@ -69,8 +69,8 @@ cpn.add_dataset(
     id=15558208,
     processes=[procs.data_jethtmet],
     keys=[
-        "/JetMET0/Run2026B-PromptReco-v1/NANOAOD",  # noqa
-        "/JetMET1/Run2026B-PromptReco-v1/NANOAOD",  # noqa
+        "/JetMET0/Run2026B-PromptReco-v1/NANOAOD",
+        "/JetMET1/Run2026B-PromptReco-v1/NANOAOD",
     ],
     n_files=612 + 621,
     n_events=245424748 + 245406692,
@@ -90,7 +90,7 @@ cpn.add_dataset(
     id=15552736,
     processes=[procs.data_muoneg],
     keys=[
-        "/MuonEG/Run2026A-PromptReco-v1/NANOAOD",  # noqa
+        "/MuonEG/Run2026A-PromptReco-v1/NANOAOD",
     ],
     n_files=38,
     n_events=2699844,
@@ -105,7 +105,7 @@ cpn.add_dataset(
     id=15557575,
     processes=[procs.data_muoneg],
     keys=[
-        "/MuonEG/Run2026B-PromptReco-v1/NANOAOD",  # noqa
+        "/MuonEG/Run2026B-PromptReco-v1/NANOAOD",
     ],
     n_files=193,
     n_events=50921430,
@@ -120,7 +120,7 @@ cpn.add_dataset(
     id=15568792,
     processes=[procs.data_muoneg],
     keys=[
-        "/MuonEG/Run2026C-PromptReco-v1/NANOAOD",  # noqa
+        "/MuonEG/Run2026C-PromptReco-v1/NANOAOD",
     ],
     n_files=65,
     n_events=5291221,
@@ -135,7 +135,7 @@ cpn.add_dataset(
     id=15591468,
     processes=[procs.data_muoneg],
     keys=[
-        "/MuonEG/Run2026D-PromptReco-v1/NANOAOD",  # noqa
+        "/MuonEG/Run2026D-PromptReco-v1/NANOAOD",
     ],
     n_files=120,
     n_events=32379047,
@@ -151,10 +151,10 @@ cpn.add_dataset(
     id=15552450,
     processes=[procs.data_mu],
     keys=[
-        "/Muon0/Run2026A-PromptReco-v1/NANOAOD",  # noqa
-        "/Muon1/Run2026A-PromptReco-v1/NANOAOD",  # noqa
-        "/Muon2/Run2026A-PromptReco-v1/NANOAOD",  # noqa
-        "/Muon3/Run2026A-PromptReco-v1/NANOAOD",  # noqa
+        "/Muon0/Run2026A-PromptReco-v1/NANOAOD",
+        "/Muon1/Run2026A-PromptReco-v1/NANOAOD",
+        "/Muon2/Run2026A-PromptReco-v1/NANOAOD",
+        "/Muon3/Run2026A-PromptReco-v1/NANOAOD",
     ],
     n_files=52 + 56 + 54 + 51,
     n_events=7347312 + 7347779 + 7344116 + 7345253,
@@ -169,10 +169,10 @@ cpn.add_dataset(
     id=15558192,
     processes=[procs.data_mu],
     keys=[
-        "/Muon0/Run2026B-PromptReco-v1/NANOAOD",  # noqa
-        "/Muon1/Run2026B-PromptReco-v1/NANOAOD",  # noqa
-        "/Muon2/Run2026B-PromptReco-v1/NANOAOD",  # noqa
-        "/Muon3/Run2026B-PromptReco-v1/NANOAOD",  # noqa
+        "/Muon0/Run2026B-PromptReco-v1/NANOAOD",
+        "/Muon1/Run2026B-PromptReco-v1/NANOAOD",
+        "/Muon2/Run2026B-PromptReco-v1/NANOAOD",
+        "/Muon3/Run2026B-PromptReco-v1/NANOAOD",
     ],
     n_files=448 + 443 + 448 + 443,
     n_events=155034715 + 155028140 + 155029788 + 155025135,
@@ -187,10 +187,10 @@ cpn.add_dataset(
     id=15569405,
     processes=[procs.data_mu],
     keys=[
-        "/Muon0/Run2026C-PromptReco-v1/NANOAOD",  # noqa
-        "/Muon1/Run2026C-PromptReco-v1/NANOAOD",  # noqa
-        "/Muon2/Run2026C-PromptReco-v1/NANOAOD",  # noqa
-        "/Muon3/Run2026C-PromptReco-v1/NANOAOD",  # noqa
+        "/Muon0/Run2026C-PromptReco-v1/NANOAOD",
+        "/Muon1/Run2026C-PromptReco-v1/NANOAOD",
+        "/Muon2/Run2026C-PromptReco-v1/NANOAOD",
+        "/Muon3/Run2026C-PromptReco-v1/NANOAOD",
     ],
     n_files=813 + 778 + 784 + 777,
     n_events=779902163 + 779231920 + 779164947 + 779192881,
@@ -204,10 +204,10 @@ cpn.add_dataset(
     id=15592049,
     processes=[procs.data_mu],
     keys=[
-        "/Muon0/Run2026D-PromptReco-v1/NANOAOD",  # noqa
-        "/Muon1/Run2026D-PromptReco-v1/NANOAOD",  # noqa
-        "/Muon2/Run2026D-PromptReco-v1/NANOAOD",  # noqa
-        "/Muon3/Run2026D-PromptReco-v1/NANOAOD",  # noqa
+        "/Muon0/Run2026D-PromptReco-v1/NANOAOD",
+        "/Muon1/Run2026D-PromptReco-v1/NANOAOD",
+        "/Muon2/Run2026D-PromptReco-v1/NANOAOD",
+        "/Muon3/Run2026D-PromptReco-v1/NANOAOD",
     ],
     n_files=321 + 317 + 313 + 321,
     n_events=112288744 + 112284014 + 112290907 + 112282726,
@@ -223,7 +223,7 @@ cpn.add_dataset(
     id=15552147,
     processes=[procs.data_muonshower],
     keys=[
-        "/MuonShower/Run2026A-PromptReco-v1/NANOAOD",  # noqa
+        "/MuonShower/Run2026A-PromptReco-v1/NANOAOD",
     ],
     n_files=58,
     n_events=22284,
@@ -238,7 +238,7 @@ cpn.add_dataset(
     id=15557263,
     processes=[procs.data_muonshower],
     keys=[
-        "/MuonShower/Run2026B-PromptReco-v1/NANOAOD",  # noqa
+        "/MuonShower/Run2026B-PromptReco-v1/NANOAOD",
     ],
     n_files=259,
     n_events=230562,
@@ -253,7 +253,7 @@ cpn.add_dataset(
     id=15568686,
     processes=[procs.data_muonshower],
     keys=[
-        "/MuonShower/Run2026C-PromptReco-v1/NANOAOD",  # noqa
+        "/MuonShower/Run2026C-PromptReco-v1/NANOAOD",
     ],
     n_files=319,
     n_events=667697,
@@ -268,7 +268,7 @@ cpn.add_dataset(
     id=15590836,
     processes=[procs.data_muonshower],
     keys=[
-        "/MuonShower/Run2026D-PromptReco-v1/NANOAOD",  # noqa
+        "/MuonShower/Run2026D-PromptReco-v1/NANOAOD",
     ],
     n_files=199,
     n_events=414608,
@@ -286,12 +286,12 @@ cpn.add_dataset(
     id=15552635,
     processes=[procs.data_egamma],
     keys=[
-        "/EGamma0/Run2026A-PromptReco-v1/NANOAOD",  # noqa
-        "/EGamma1/Run2026A-PromptReco-v1/NANOAOD",  # noqa
-        "/EGamma2/Run2026A-PromptReco-v1/NANOAOD",  # noqa
-        "/EGamma3/Run2026A-PromptReco-v1/NANOAOD",  # noqa
-        "/EGamma4/Run2026A-PromptReco-v1/NANOAOD",  # noqa
-        "/EGamma5/Run2026A-PromptReco-v1/NANOAOD",  # noqa
+        "/EGamma0/Run2026A-PromptReco-v1/NANOAOD",
+        "/EGamma1/Run2026A-PromptReco-v1/NANOAOD",
+        "/EGamma2/Run2026A-PromptReco-v1/NANOAOD",
+        "/EGamma3/Run2026A-PromptReco-v1/NANOAOD",
+        "/EGamma4/Run2026A-PromptReco-v1/NANOAOD",
+        "/EGamma5/Run2026A-PromptReco-v1/NANOAOD",
     ],
     n_files=62 + 61 + 66 + 65 + 60 + 60,
     n_events=11733359 + 11731043 + 11732795 + 11731165 + 11733095 + 11731599,
@@ -306,12 +306,12 @@ cpn.add_dataset(
     id=15557176,
     processes=[procs.data_egamma],
     keys=[
-        "/EGamma0/Run2026B-PromptReco-v1/NANOAOD",  # noqa
-        "/EGamma1/Run2026B-PromptReco-v1/NANOAOD",  # noqa
-        "/EGamma2/Run2026B-PromptReco-v1/NANOAOD",  # noqa
-        "/EGamma3/Run2026B-PromptReco-v1/NANOAOD",  # noqa
-        "/EGamma4/Run2026B-PromptReco-v1/NANOAOD",  # noqa
-        "/EGamma5/Run2026B-PromptReco-v1/NANOAOD",  # noqa
+        "/EGamma0/Run2026B-PromptReco-v1/NANOAOD",
+        "/EGamma1/Run2026B-PromptReco-v1/NANOAOD",
+        "/EGamma2/Run2026B-PromptReco-v1/NANOAOD",
+        "/EGamma3/Run2026B-PromptReco-v1/NANOAOD",
+        "/EGamma4/Run2026B-PromptReco-v1/NANOAOD",
+        "/EGamma5/Run2026B-PromptReco-v1/NANOAOD",
     ],
     n_files=536 + 532 + 534 + 529 + 533 + 535,
     n_events=205275441 + 205266455 + 205274221 + 205271520 + 205273231 + 205265468,
@@ -326,12 +326,12 @@ cpn.add_dataset(
     id=15568826,
     processes=[procs.data_egamma],
     keys=[
-        "/EGamma0/Run2026C-PromptReco-v1/NANOAOD",  # noqa
-        "/EGamma1/Run2026C-PromptReco-v1/NANOAOD",  # noqa
-        "/EGamma2/Run2026C-PromptReco-v1/NANOAOD",  # noqa
-        "/EGamma3/Run2026C-PromptReco-v1/NANOAOD",  # noqa
-        "/EGamma4/Run2026C-PromptReco-v1/NANOAOD",  # noqa
-        "/EGamma5/Run2026C-PromptReco-v1/NANOAOD",  # noqa
+        "/EGamma0/Run2026C-PromptReco-v1/NANOAOD",
+        "/EGamma1/Run2026C-PromptReco-v1/NANOAOD",
+        "/EGamma2/Run2026C-PromptReco-v1/NANOAOD",
+        "/EGamma3/Run2026C-PromptReco-v1/NANOAOD",
+        "/EGamma4/Run2026C-PromptReco-v1/NANOAOD",
+        "/EGamma5/Run2026C-PromptReco-v1/NANOAOD",
     ],
     n_files=603 + 611 + 594 + 590 + 592 + 589,
     n_events=375030929 + 374809724 + 374832870 + 374811337 + 374793369 + 374804007,
@@ -346,12 +346,12 @@ cpn.add_dataset(
     id=15591574,
     processes=[procs.data_egamma],
     keys=[
-        "/EGamma0/Run2026D-PromptReco-v1/NANOAOD",  # noqa
-        "/EGamma1/Run2026D-PromptReco-v1/NANOAOD",  # noqa
-        "/EGamma2/Run2026D-PromptReco-v1/NANOAOD",  # noqa
-        "/EGamma3/Run2026D-PromptReco-v1/NANOAOD",  # noqa
-        "/EGamma4/Run2026D-PromptReco-v1/NANOAOD",  # noqa
-        "/EGamma5/Run2026D-PromptReco-v1/NANOAOD",  # noqa
+        "/EGamma0/Run2026D-PromptReco-v1/NANOAOD",
+        "/EGamma1/Run2026D-PromptReco-v1/NANOAOD",
+        "/EGamma2/Run2026D-PromptReco-v1/NANOAOD",
+        "/EGamma3/Run2026D-PromptReco-v1/NANOAOD",
+        "/EGamma4/Run2026D-PromptReco-v1/NANOAOD",
+        "/EGamma5/Run2026D-PromptReco-v1/NANOAOD",
     ],
     n_files=334 + 325 + 335 + 327 + 332 + 327,
     n_events=125742096 + 125740549 + 125741242 + 125739959 + 125741715 + 125738632,

--- a/cmsdb/campaigns/run3_2026_nano_v15/data.py
+++ b/cmsdb/campaigns/run3_2026_nano_v15/data.py
@@ -13,9 +13,9 @@ from cmsdb.campaigns.run3_2026_nano_v15 import campaign_run3_2026_nano_v15 as cp
 #
 
 cpn.add_dataset(
-    name="data_jethtmet_a",
+    name="data_met_a",
     id=15552525,
-    processes=[procs.data_jethtmet],
+    processes=[procs.data_met],
     keys=[
         "/JetMET0/Run2026A-PromptReco-v1/NANOAOD",
         "/JetMET1/Run2026A-PromptReco-v1/NANOAOD",
@@ -29,9 +29,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="data_jethtmet_d",
+    name="data_met_d",
     id=15591506,
-    processes=[procs.data_jethtmet],
+    processes=[procs.data_met],
     keys=[
         "/JetMET0/Run2026D-PromptReco-v1/NANOAOD",
         "/JetMET1/Run2026D-PromptReco-v1/NANOAOD",
@@ -45,9 +45,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="data_jethtmet_c",
+    name="data_met_c",
     id=15569003,
-    processes=[procs.data_jethtmet],
+    processes=[procs.data_met],
     keys=[
         "/JetMET0/Run2026C-PromptReco-v1/NANOAOD",
         "/JetMET1/Run2026C-PromptReco-v1/NANOAOD",
@@ -65,9 +65,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="data_jethtmet_b",
+    name="data_met_b",
     id=15558208,
-    processes=[procs.data_jethtmet],
+    processes=[procs.data_met],
     keys=[
         "/JetMET0/Run2026B-PromptReco-v1/NANOAOD",
         "/JetMET1/Run2026B-PromptReco-v1/NANOAOD",
@@ -282,9 +282,9 @@ cpn.add_dataset(
 # E Gamma datasets
 #
 cpn.add_dataset(
-    name="data_egamma_a",
+    name="data_e_a",
     id=15552635,
-    processes=[procs.data_egamma],
+    processes=[procs.data_e],
     keys=[
         "/EGamma0/Run2026A-PromptReco-v1/NANOAOD",
         "/EGamma1/Run2026A-PromptReco-v1/NANOAOD",
@@ -302,9 +302,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="data_egamma_b",
+    name="data_e_b",
     id=15557176,
-    processes=[procs.data_egamma],
+    processes=[procs.data_e],
     keys=[
         "/EGamma0/Run2026B-PromptReco-v1/NANOAOD",
         "/EGamma1/Run2026B-PromptReco-v1/NANOAOD",
@@ -322,9 +322,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="data_egamma_c",
+    name="data_e_c",
     id=15568826,
-    processes=[procs.data_egamma],
+    processes=[procs.data_e],
     keys=[
         "/EGamma0/Run2026C-PromptReco-v1/NANOAOD",
         "/EGamma1/Run2026C-PromptReco-v1/NANOAOD",
@@ -342,9 +342,9 @@ cpn.add_dataset(
 )
 
 cpn.add_dataset(
-    name="data_egamma_d",
+    name="data_e_d",
     id=15591574,
-    processes=[procs.data_egamma],
+    processes=[procs.data_e],
     keys=[
         "/EGamma0/Run2026D-PromptReco-v1/NANOAOD",
         "/EGamma1/Run2026D-PromptReco-v1/NANOAOD",

--- a/cmsdb/campaigns/run3_2026_nano_v15/data.py
+++ b/cmsdb/campaigns/run3_2026_nano_v15/data.py
@@ -25,7 +25,7 @@ cpn.add_dataset(
     is_data=True,
     aux={
         "era": "A",
-    }
+    },
 )
 
 cpn.add_dataset(
@@ -41,7 +41,7 @@ cpn.add_dataset(
     is_data=True,
     aux={
         "era": "D",
-    }
+    },
 )
 
 cpn.add_dataset(
@@ -61,7 +61,7 @@ cpn.add_dataset(
     is_data=True,
     aux={
         "era": "C",
-    }
+    },
 )
 
 cpn.add_dataset(
@@ -77,7 +77,7 @@ cpn.add_dataset(
     is_data=True,
     aux={
         "era": "B",
-    }
+    },
 )
 
 #
@@ -97,7 +97,7 @@ cpn.add_dataset(
     is_data=True,
     aux={
         "era": "A",
-    }
+    },
 )
 
 cpn.add_dataset(
@@ -112,7 +112,7 @@ cpn.add_dataset(
     is_data=True,
     aux={
         "era": "B",
-    }
+    },
 )
 
 cpn.add_dataset(
@@ -127,7 +127,7 @@ cpn.add_dataset(
     is_data=True,
     aux={
         "era": "C",
-    }
+    },
 )
 
 cpn.add_dataset(
@@ -142,7 +142,7 @@ cpn.add_dataset(
     is_data=True,
     aux={
         "era": "D",
-    }
+    },
 )
 
 # muon
@@ -161,7 +161,7 @@ cpn.add_dataset(
     is_data=True,
     aux={
         "era": "A",
-    }
+    },
 )
 
 cpn.add_dataset(
@@ -179,7 +179,7 @@ cpn.add_dataset(
     is_data=True,
     aux={
         "era": "B",
-    }
+    },
 )
 
 cpn.add_dataset(
@@ -197,7 +197,7 @@ cpn.add_dataset(
     is_data=True,
     aux={
         "era": "C",
-    }
+    },
 )
 cpn.add_dataset(
     name="data_mu_d",
@@ -214,7 +214,7 @@ cpn.add_dataset(
     is_data=True,
     aux={
         "era": "D",
-    }
+    },
 )
 
 # muon shower
@@ -230,7 +230,7 @@ cpn.add_dataset(
     is_data=True,
     aux={
         "era": "A",
-    }
+    },
 )
 
 cpn.add_dataset(
@@ -245,7 +245,7 @@ cpn.add_dataset(
     is_data=True,
     aux={
         "era": "B",
-    }
+    },
 )
 
 cpn.add_dataset(
@@ -260,7 +260,7 @@ cpn.add_dataset(
     is_data=True,
     aux={
         "era": "C",
-    }
+    },
 )
 
 cpn.add_dataset(
@@ -275,7 +275,7 @@ cpn.add_dataset(
     is_data=True,
     aux={
         "era": "D",
-    }
+    },
 )
 
 #
@@ -298,7 +298,7 @@ cpn.add_dataset(
     is_data=True,
     aux={
         "era": "A",
-    }
+    },
 )
 
 cpn.add_dataset(
@@ -318,7 +318,7 @@ cpn.add_dataset(
     is_data=True,
     aux={
         "era": "B",
-    }
+    },
 )
 
 cpn.add_dataset(
@@ -338,7 +338,7 @@ cpn.add_dataset(
     is_data=True,
     aux={
         "era": "C",
-    }
+    },
 )
 
 cpn.add_dataset(
@@ -358,5 +358,5 @@ cpn.add_dataset(
     is_data=True,
     aux={
         "era": "D",
-    }
+    },
 )

--- a/cmsdb/campaigns/run3_2026_nano_v15/data.py
+++ b/cmsdb/campaigns/run3_2026_nano_v15/data.py
@@ -1,0 +1,362 @@
+# coding: utf-8
+
+"""
+Recorded datasets for the 2026 data-taking campaign with datasets at NanoAOD tier in version 15.
+"""
+
+import cmsdb.processes as procs
+from cmsdb.campaigns.run3_2026_nano_v15 import campaign_run3_2026_nano_v15 as cpn
+
+
+#
+# JetMET datasets
+#
+
+cpn.add_dataset(
+    name="data_jethtmet_a",
+    id=15552525,
+    processes=[procs.data_jethtmet],
+    keys=[
+        "/JetMET0/Run2026A-PromptReco-v1/NANOAOD",  # noqa
+        "/JetMET1/Run2026A-PromptReco-v1/NANOAOD",  # noqa
+    ],
+    n_files=72 + 76,
+    n_events=16602265 + 16588421,
+    is_data=True,
+    aux={
+        "era": "A",
+    }
+)
+
+cpn.add_dataset(
+    name="data_jethtmet_d",
+    id=15591506,
+    processes=[procs.data_jethtmet],
+    keys=[
+        "/JetMET0/Run2026D-PromptReco-v1/NANOAOD",  # noqa
+        "/JetMET1/Run2026D-PromptReco-v1/NANOAOD",  # noqa
+    ],
+    n_files=405 + 399,
+    n_events=151375589 + 151355297,
+    is_data=True,
+    aux={
+        "era": "D",
+    }
+)
+
+cpn.add_dataset(
+    name="data_jethtmet_c",
+    id=15569003,
+    processes=[procs.data_jethtmet],
+    keys=[
+        "/JetMET0/Run2026C-PromptReco-v1/NANOAOD",  # noqa
+        "/JetMET1/Run2026C-PromptReco-v1/NANOAOD",  # noqa
+        "/JetMET2/Run2026C-PromptReco-v1/NANOAOD",  # noqa
+        "/JetMET3/Run2026C-PromptReco-v1/NANOAOD",  # noqa
+        "/JetMET4/Run2026C-PromptReco-v1/NANOAOD",  # noqa
+        "/JetMET5/Run2026C-PromptReco-v1/NANOAOD",  # noqa
+    ],
+    n_files=1393 + 1383 + 1371 + 1362 + 1360 + 1354,
+    n_events=1756939928 + 1756363080 + 1755211834 + 1755216678 + 1755215414 + 1755211453,
+    is_data=True,
+    aux={
+        "era": "C",
+    }
+)
+
+cpn.add_dataset(
+    name="data_jethtmet_b",
+    id=15558208,
+    processes=[procs.data_jethtmet],
+    keys=[
+        "/JetMET0/Run2026B-PromptReco-v1/NANOAOD",  # noqa
+        "/JetMET1/Run2026B-PromptReco-v1/NANOAOD",  # noqa
+    ],
+    n_files=612 + 621,
+    n_events=245424748 + 245406692,
+    is_data=True,
+    aux={
+        "era": "B",
+    }
+)
+
+#
+# muon datasets
+#
+
+# muon egamma
+cpn.add_dataset(
+    name="data_muoneg_a",
+    id=15552736,
+    processes=[procs.data_muoneg],
+    keys=[
+        "/MuonEG/Run2026A-PromptReco-v1/NANOAOD",  # noqa
+    ],
+    n_files=38,
+    n_events=2699844,
+    is_data=True,
+    aux={
+        "era": "A",
+    }
+)
+
+cpn.add_dataset(
+    name="data_muoneg_b",
+    id=15557575,
+    processes=[procs.data_muoneg],
+    keys=[
+        "/MuonEG/Run2026B-PromptReco-v1/NANOAOD",  # noqa
+    ],
+    n_files=193,
+    n_events=50921430,
+    is_data=True,
+    aux={
+        "era": "B",
+    }
+)
+
+cpn.add_dataset(
+    name="data_muoneg_c",
+    id=15568792,
+    processes=[procs.data_muoneg],
+    keys=[
+        "/MuonEG/Run2026C-PromptReco-v1/NANOAOD",  # noqa
+    ],
+    n_files=65,
+    n_events=5291221,
+    is_data=True,
+    aux={
+        "era": "C",
+    }
+)
+
+cpn.add_dataset(
+    name="data_muoneg_d",
+    id=15591468,
+    processes=[procs.data_muoneg],
+    keys=[
+        "/MuonEG/Run2026D-PromptReco-v1/NANOAOD",  # noqa
+    ],
+    n_files=120,
+    n_events=32379047,
+    is_data=True,
+    aux={
+        "era": "D",
+    }
+)
+
+# muon
+cpn.add_dataset(
+    name="data_mu_a",
+    id=15552450,
+    processes=[procs.data_mu],
+    keys=[
+        "/Muon0/Run2026A-PromptReco-v1/NANOAOD",  # noqa
+        "/Muon1/Run2026A-PromptReco-v1/NANOAOD",  # noqa
+        "/Muon2/Run2026A-PromptReco-v1/NANOAOD",  # noqa
+        "/Muon3/Run2026A-PromptReco-v1/NANOAOD",  # noqa
+    ],
+    n_files=52 + 56 + 54 + 51,
+    n_events=7347312 + 7347779 + 7344116 + 7345253,
+    is_data=True,
+    aux={
+        "era": "A",
+    }
+)
+
+cpn.add_dataset(
+    name="data_mu_b",
+    id=15558192,
+    processes=[procs.data_mu],
+    keys=[
+        "/Muon0/Run2026B-PromptReco-v1/NANOAOD",  # noqa
+        "/Muon1/Run2026B-PromptReco-v1/NANOAOD",  # noqa
+        "/Muon2/Run2026B-PromptReco-v1/NANOAOD",  # noqa
+        "/Muon3/Run2026B-PromptReco-v1/NANOAOD",  # noqa
+    ],
+    n_files=448 + 443 + 448 + 443,
+    n_events=155034715 + 155028140 + 155029788 + 155025135,
+    is_data=True,
+    aux={
+        "era": "B",
+    }
+)
+
+cpn.add_dataset(
+    name="data_mu_c",
+    id=15569405,
+    processes=[procs.data_mu],
+    keys=[
+        "/Muon0/Run2026C-PromptReco-v1/NANOAOD",  # noqa
+        "/Muon1/Run2026C-PromptReco-v1/NANOAOD",  # noqa
+        "/Muon2/Run2026C-PromptReco-v1/NANOAOD",  # noqa
+        "/Muon3/Run2026C-PromptReco-v1/NANOAOD",  # noqa
+    ],
+    n_files=813 + 778 + 784 + 777,
+    n_events=779902163 + 779231920 + 779164947 + 779192881,
+    is_data=True,
+    aux={
+        "era": "C",
+    }
+)
+cpn.add_dataset(
+    name="data_mu_d",
+    id=15592049,
+    processes=[procs.data_mu],
+    keys=[
+        "/Muon0/Run2026D-PromptReco-v1/NANOAOD",  # noqa
+        "/Muon1/Run2026D-PromptReco-v1/NANOAOD",  # noqa
+        "/Muon2/Run2026D-PromptReco-v1/NANOAOD",  # noqa
+        "/Muon3/Run2026D-PromptReco-v1/NANOAOD",  # noqa
+    ],
+    n_files=321 + 317 + 313 + 321,
+    n_events=112288744 + 112284014 + 112290907 + 112282726,
+    is_data=True,
+    aux={
+        "era": "D",
+    }
+)
+
+# muon shower
+cpn.add_dataset(
+    name="data_muonshower_a",
+    id=15552147,
+    processes=[procs.data_muonshower],
+    keys=[
+        "/MuonShower/Run2026A-PromptReco-v1/NANOAOD",  # noqa
+    ],
+    n_files=58,
+    n_events=22284,
+    is_data=True,
+    aux={
+        "era": "A",
+    }
+)
+
+cpn.add_dataset(
+    name="data_muonshower_b",
+    id=15557263,
+    processes=[procs.data_muonshower],
+    keys=[
+        "/MuonShower/Run2026B-PromptReco-v1/NANOAOD",  # noqa
+    ],
+    n_files=259,
+    n_events=230562,
+    is_data=True,
+    aux={
+        "era": "B",
+    }
+)
+
+cpn.add_dataset(
+    name="data_muonshower_c",
+    id=15568686,
+    processes=[procs.data_muonshower],
+    keys=[
+        "/MuonShower/Run2026C-PromptReco-v1/NANOAOD",  # noqa
+    ],
+    n_files=319,
+    n_events=667697,
+    is_data=True,
+    aux={
+        "era": "C",
+    }
+)
+
+cpn.add_dataset(
+    name="data_muonshower_d",
+    id=15590836,
+    processes=[procs.data_muonshower],
+    keys=[
+        "/MuonShower/Run2026D-PromptReco-v1/NANOAOD",  # noqa
+    ],
+    n_files=199,
+    n_events=414608,
+    is_data=True,
+    aux={
+        "era": "D",
+    }
+)
+
+#
+# E Gamma datasets
+#
+cpn.add_dataset(
+    name="data_egamma_a",
+    id=15552635,
+    processes=[procs.data_egamma],
+    keys=[
+        "/EGamma0/Run2026A-PromptReco-v1/NANOAOD",  # noqa
+        "/EGamma1/Run2026A-PromptReco-v1/NANOAOD",  # noqa
+        "/EGamma2/Run2026A-PromptReco-v1/NANOAOD",  # noqa
+        "/EGamma3/Run2026A-PromptReco-v1/NANOAOD",  # noqa
+        "/EGamma4/Run2026A-PromptReco-v1/NANOAOD",  # noqa
+        "/EGamma5/Run2026A-PromptReco-v1/NANOAOD",  # noqa
+    ],
+    n_files=62 + 61 + 66 + 65 + 60 + 60,
+    n_events=11733359 + 11731043 + 11732795 + 11731165 + 11733095 + 11731599,
+    is_data=True,
+    aux={
+        "era": "A",
+    }
+)
+
+cpn.add_dataset(
+    name="data_egamma_b",
+    id=15557176,
+    processes=[procs.data_egamma],
+    keys=[
+        "/EGamma0/Run2026B-PromptReco-v1/NANOAOD",  # noqa
+        "/EGamma1/Run2026B-PromptReco-v1/NANOAOD",  # noqa
+        "/EGamma2/Run2026B-PromptReco-v1/NANOAOD",  # noqa
+        "/EGamma3/Run2026B-PromptReco-v1/NANOAOD",  # noqa
+        "/EGamma4/Run2026B-PromptReco-v1/NANOAOD",  # noqa
+        "/EGamma5/Run2026B-PromptReco-v1/NANOAOD",  # noqa
+    ],
+    n_files=536 + 532 + 534 + 529 + 533 + 535,
+    n_events=205275441 + 205266455 + 205274221 + 205271520 + 205273231 + 205265468,
+    is_data=True,
+    aux={
+        "era": "B",
+    }
+)
+
+cpn.add_dataset(
+    name="data_egamma_c",
+    id=15568826,
+    processes=[procs.data_egamma],
+    keys=[
+        "/EGamma0/Run2026C-PromptReco-v1/NANOAOD",  # noqa
+        "/EGamma1/Run2026C-PromptReco-v1/NANOAOD",  # noqa
+        "/EGamma2/Run2026C-PromptReco-v1/NANOAOD",  # noqa
+        "/EGamma3/Run2026C-PromptReco-v1/NANOAOD",  # noqa
+        "/EGamma4/Run2026C-PromptReco-v1/NANOAOD",  # noqa
+        "/EGamma5/Run2026C-PromptReco-v1/NANOAOD",  # noqa
+    ],
+    n_files=603 + 611 + 594 + 590 + 592 + 589,
+    n_events=375030929 + 374809724 + 374832870 + 374811337 + 374793369 + 374804007,
+    is_data=True,
+    aux={
+        "era": "C",
+    }
+)
+
+cpn.add_dataset(
+    name="data_egamma_d",
+    id=15591574,
+    processes=[procs.data_egamma],
+    keys=[
+        "/EGamma0/Run2026D-PromptReco-v1/NANOAOD",  # noqa
+        "/EGamma1/Run2026D-PromptReco-v1/NANOAOD",  # noqa
+        "/EGamma2/Run2026D-PromptReco-v1/NANOAOD",  # noqa
+        "/EGamma3/Run2026D-PromptReco-v1/NANOAOD",  # noqa
+        "/EGamma4/Run2026D-PromptReco-v1/NANOAOD",  # noqa
+        "/EGamma5/Run2026D-PromptReco-v1/NANOAOD",  # noqa
+    ],
+    n_files=334 + 325 + 335 + 327 + 332 + 327,
+    n_events=125742096 + 125740549 + 125741242 + 125739959 + 125741715 + 125738632,
+    is_data=True,
+    aux={
+        "era": "D",
+    }
+)

--- a/cmsdb/processes/data.py
+++ b/cmsdb/processes/data.py
@@ -9,7 +9,7 @@ __all__ = [
     "data_tau", "data_met", "data_pho",
     "data_egamma", "data_muoneg", "data_jetht",
     "data_jethtmet", "data_doublemu", "data_vbf", "data_hh",
-    "data_mushower",
+    "data_muonshower",
 ]
 
 from order import Process

--- a/cmsdb/processes/data.py
+++ b/cmsdb/processes/data.py
@@ -7,7 +7,9 @@ Data process definitions.
 __all__ = [
     "data", "data_e", "data_mu",
     "data_tau", "data_met", "data_pho",
-    "data_egamma", "data_muoneg", "data_jetht", "data_jethtmet", "data_doublemu", "data_mushower", "data_vbf",
+    "data_egamma", "data_muoneg", "data_jetht",
+    "data_jethtmet", "data_doublemu", "data_vbf", "data_hh",
+    "data_mushower",
 ]
 
 from order import Process

--- a/cmsdb/processes/data.py
+++ b/cmsdb/processes/data.py
@@ -83,8 +83,8 @@ data_doublemu = data.add_process(
     label=r"Data $\mu$",
 )
 
-data_mushower = data.add_process(
-    name="data_mushower",
+data_muonshower = data.add_process(
+    name="data_muonshower",
     id=90,
     is_data=True,
     label=r"Data $\mu$",

--- a/cmsdb/processes/data.py
+++ b/cmsdb/processes/data.py
@@ -7,8 +7,7 @@ Data process definitions.
 __all__ = [
     "data", "data_e", "data_mu",
     "data_tau", "data_met", "data_pho",
-    "data_egamma", "data_muoneg", "data_jetht",
-    "data_jethtmet", "data_doublemu", "data_vbf", "data_hh",
+    "data_egamma", "data_muoneg", "data_jetht", "data_jethtmet", "data_doublemu", "data_mushower", "data_vbf",
 ]
 
 from order import Process
@@ -78,6 +77,13 @@ data_muoneg = data.add_process(
 data_doublemu = data.add_process(
     name="data_doublemu",
     id=80,
+    is_data=True,
+    label=r"Data $\mu$",
+)
+
+data_mushower = data.add_process(
+    name="data_mushower",
+    id=90,
     is_data=True,
     label=r"Data $\mu$",
 )

--- a/cmsdb/util.py
+++ b/cmsdb/util.py
@@ -12,7 +12,7 @@ from typing import Callable
 from functools import partial
 from scinum import Number
 
-from order import Process, Campaign
+from order import Process, Campaign, Dataset
 from collections import OrderedDict
 
 
@@ -198,12 +198,23 @@ add_sub_decay_process = partial(
 )
 
 
-def transfer_datasets(src_campaign: Campaign, dst_campaign: Campaign) -> None:
+def transfer_datasets(
+    src_campaign: Campaign,
+    dst_campaign: Campaign,
+    skip_fn: Callable[[Dataset], bool] | None = None,
+) -> None:
     """
     Copy all datasets from one *src_campaign* to another *dst_campaign*, making sure that linked processes are not
     copied but shared.
     """
+    if skip_fn is None:
+        skip_fn = lambda ds: False
+
     for dataset in src_campaign.datasets:
+        # potentially skip
+        if skip_fn(dataset):
+            continue
+
         # shallow copy of the dataset (no processes, no campaign reference)
         copy = dataset.copy_shallow()
 


### PR DESCRIPTION
This PR builds the campaigns for the 2025 and 2026 Nano v15 Data datasets. Since the current recommendation is to use the 2024 MC datasets for both Eras, the 2024 campaign is copied and only the Data datasets are exchanged. 