### PR TITLE
WIP: Diboson process split (ggZZ/qqZZ) and add missing Run 3 datasets

### DIFF
--- a/cmsdb/campaigns/run3_2024_nano_v15/ewk.py
+++ b/cmsdb/campaigns/run3_2024_nano_v15/ewk.py
@@ -871,7 +871,7 @@ cpn.add_dataset(
     n_events=4_800_000,
 )
 
-# further ww decay modes
+# qqWW decay modes (Powheg NLO)
 cpn.add_dataset(
     name="ww_dl_powheg",
     id=15304453,
@@ -905,7 +905,7 @@ cpn.add_dataset(
     n_events=151_214_029,
 )
 
-# further ww decay modes with specific leptons
+# ggWW dilepton decay modes (MCFM LO)
 cpn.add_dataset(
     name="ww_wenu_wenu_pythia",
     id=15349213,

--- a/cmsdb/campaigns/run3_2024_nano_v15/ewk.py
+++ b/cmsdb/campaigns/run3_2024_nano_v15/ewk.py
@@ -975,6 +975,18 @@ cpn.add_dataset(
     n_events=1_999_273,
 )
 
+# same-sign WW
+cpn.add_dataset(
+    name="wpwp_jj_ewkqcd_madgraph",
+    id=15515111,
+    processes=[procs.wpwp_jj],
+    keys=[
+        "/WpWpJJ-EWK-QCD_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=17,
+    n_events=243_119,
+)
+
 # further wz decay modes
 cpn.add_dataset(
     name="wz_wlnu_zll_powheg",
@@ -1156,6 +1168,21 @@ cpn.add_dataset(
     ],
     n_files=39,
     n_events=2_800_000,
+)
+
+#
+# V + gamma
+#
+
+cpn.add_dataset(
+    name="wg_lnug_amcatnlo",
+    id=15467536,
+    processes=[procs.wg_lnug],
+    keys=[
+        "/WGtoLNuG-1Jets_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=2_424,
+    n_events=445_891_677,
 )
 
 #

--- a/cmsdb/campaigns/run3_2024_nano_v15/higgs.py
+++ b/cmsdb/campaigns/run3_2024_nano_v15/higgs.py
@@ -260,7 +260,27 @@ cpn.add_dataset(
 # tH
 #
 
-# tba
+cpn.add_dataset(
+    name="thq_ctcvcp_madgraph",
+    id=15537100,
+    processes=[procs.thq],
+    keys=[
+        "/THQ-4FS-ctcvcp_Par-M-125_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=352,
+    n_events=19_985_991,
+)
+
+cpn.add_dataset(
+    name="thw_ctcvcp_madgraph",
+    id=15539363,
+    processes=[procs.thw],
+    keys=[
+        "/THW-5FS-ctcvcp_Par-M-125_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=267,
+    n_events=14_995_985,
+)
 
 #
 # ttVH

--- a/cmsdb/campaigns/run3_2024_nano_v15/top.py
+++ b/cmsdb/campaigns/run3_2024_nano_v15/top.py
@@ -610,8 +610,50 @@ cpn.add_dataset(
 # 4 top
 #
 
-# missing
-# cpn.add_dataset(
-#     name="tttt_amcatnlo",
-#     ...
-# )
+cpn.add_dataset(
+    name="tttt_amcatnlo",
+    id=15529183,
+    processes=[procs.tttt],
+    keys=[
+        "/TTTT_TuneCP5_13p6TeV_amcatnlo-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=101,
+    n_events=9_776_800,
+)
+
+#
+# top + photon
+#
+
+cpn.add_dataset(
+    name="ttg_amcatnlo",
+    id=15536929,
+    processes=[procs.ttg],
+    keys=[
+        "/TTG-1Jets_TuneCP5_13p6TeV_amcatnloFXFXold-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=143,
+    n_events=19_416_271,
+)
+
+cpn.add_dataset(
+    name="ttg_pt100to200_amcatnlo",
+    id=15536699,
+    processes=[procs.ttg_pt100to200],
+    keys=[
+        "/TTG-1Jets_Bin-PTG-100_TuneCP5_13p6TeV_amcatnloFXFXold-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM",  # noqa
+    ],
+    n_files=113,
+    n_events=10_495_130,
+)
+
+cpn.add_dataset(
+    name="ttg_pt200toinf_amcatnlo",
+    id=15536925,
+    processes=[procs.ttg_pt200toinf],
+    keys=[
+        "/TTG-1Jets_Bin-PTG-200_TuneCP5_13p6TeV_amcatnloFXFXold-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v3/NANOAODSIM",  # noqa
+    ],
+    n_files=107,
+    n_events=9_630_092,
+)

--- a/cmsdb/processes/ewk.py
+++ b/cmsdb/processes/ewk.py
@@ -93,7 +93,7 @@ __all__ = [  # noqa: F822
     "wz", "wz_wlnu_zll", "wz_wqq_zll", "wz_wqq_zqq", "wz_wlnu_zqq",
     "wzg", "wzg_wlnu",
     "wg_lnug",
-    "ww",
+    "ww", "ww_qqbar", "ww_gg",
     "ww_dl", "ww_sl", "ww_fh",
     "ww_wenu_wenu", "ww_wenu_wmnu", "ww_wenu_wtnu", "ww_wmnu_wmnu", "ww_wmnu_wtnu", "ww_wtnu_wtnu",
     "wpwp_jj",
@@ -2441,7 +2441,18 @@ wg_lnug = Process(
 
 # NNLO QCD from https://twiki.cern.ch/twiki/bin/view/CMS/StandardModelCrossSectionsat13TeV?rev=28
 # itself from https://arxiv.org/pdf/1408.5243.pdf v1
-
+#
+# 13.6 TeV: WW_TuneCP5_13p6TeV_pythia8 is LO Pythia (WeakDoubleBoson:ffbar2WW, qq only).
+# McM fragment: BTV-Run3Summer22GS-00015, crossSection = 75.8 (hardcoded LO).
+# GenXSecAnalyzer: 80.22 pb (LO). XSDB: 80.23 pb.
+# k(LO→NNLO) ≈ 1.75 from Grazzini et al., JHEP 08 (2016) 140 [arXiv:1605.02716], Table 2:
+#   13 TeV: NNLO/LO = 1370.9/778.99 = 1.76
+#
+# NOTE on WW k-factors:
+#   qqWW: k=1.14 (NLO→NNLO) from arXiv:1605.02716 (Grazzini et al., JHEP 08 (2016) 140)
+#   ggWW: k=1.41 (LO→NLO) from arXiv:1511.08617 (Caola et al., Phys. Lett. B 754 (2016) 275)
+#   LO→NNLO (Pythia inclusive): k≈1.75 from the same Grazzini et al. paper
+#
 # old value before update:
 # https://cms.cern.ch/iCMS/jsp/db_notes/noteInfo.jsp?cmsnoteid=CMS%20AN-2019/197 (v3) Number(75.91) (LO)
 ww = vv.add_process(
@@ -2450,10 +2461,9 @@ ww = vv.add_process(
     label="WW",
     xsecs={
         13: Number(118.7, {"scale": (0.025j, 0.022j)}),
-        # 13.6 from GenXSecAnalyzer:
-        13.6: Number(80.22, {
-            "tot": 0.01677,  # xsdb: Number(80.23, {"tot": 0.3733})
-        }),
+        # 13.6: LO Pythia GenXSecAnalyzer × k(LO→NNLO) ≈ 1.75
+        # 80.22 × 1.75 = 140.385 pb
+        13.6: Number(80.22, {"tot": 0.01677}) * 1.75,
     },
 )
 
@@ -2461,82 +2471,145 @@ ww = vv.add_process(
 for cme in [13]:
     vv.set_xsec(cme, ww.get_xsec(cme) + wz.get_xsec(cme) + zz.get_xsec(cme))
 
+# qqWW: each decay mode normalized independently by its NLO XSDB value × k=1.14
+# NLO XS values from XSDB for individual Powheg samples (WWto2L2Nu, WWtoLNu2Q, WWto4Q)
+# k=1.14 (NLO→NNLO) from arXiv:1605.02716 (Grazzini et al., JHEP 08 (2016) 140)
+ww_qqbar = ww.add_process(
+    name="ww_qqbar",
+    id=8370,
+    label=r"$q\bar{q} \rightarrow WW$",
+    xsecs={
+        13: ww.get_xsec(13),  # at 13 TeV, qqWW ≈ inclusive (ggWW is small)
+        # 13.6: sum of Powheg NLO decay modes × k=1.14
+        # dl: 11.79 × 1.14 = 13.4406, sl: 48.94 × 1.14 = 55.7916, fh: 50.79 × 1.14 = 57.9006
+        # sum = 127.1328 pb
+        13.6: Number(127.1328),
+    },
+)
+
 # no additional cut found in generator card:
 # https://raw.githubusercontent.com/cms-sw/genproductions/master/bin/Powheg/production/2017/13TeV/WWTo2L2Nu_NNPDF31nnlo_13TeV/WWTo2L2Nu_NNPDF31nnlo_13TeV.input  # noqa
-# therefore, value obtained from branching ratio.
+# therefore, 13 TeV value obtained from branching ratio.
 # Log for GenXSecAnalyzer of
 # WWTo2L2Nu_TuneCP5_13TeV-powheg-pythia8 (Summer20UL16, NLO) with Number(11.09, {"tot": 0.00704})
 # also available, but not used here
-ww_dl = ww.add_process(
+ww_dl = ww_qqbar.add_process(
     name="ww_dl",
     id=8310,
     xsecs={
         13: ww.get_xsec(13) * const.br_ww.dl,  # value around 12.6 for comparison to GenXSecAnalyzer NLO result
+        # 13.6: XSDB NLO 11.79 pb × k=1.14 (NLO→NNLO) = 13.4406 pb
+        13.6: Number(11.79, {"tot": 0.004216}) * 1.14,
     },
 )
 
 # no additional cut found in generator card in MCM:
 # dataset: /WWTo1L1Nu2Q_4f_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM  # noqa
-# therefore, value obtained from branching ratio.
+# therefore, 13 TeV value obtained from branching ratio.
 # Log for GenXSecAnalyzer of
 # for WWTo1L1Nu2Q_4f_TuneCP5_13TeV-amcatnloFXFX-pythia8 (Summer20UL16, NLO) -> value : Number(50.94, {"tot": 0.042})
 # also available, but not used here
-ww_sl = ww.add_process(
+ww_sl = ww_qqbar.add_process(
     name="ww_sl",
     id=8320,
     xsecs={
         13: ww.get_xsec(13) * const.br_ww.sl,  # value around 50.06 for comparison to GenXSecAnalyzer NLO result
+        # 13.6: XSDB NLO 48.94 pb × k=1.14 (NLO→NNLO) = 55.7916 pb
+        13.6: Number(48.94, {"tot": 0.0175}) * 1.14,
     },
 )
 
 # no additional cut found in generator card in MCM:
 # dataset: /WWTo4Q_4f_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v3/MINIAODSIM  # noqa
-# therefore, value obtained from branching ratio.
+# therefore, 13 TeV value obtained from branching ratio.
 # Log for GenXSecAnalyzer of
 # for WWTo4Q_4f_TuneCP5_13TeV-amcatnloFXFX-pythia8 (Summer20UL16, NLO) -> value : Number(51.53, {"tot": 0.04349})
 # also available, but not used here
-ww_fh = ww.add_process(
+ww_fh = ww_qqbar.add_process(
     name="ww_fh",
     id=8330,
     xsecs={
         13: ww.get_xsec(13) * const.br_ww.fh,  # value around 53.94 for comparison to GenXSecAnalyzer NLO result
+        # 13.6: XSDB NLO 50.79 pb × k=1.14 (NLO→NNLO) = 57.9006 pb
+        13.6: Number(50.79, {"tot": 0.01816}) * 1.14,
     },
 )
 
-ww_wenu_wenu = ww_dl.add_process(
+# ggWW: each decay mode normalized independently by its LO MCFM value × k=1.41
+# LO XS values in fb from XSDB for individual mcfm samples (XSDB mistakenly lists as pb; MCFM outputs in fb)
+# k=1.41 (LO→NLO) from arXiv:1511.08617 (Caola et al., Phys. Lett. B 754 (2016) 275)
+# See also CMS AN-2023/179.
+#
+# NOTE on same-flavor vs different-flavor:
+# MCFM gridpacks give the same XS (49.63 fb) for all channels (per-sample).
+# Same-flavor (ee, μμ, ττ): 1 sample per pair → XS = 49.63 fb × k
+# Different-flavor (eμ, eτ, μτ): 2 samples per pair (e.g., ENuMuNu + MuNuENu) → XS = 2 × 49.63 fb × k
+# Total ggWW→2l2ν = 3×69.9783 + 3×139.9566 = 629.8047 fb
+ww_gg = ww.add_process(
+    name="ww_gg",
+    id=8380,
+    label=r"$gg \rightarrow WW$",
+    xsecs={
+        # sum of ggWW decay modes: 13.6 TeV: 3×69.9783 + 3×139.9566 = 629.8047 fb
+        13.6: Number(629.8047e-03),
+    },
+)
+
+# same-flavor channels: 49.63 fb × k=1.41 = 69.9783 fb each
+ww_wenu_wenu = ww_gg.add_process(
     name="ww_wenu_wenu",
     id=8311,
-    xsecs=multiply_xsecs(ww, const.br_ww.enuenu),
+    xsecs={
+        13: ww.get_xsec(13) * const.br_ww.enuenu,
+        13.6: Number(49.63e-03) * 1.41,  # LO MCFM 49.63 fb × k=1.41 (same-flavor, 1 sample)
+    },
 )
 
-ww_wenu_wmnu = ww_dl.add_process(
+# different-flavor channels: 2 × 49.63 fb × k=1.41 = 139.9566 fb each
+# factor 2 from combining two ordering samples (ENuMuNu + MuNuENu)
+ww_wenu_wmnu = ww_gg.add_process(
     name="ww_wenu_wmnu",
     id=8312,
-    xsecs=multiply_xsecs(ww, const.br_ww.enumnu),
+    xsecs={
+        13: ww.get_xsec(13) * const.br_ww.enumnu,
+        13.6: Number(2 * 49.63e-03) * 1.41,  # LO MCFM 2×49.63 fb × k=1.41 (different-flavor, 2 samples)
+    },
 )
 
-ww_wenu_wtnu = ww_dl.add_process(
+ww_wenu_wtnu = ww_gg.add_process(
     name="ww_wenu_wtnu",
     id=8313,
-    xsecs=multiply_xsecs(ww, const.br_ww.enutnu),
+    xsecs={
+        13: ww.get_xsec(13) * const.br_ww.enutnu,
+        13.6: Number(2 * 49.63e-03) * 1.41,  # LO MCFM 2×49.63 fb × k=1.41 (different-flavor, 2 samples)
+    },
 )
 
-ww_wmnu_wmnu = ww_dl.add_process(
+ww_wmnu_wmnu = ww_gg.add_process(
     name="ww_wmnu_wmnu",
     id=8314,
-    xsecs=multiply_xsecs(ww, const.br_ww.mnumnu),
+    xsecs={
+        13: ww.get_xsec(13) * const.br_ww.mnumnu,
+        13.6: Number(49.63e-03) * 1.41,  # LO MCFM 49.63 fb × k=1.41 (same-flavor, 1 sample)
+    },
 )
 
-ww_wmnu_wtnu = ww_dl.add_process(
+ww_wmnu_wtnu = ww_gg.add_process(
     name="ww_wmnu_wtnu",
     id=8315,
-    xsecs=multiply_xsecs(ww, const.br_ww.mnutnu),
+    xsecs={
+        13: ww.get_xsec(13) * const.br_ww.mnutnu,
+        13.6: Number(2 * 49.63e-03) * 1.41,  # LO MCFM 2×49.63 fb × k=1.41 (different-flavor, 2 samples)
+    },
 )
 
-ww_wtnu_wtnu = ww_dl.add_process(
+ww_wtnu_wtnu = ww_gg.add_process(
     name="ww_wtnu_wtnu",
     id=8316,
-    xsecs=multiply_xsecs(ww, const.br_ww.tnutnu),
+    xsecs={
+        13: ww.get_xsec(13) * const.br_ww.tnutnu,
+        13.6: Number(49.63e-03) * 1.41,  # LO MCFM 49.63 fb × k=1.41 (same-flavor, 1 sample)
+    },
 )
 
 # same-sign WW (EWK+QCD)

--- a/cmsdb/processes/ewk.py
+++ b/cmsdb/processes/ewk.py
@@ -2363,25 +2363,48 @@ wz_wlnu_zll = wz.add_process(
 wz_wqq_zll = wz.add_process(
     name="wz_wqq_zll",
     id=8220,
-    xsecs=multiply_xsecs(wz, const.br_w.had * const.br_z.clep),
+    xsecs={
+        13: multiply_xsecs(wz, const.br_w.had * const.br_z.clep)[13],
+        # XSDB NLO (powheg) 7.568 pb × k=1.08 (NLO POWHEG -> NNLO QCD x NLO EW) = 8.17344 pb
+        # https://xsecdb-xsdb-official.app.cern.ch/xsdb/ DAS=WZto2L2Q_TuneCP5_13p6TeV_powheg-pythia8
+        # verified from CMS AN-2023/179
+        # k-factor ~1.08 from WZ Run3 paper: https://arxiv.org/pdf/2412.02477
+        # MATRIX paper: https://arxiv.org/abs/1912.00068
+        13.6: Number(8.17344),
+    },
 )
 
 wz_wqq_zqq = wz.add_process(
     name="wz_wqq_zqq",
     id=8240,
-    xsecs=multiply_xsecs(wz, const.br_w.had * const.br_z.qq),
+    xsecs={
+        13: multiply_xsecs(wz, const.br_w.had * const.br_z.qq)[13],
+        # XSDB labels this as "LO" but it is actually NLO (amcatnloFXFX = NLO + FxFx jet merging):
+        #   - 21% negative weights (impossible at LO)
+        #   - FxFx matching efficiency ~63% (before: 39.31 pb, after: 24.97 pb)
+        # https://xsecdb-xsdb-official.app.cern.ch/xsdb/ DAS=WZto4Q-1Jets-4FS_TuneCP5_13p6TeV_amcatnloFXFX-pythia8
+        # GenXSecAnalyzer (Run3Summer22EEMiniAODv4, 1M events): 24.97 ± 0.03314 pb (after matching)
+        # NLO (amcatnlo) 24.97 pb × k=1.08 (NLO -> NNLO QCD x NLO EW) = 26.9676 pb
+        # k-factor ~1.08 from WZ Run3 paper: https://arxiv.org/pdf/2412.02477
+        # MATRIX paper: https://arxiv.org/abs/1912.00068
+        13.6: Number(26.9676),
+    },
 )
 
-# no additional cut found in generator card in MCM:
-# dataset: /WZTo1L1Nu2Q_4f_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL16MiniAODv2-106X_mcRun2_asymptotic_v17-v2/MINIAODSIM  # noqa
-# therefore, value obtained from branching ratio.
-# Log for GenXSecAnalyzer of
-# for WZTo1L1Nu2Q_4f_TuneCP5_13TeV-amcatnloFXFX-pythia8 (Summer20UL16, NLO) -> value : Number(9.159, {"tot": 0.008259})
-# also available, but not used here
+# GenXSecAnalyzer of WZTo1L1Nu2Q_4f_TuneCP5_13TeV-amcatnloFXFX-pythia8 (Summer20UL16, NLO)
+# -> value: Number(9.159, {"tot": 0.008259}), also available but not used for 13 TeV
 wz_wlnu_zqq = wz.add_process(
     name="wz_wlnu_zqq",
     id=8230,
-    xsecs=multiply_xsecs(wz, const.br_w.lep * const.br_z.qq),
+    xsecs={
+        13: multiply_xsecs(wz, const.br_w.lep * const.br_z.qq)[13],
+        # XSDB NLO (powheg) 15.87 pb × k=1.08 (NLO POWHEG -> NNLO QCD x NLO EW) = 17.1396 pb
+        # https://xsecdb-xsdb-official.app.cern.ch/xsdb/ DAS=WZtoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8
+        # GenXSecAnalyzer (Run3Summer22EEMiniAODv4, 1M events): 15.87 ± 0.007874 pb — exact match with XSDB
+        # k-factor ~1.08 from WZ Run3 paper: https://arxiv.org/pdf/2412.02477
+        # MATRIX paper: https://arxiv.org/abs/1912.00068
+        13.6: Number(17.1396),
+    },
 )
 
 # wz + photon

--- a/cmsdb/processes/ewk.py
+++ b/cmsdb/processes/ewk.py
@@ -87,14 +87,16 @@ __all__ = [  # noqa: F822
     "ewk",
     "ewk_wp_lnu_m50toinf", "ewk_wm_lnu_m50toinf", "ewk_z_ll_m50toinf",
     "vv",
-    "zz",
+    "zz", "zz_qqbar", "zz_gg",
     "zz_zqq_zll", "zz_zll_znunu", "zz_zll_zll", "zz_zqq_zqq", "zz_znunu_zqq",
     "zz_zee_zee", "zz_zee_zmm", "zz_zee_ztt", "zz_zmm_zmm", "zz_zmm_ztt", "zz_ztt_ztt",
     "wz", "wz_wlnu_zll", "wz_wqq_zll", "wz_wqq_zqq", "wz_wlnu_zqq",
     "wzg", "wzg_wlnu",
+    "wg_lnug",
     "ww",
     "ww_dl", "ww_sl", "ww_fh",
     "ww_wenu_wenu", "ww_wenu_wmnu", "ww_wenu_wtnu", "ww_wmnu_wmnu", "ww_wmnu_wtnu", "ww_wtnu_wtnu",
+    "wpwp_jj",
     "vvv",
     "zzz", "wzz", "wwz", "www",
 ]
@@ -2121,84 +2123,166 @@ vv = Process(
     label="Di-Boson",
 )
 
-# ZZ 13 TeV xsec values at nNNLO from
+# ZZ
+# Theory inclusive XS (qqZZ + ggZZ):
+#   13 TeV:   NNLO+NNLL = 16.518 ± 1.84% pb from https://journals.aps.org/prd/abstract/10.1103/2rr7-5xv3, table 1
+#   13.6 TeV: NNLO+NNLL = 17.627 ± 1.93% pb from the same paper, table 1
+# For the inclusive Pythia sample (ZZ_TuneCP5_13p6TeV_pythia8), XSDB lists 12.75 pb.
+# The order is not documented; assuming NLO and applying k=1.15 gives 14.6625 pb,
+# which is consistent with qqZZ-only at NNLO (the Pythia sample is qqZZ-dominated).
+#
+# NOTE on k-factor: historically k=1.1 was used for NLO→NNLO scaling; we use k=1.15
+# as it is closer to the actual NLO→NNLO ratio from theory sources.
+# See Torben's slides: https://indico.cern.ch/event/1677270/contributions/7200886/attachments/3317393/5938464/ZZXS.pdf
+#
+# NOTE on per-decay-mode normalization: each dataset is normalized by its own
+# XSDB cross section (per decay mode) × k-factor. The per-decay-mode NLO values
+# from XSDB do NOT sum to the inclusive (they exceed it due to overlap / different
+# phase space cuts / EWK contributions at NLO enhancing leptonic modes).
+# If combining multiple ZZ decay-mode samples, stitching would be required.
 zz = vv.add_process(
     name="zz",
     id=8100,
     label="ZZ",
     xsecs={
-        # https://link.springer.com/article/10.1007/JHEP03(2019)070#preview, table 3, nNNLO
-        13: Number(24.97, {"scale": (0.029j, 0.027j)}),
-        # no theory prediction found yet, so take accurate value at 13 TeV and scale by the ratio
-        # of XSDB values at https://xsdb-temp.app.cern.ch/xsdb/?columns=67108863&currentPage=0&pageSize=40&searchQuery=process_name%3D%5EZZ_TuneCP5_13.%2Bpythia8%24  # noqa
-        13.6: Number(24.97, {"scale": (0.029j, 0.027j)}) * (12.75 / 12.14),
+        # NNLO+NNLL from https://journals.aps.org/prd/abstract/10.1103/2rr7-5xv3, table 1
+        13: Number(16.518, {"scale": 0.0184j}),
+        13.6: Number(17.627, {"scale": 0.0193j}),
     },
 )
 
-zz_zqq_zll = zz.add_process(
-    name="zz_zqq_zll",
-    id=8110,
-    xsecs=multiply_xsecs(zz, const.br_zz.llqq),
+# qqZZ: each decay mode normalized independently by its NLO XSDB value × k=1.15
+# NLO XS values from XSDB for individual powheg/amcatnlo samples
+zz_qqbar = zz.add_process(
+    name="zz_qqbar",
+    id=8170,
+    label=r"$q\bar{q} \rightarrow ZZ$",
+    xsecs={
+        # XSDB inclusive (assumed NLO) × k=1.15 = 12.75 × 1.15 = 14.6625 pb
+        # this represents qqZZ only; consistent with NNLO theory after phase space effects
+        13.6: Number(14.6625),
+    },
 )
 
-zz_zll_znunu = zz.add_process(
-    name="zz_zll_znunu",
-    id=8120,
-    xsecs=multiply_xsecs(zz, const.br_zz.llnunu),
-)
-
-zz_zll_zll = zz.add_process(
+zz_zll_zll = zz_qqbar.add_process(
     name="zz_zll_zll",
     id=8130,
-    xsecs=multiply_xsecs(zz, const.br_zz.llll),
+    xsecs={
+        # 13 TeV: NLO 1.256 pb × k=1.15 = 1.4444 pb (XSDB: ZZTo4L powheg)
+        # NOTE: for ZZTo4L amcatnlo, XSDB gives 1.5 pb × k=1.15 = 1.725 pb (NNLO+NNLL)
+        13: Number(1.4444),
+        # 13.6 TeV: NLO 1.39 pb × k=1.15 = 1.5985 pb (XSDB: ZZto4L powheg)
+        13.6: Number(1.5985),
+    },
 )
 
-zz_zqq_zqq = zz.add_process(
-    name="zz_zqq_zqq",
-    id=8140,
-    xsecs=multiply_xsecs(zz, const.br_zz.qqqq),
+zz_zqq_zll = zz_qqbar.add_process(
+    name="zz_zqq_zll",
+    id=8110,
+    xsecs={
+        # TODO: add 13 TeV value (NLO × k=1.15 from XSDB, same approach as 13.6 TeV)
+        # 13.6 TeV: NLO 6.788 pb × k=1.15 = 7.8062 pb (XSDB: ZZto2L2Q powheg)
+        13.6: Number(7.8062),
+    },
 )
 
-zz_znunu_zqq = zz.add_process(
+zz_zll_znunu = zz_qqbar.add_process(
+    name="zz_zll_znunu",
+    id=8120,
+    xsecs={
+        # TODO: add 13 TeV value (NLO × k=1.15 from XSDB, same approach as 13.6 TeV)
+        # 13.6 TeV: NLO 1.031 pb × k=1.15 = 1.18565 pb (XSDB: ZZto2L2Nu powheg)
+        13.6: Number(1.18565),
+    },
+)
+
+zz_znunu_zqq = zz_qqbar.add_process(
     name="zz_znunu_zqq",
     id=8150,
-    xsecs=multiply_xsecs(zz, const.br_zz.qqnunu),
+    xsecs={
+        # TODO: add 13 TeV value (NLO × k=1.15 from XSDB, same approach as 13.6 TeV)
+        # 13.6 TeV: NLO 4.826 pb × k=1.15 = 5.5499 pb (XSDB: ZZto2Nu2Q powheg)
+        13.6: Number(5.5499),
+    },
 )
 
-zz_zee_zee = zz.add_process(
+zz_zqq_zqq = zz_qqbar.add_process(
+    name="zz_zqq_zqq",
+    id=8140,
+    xsecs={
+        # TODO: add 13 TeV value (NLO × k=1.15 from XSDB, same approach as 13.6 TeV)
+        # 13.6 TeV: NLO 7.832 pb × k=1.15 = 9.0068 pb (XSDB: ZZto4Q amcatnlo)
+        13.6: Number(9.0068),
+    },
+)
+
+# ggZZ: each decay mode normalized independently by its LO MCFM value × k=1.7
+# LO XS values in fb from XSDB for individual mcfm samples
+# See slides: https://indico.cern.ch/event/1677270/contributions/7200886/attachments/3317393/5938464/ZZXS.pdf
+zz_gg = zz.add_process(
+    name="zz_gg",
+    id=8180,
+    label=r"$gg \rightarrow ZZ$",
+    xsecs={
+        # sum of ggZZ decay modes: 13 TeV: 3×2.703 + 3×5.423 = 24.378 fb
+        13: Number(24.378e-03),
+        # sum of ggZZ decay modes: 13.6 TeV: 3×5.199467 + 3×10.610669 = 47.430408 fb
+        13.6: Number(47.430408e-03),
+    },
+)
+
+zz_zee_zee = zz_gg.add_process(
     name="zz_zee_zee",
     id=8160,
-    xsecs=multiply_xsecs(zz, const.br_zz.eeee),
+    xsecs={
+        13: Number(2.703e-03),       # LO × k=1.7 (XSDB: GluGlu2Zto4E mcfm)
+        13.6: Number(5.199467e-03),  # LO × k=1.7 (XSDB: GluGlu2Zto4E mcfm)
+    },
 )
 
-zz_zee_zmm = zz.add_process(
+zz_zee_zmm = zz_gg.add_process(
     name="zz_zee_zmm",
     id=8161,
-    xsecs=multiply_xsecs(zz, const.br_zz.eemm),
+    xsecs={
+        13: Number(5.423e-03),        # LO × k=1.7 (XSDB: GluGlu2Zto2E2Mu mcfm)
+        13.6: Number(10.610669e-03),  # LO × k=1.7 (XSDB: GluGlu2Zto2E2Mu mcfm)
+    },
 )
 
-zz_zee_ztt = zz.add_process(
+zz_zee_ztt = zz_gg.add_process(
     name="zz_zee_ztt",
     id=8162,
-    xsecs=multiply_xsecs(zz, const.br_zz.eett),
+    xsecs={
+        13: Number(5.423e-03),        # LO × k=1.7 (XSDB: GluGlu2Zto2E2Tau mcfm)
+        13.6: Number(10.610669e-03),  # LO × k=1.7 (XSDB: GluGlu2Zto2E2Tau mcfm)
+    },
 )
 
-zz_zmm_zmm = zz.add_process(
+zz_zmm_zmm = zz_gg.add_process(
     name="zz_zmm_zmm",
     id=8163,
-    xsecs=multiply_xsecs(zz, const.br_zz.mmmm),
+    xsecs={
+        13: Number(2.703e-03),       # LO × k=1.7 (XSDB: GluGlu2Zto4Mu mcfm)
+        13.6: Number(5.199467e-03),  # LO × k=1.7 (XSDB: GluGlu2Zto4Mu mcfm)
+    },
 )
 
-zz_zmm_ztt = zz.add_process(
+zz_zmm_ztt = zz_gg.add_process(
     name="zz_zmm_ztt",
     id=8164,
-    xsecs=multiply_xsecs(zz, const.br_zz.mmtt),
+    xsecs={
+        13: Number(5.423e-03),        # LO × k=1.7 (XSDB: GluGlu2Zto2Mu2Tau mcfm)
+        13.6: Number(10.610669e-03),  # LO × k=1.7 (XSDB: GluGlu2Zto2Mu2Tau mcfm)
+    },
 )
 
-zz_ztt_ztt = zz.add_process(
+zz_ztt_ztt = zz_gg.add_process(
     name="zz_ztt_ztt",
     id=8165,
-    xsecs=multiply_xsecs(zz, const.br_zz.tttt),
+    xsecs={
+        13: Number(2.703e-03),       # LO × k=1.7 (XSDB: GluGlu2Zto4Tau mcfm)
+        13.6: Number(5.199467e-03),  # LO × k=1.7 (XSDB: GluGlu2Zto4Tau mcfm)
+    },
 )
 
 # WZ xsec values at NLO from https://arxiv.org/pdf/1105.0020.pdf v1
@@ -2273,6 +2357,19 @@ wzg_wlnu = wzg.add_process(
         # XSDB (Run3Summer22)
         13.6: Number(0.08425, {
             "tot": 4.238e-05,
+        }),
+    },
+)
+
+# w + photon
+wg_lnug = Process(
+    name="wg_lnug",
+    id=9600,
+    label=r"$W\gamma \rightarrow \ell\nu\gamma$",
+    xsecs={
+        # NLO from XSDB: https://xsecdb-xsdb-official.app.cern.ch/xsdb/?columns=67108863&currentPage=0&pageSize=40&searchQuery=process_name%3D%5EWGtoLNuG-1Jets_TuneCP5_13p6TeV  # noqa
+        13.6: Number(671.5, {
+            "tot": 0.7548,
         }),
     },
 )
@@ -2375,6 +2472,19 @@ ww_wtnu_wtnu = ww_dl.add_process(
     name="ww_wtnu_wtnu",
     id=8316,
     xsecs=multiply_xsecs(ww, const.br_ww.tnutnu),
+)
+
+# same-sign WW (EWK+QCD)
+wpwp_jj = Process(
+    name="wpwp_jj",
+    id=8400,
+    label=r"$W^{\pm}W^{\pm}jj$",
+    xsecs={
+        # LO from XSDB: https://xsecdb-xsdb-official.app.cern.ch/xsdb/?columns=67108863&currentPage=0&pageSize=40&searchQuery=process_name%3D%5EWpWpJJ-EWK-QCD_TuneCP5_13p6TeV  # noqa
+        13.6: Number(0.0587, {
+            "tot": 0.00001523,
+        }),
+    },
 )
 
 #

--- a/cmsdb/processes/ewk.py
+++ b/cmsdb/processes/ewk.py
@@ -2158,7 +2158,7 @@ zz_qqbar = zz.add_process(
     id=8170,
     label=r"$q\bar{q} \rightarrow ZZ$",
     xsecs={
-        #XSDB inclusive (LO, Pythia-only) × k=1.51 (LO→NNLO) = 12.14 × 1.51 = 18.3314 pb
+        # XSDB inclusive (LO, Pythia-only) × k=1.51 (LO→NNLO) = 12.14 × 1.51 = 18.3314 pb
         # https://xsecdb-xsdb-official.app.cern.ch/xsdb/?columns=67108863&currentPage=0&pageSize=10&searchQuery=DAS%3DZZ_TuneCP5_13TeV-pythia8
         13: Number(18.3314),
         # XSDB inclusive (LO, Pythia-only) × k=1.51 (LO→NNLO) = 12.75 × 1.51 = 19.2525 pb
@@ -2204,7 +2204,8 @@ zz_zll_znunu = zz_qqbar.add_process(
         # GenXSecAnalyzer After filter: 0.9738 ± 0.001 pb × k=1.15 = 1.1199 pb
         # (sanity: 1.120 pb at 13 TeV < 1.186 pb at 13.6 TeV → ~5.5% energy scaling ✓)
         # NOTE (Torben): the Autumn18 sample (RunIIAutumn18MiniAOD, gridpack v1 with mll > 40 GeV) gives 0.6008 pb —
-        # a different phase space; treat as ZZTo2L2Nu_mll40 if needed. The UL value (0.9738 pb, mll > 4 GeV) is used here.
+        # a different phase space; treat as ZZTo2L2Nu_mll40 if needed.
+        # The UL value (0.9738 pb, mll > 4 GeV) is used here.
         13: Number(0.9738, {"tot": 0.001}) * 1.15,
         # 13.6 TeV: NLO 1.031 pb × k=1.15 = 1.18565 pb (XSDB: ZZto2L2Nu powheg)
         13.6: Number(1.18565),

--- a/cmsdb/processes/ewk.py
+++ b/cmsdb/processes/ewk.py
@@ -2128,11 +2128,11 @@ vv = Process(
 #   13 TeV:   NNLO+NNLL = 16.518 ± 1.84% pb from https://journals.aps.org/prd/abstract/10.1103/2rr7-5xv3, table 1
 #   13.6 TeV: NNLO+NNLL = 17.627 ± 1.93% pb from the same paper, table 1
 # For the inclusive Pythia sample (ZZ_TuneCP5_13p6TeV_pythia8), XSDB lists 12.75 pb.
-# The order is not documented; assuming NLO and applying k=1.15 gives 14.6625 pb,
-# which is consistent with qqZZ-only at NNLO (the Pythia sample is qqZZ-dominated).
+# A second XSDB entry explicitly marks the order as LO (typical for Pythia-only samples).
+# Applying k=1.51 (LO→NNLO) gives 12.75 × 1.51 = 19.2525 pb.
 #
-# NOTE on k-factor: historically k=1.1 was used for NLO→NNLO scaling; we use k=1.15
-# as it is closer to the actual NLO→NNLO ratio from theory sources.
+# NOTE on k-factor: k=1.15 is used for NLO→NNLO (powheg/amcatnlo samples);
+# k=1.51 is used for LO→NNLO (Pythia-only/inclusive samples).
 # See Torben's slides: https://indico.cern.ch/event/1677270/contributions/7200886/attachments/3317393/5938464/ZZXS.pdf
 #
 # NOTE on per-decay-mode normalization: each dataset is normalized by its own
@@ -2158,9 +2158,8 @@ zz_qqbar = zz.add_process(
     id=8170,
     label=r"$q\bar{q} \rightarrow ZZ$",
     xsecs={
-        # XSDB inclusive (assumed NLO) × k=1.15 = 12.75 × 1.15 = 14.6625 pb
-        # this represents qqZZ only; consistent with NNLO theory after phase space effects
-        13.6: Number(14.6625),
+        # XSDB inclusive (LO, Pythia-only) × k=1.51 (LO→NNLO) = 12.75 × 1.51 = 19.2525 pb
+        13.6: Number(19.2525),
     },
 )
 
@@ -2169,7 +2168,7 @@ zz_zll_zll = zz_qqbar.add_process(
     id=8130,
     xsecs={
         # 13 TeV: NLO 1.256 pb × k=1.15 = 1.4444 pb (XSDB: ZZTo4L powheg)
-        # NOTE: for ZZTo4L amcatnlo, XSDB gives 1.5 pb × k=1.15 = 1.725 pb (NNLO+NNLL)
+        # NOTE: ZZTo4L amcatnlo is not on XSDB; CMS AN-19-191 gives 1.5 pb × k=1.15 = 1.725 pb (NNLO+NNLL)
         13: Number(1.4444),
         # 13.6 TeV: NLO 1.39 pb × k=1.15 = 1.5985 pb (XSDB: ZZto4L powheg)
         13.6: Number(1.5985),

--- a/cmsdb/processes/ewk.py
+++ b/cmsdb/processes/ewk.py
@@ -2158,6 +2158,9 @@ zz_qqbar = zz.add_process(
     id=8170,
     label=r"$q\bar{q} \rightarrow ZZ$",
     xsecs={
+        #XSDB inclusive (LO, Pythia-only) × k=1.51 (LO→NNLO) = 12.14 × 1.51 = 18.3314 pb
+        # https://xsecdb-xsdb-official.app.cern.ch/xsdb/?columns=67108863&currentPage=0&pageSize=10&searchQuery=DAS%3DZZ_TuneCP5_13TeV-pythia8
+        13: Number(18.3314),
         # XSDB inclusive (LO, Pythia-only) × k=1.51 (LO→NNLO) = 12.75 × 1.51 = 19.2525 pb
         13.6: Number(19.2525),
     },
@@ -2179,7 +2182,13 @@ zz_zqq_zll = zz_qqbar.add_process(
     name="zz_zqq_zll",
     id=8110,
     xsecs={
-        # TODO: add 13 TeV value (NLO × k=1.15 from XSDB, same approach as 13.6 TeV)
+        # 13 TeV: NLO from GenXSecAnalyzer on UL18 MiniAODv2 (1M events) × k=1.15 (NLO→NNLO)
+        # Sample: ZZTo2Q2L_mllmin4p0_TuneCP5_13TeV-amcatnloFXFX-pythia8 (amcatnloFXFX → NLO)
+        # Torben confirmed: XSDB "LO" label is misleading; generator is NLO (amcatnloFXFX)
+        # GenXSecAnalyzer After filter: 3.698 ± 0.004 pb × k=1.15 = 4.253 pb
+        # (consistent with XSDB value 3.676 pb for same sample)
+        # NOTE: 13 TeV sample has mllmin4p0 cut; 13.6 TeV uses powheg without this cut — different phase space
+        13: Number(3.698, {"tot": 0.004}) * 1.15,
         # 13.6 TeV: NLO 6.788 pb × k=1.15 = 7.8062 pb (XSDB: ZZto2L2Q powheg)
         13.6: Number(7.8062),
     },
@@ -2189,7 +2198,14 @@ zz_zll_znunu = zz_qqbar.add_process(
     name="zz_zll_znunu",
     id=8120,
     xsecs={
-        # TODO: add 13 TeV value (NLO × k=1.15 from XSDB, same approach as 13.6 TeV)
+        # 13 TeV: NLO from GenXSecAnalyzer on UL18 MiniAODv2 (1M events) × k=1.15 (NLO→NNLO)
+        # Sample: ZZTo2L2Nu_TuneCP5_13TeV_powheg_pythia8/RunIISummer20UL18MiniAODv2 (Powheg NLO, ~0% neg. weights)
+        # Gridpack: ZZ_slc7_amd64_gcc820_CMSSW_11_0_1_ZZ2L2Nu.tgz (UL v2, mll > 4 GeV)
+        # GenXSecAnalyzer After filter: 0.9738 ± 0.001 pb × k=1.15 = 1.1199 pb
+        # (sanity: 1.120 pb at 13 TeV < 1.186 pb at 13.6 TeV → ~5.5% energy scaling ✓)
+        # NOTE (Torben): the Autumn18 sample (RunIIAutumn18MiniAOD, gridpack v1 with mll > 40 GeV) gives 0.6008 pb —
+        # a different phase space; treat as ZZTo2L2Nu_mll40 if needed. The UL value (0.9738 pb, mll > 4 GeV) is used here.
+        13: Number(0.9738, {"tot": 0.001}) * 1.15,
         # 13.6 TeV: NLO 1.031 pb × k=1.15 = 1.18565 pb (XSDB: ZZto2L2Nu powheg)
         13.6: Number(1.18565),
     },
@@ -2199,7 +2215,12 @@ zz_znunu_zqq = zz_qqbar.add_process(
     name="zz_znunu_zqq",
     id=8150,
     xsecs={
-        # TODO: add 13 TeV value (NLO × k=1.15 from XSDB, same approach as 13.6 TeV)
+        # 13 TeV: NLO from GenXSecAnalyzer on UL18 MiniAODv2 (1M events) × k=1.15 (NLO→NNLO)
+        # Sample: ZZTo2Q2Nu_TuneCP5_13TeV-amcatnloFXFX-pythia8 (ZZTo2Q2Nu01j_5f_NLO_FXFX gridpack → amcatnloFXFX)
+        # Torben confirmed: XSDB "LO" label is misleading; generator is NLO (amcatnloFXFX)
+        # GenXSecAnalyzer After filter: 4.487 ± 0.008 pb × k=1.15 = 5.160 pb
+        # (sanity check: 5.160 pb at 13 TeV < 5.5499 pb at 13.6 TeV — physically consistent)
+        13: Number(4.487, {"tot": 0.008}) * 1.15,
         # 13.6 TeV: NLO 4.826 pb × k=1.15 = 5.5499 pb (XSDB: ZZto2Nu2Q powheg)
         13.6: Number(5.5499),
     },
@@ -2209,7 +2230,14 @@ zz_zqq_zqq = zz_qqbar.add_process(
     name="zz_zqq_zqq",
     id=8140,
     xsecs={
-        # TODO: add 13 TeV value (NLO × k=1.15 from XSDB, same approach as 13.6 TeV)
+        # 13 TeV: NLO from XSDB × k=1.15 (NLO→NNLO)
+        # Sample: ZZTo4Q_13TeV_amcatnloFXFX_madspin_pythia8
+        # https://xsecdb-xsdb-official.app.cern.ch/xsdb/?columns=67108863&currentPage=0&pageSize=40&searchQuery=process_name%3D%5EZZTo4Q_13TeV_amcatnloFXFX_madspin_pythia8
+        # XSDB NLO: 6.912 pb × k=1.15 = 7.9488 pb
+        # NOTE: GenXSecAnalyzer on ZZTo4Q_5f (no madspin) gives only 3.305 pb — different generator setup,
+        # likely a mass cut difference (Torben). The madspin sample is consistent with the 13.6 TeV setup.
+        # (sanity: 7.949 pb at 13 TeV < 9.007 pb at 13.6 TeV → ~12% energy scaling ✓)
+        13: Number(6.912) * 1.15,
         # 13.6 TeV: NLO 7.832 pb × k=1.15 = 9.0068 pb (XSDB: ZZto4Q amcatnlo)
         13.6: Number(9.0068),
     },
@@ -2284,7 +2312,7 @@ zz_ztt_ztt = zz_gg.add_process(
     },
 )
 
-# WZ xsec values at NLO from https://arxiv.org/pdf/1105.0020.pdf v1
+# WZ inclusive NLO xsec values from https://arxiv.org/pdf/1105.0020.pdf v1
 wp_z_xsec = {
     13: Number(28.55, {"scale": (0.041j, 0.032j)}),
 }
@@ -2311,10 +2339,24 @@ wz = vv.add_process(
     },
 )
 
+# WZto3LNu cross sections for the powheg decay-mode sample (W->lnu, Z->ll).
+# Each decay mode is normalized independently by its XSDB NLO value × k-factor (NNLO QCD x NLO EW).
+# k-factor is between NNLO QCD x NLO EW (MATRIX) and NLO POWHEG (not NLO MATRIX).
+# MATRIX paper: https://arxiv.org/abs/1912.00068
 wz_wlnu_zll = wz.add_process(
     name="wz_wlnu_zll",
     id=8210,
-    xsecs=multiply_xsecs(wz, const.br_w.lep * const.br_z.clep),
+    xsecs={
+        # XSDB NLO (powheg) 4.42965 pb × k=1.19 (NLO POWHEG -> NNLO QCD x NLO EW) = 5.2713 pb
+        # https://twiki.cern.ch/twiki/bin/view/CMS/SummaryTable1G25ns#Diboson (NLO: 4.42965 pb)
+        # https://xsecdb-xsdb-official.app.cern.ch/xsdb/?columns=67108863&currentPage=0&pageSize=10&searchQuery=DAS=WZto3LNu_TuneCUETP8M1_13TeV-powheg-pythia8  # noqa
+        # k-factor ~1.19 from WZ Run2 paper: https://arxiv.org/pdf/2110.11231
+        13: Number(5.2713),
+        # XSDB NLO (powheg) 4.924 pb × k=1.08 (NLO POWHEG -> NNLO QCD x NLO EW) = 5.31792 pb
+        # https://xsecdb-xsdb-official.app.cern.ch/xsdb/?columns=67108863&currentPage=0&pageSize=10&searchQuery=DAS=WZto3LNu_TuneCP5_13p6TeV_powheg-pythia8  # noqa
+        # k-factor ~1.08 from WZ Run3 paper: https://arxiv.org/pdf/2412.02477
+        13.6: Number(5.31792),
+    },
 )
 
 wz_wqq_zll = wz.add_process(


### PR DESCRIPTION
# PR Description: Diboson Process Split + Missing Samples

### Summary of Changes

1. **ZZ Diboson Process Split (`processes/ewk.py`)**:
   - Restructured flat `zz` process tree into explicit `zz_qqbar` ($q\bar{q}\to ZZ$) and `zz_gg` ($gg\to ZZ$) sub-processes.
   - All existing leaf process names (`zz_zll_zll`, `zz_zee_zee`, etc.) are preserved for backwards compatibility.
   - Updated theory inclusive cross sections:
     - 13 TeV: $16.518 \pm 1.84\%$ pb (NNLO+NNLL, PhysRevD 10.1103/2rr7-5xv3, Table 1)
     - 13.6 TeV: $17.627 \pm 1.93\%$ pb (NNLO+NNLL, PhysRevD 10.1103/2rr7-5xv3, Table 1)
   - Updated per-decay-mode cross sections:
     - `zz_qqbar`: NLO $\times k=1.15$ ($14.6625$ pb inclusive; per-decay-mode values from XSDB)
     - `zz_gg`: LO $\times k=1.7$ ($47.43$ fb inclusive; values symmetric by lepton universality from [Torben's slides](https://indico.cern.ch/event/1677270/contributions/7200886/attachments/3317393/5938464/ZZXS.pdf))
   - Updated `zz_qqbar` 13 TeV inclusive: XSDB LO $\times k=1.51$ (LO$\to$NNLO) $= 12.14 \times 1.51 = 18.3314$ pb

2. **WW Diboson Process Split (`processes/ewk.py`)**:
   - Restructured flat `ww` process tree into explicit `ww_qqbar` ($q\bar{q}\to WW$, id=8370) and `ww_gg` ($gg\to WW$, id=8380) sub-processes, same pattern as ZZ.
   - All existing leaf process names preserved for backwards compatibility.
   - Updated WW inclusive 13.6 TeV: LO Pythia $80.22$ pb $\times k \approx 1.75$ (LO$\to$NNLO) $= 140.4$ pb
   - `ww_qqbar` decay modes with explicit 13.6 TeV cross sections using XSDB Powheg NLO $\times k=1.14$ (NLO$\to$NNLO, [arXiv:1605.02716](https://arxiv.org/abs/1605.02716)):
     - `ww_dl` (WWto2L2Nu): $11.79 \times 1.14 = 13.44$ pb
     - `ww_sl` (WWtoLNu2Q): $48.94 \times 1.14 = 55.79$ pb
     - `ww_fh` (WWto4Q): $50.79 \times 1.14 = 57.90$ pb
   - `ww_gg` dilepton decay modes with explicit 13.6 TeV cross sections using MCFM LO (in fb, not pb) $\times k=1.41$ (LO$\to$NLO, [arXiv:1511.08617](https://arxiv.org/abs/1511.08617)):
     - Same-flavor (ee, $\mu\mu$, $\tau\tau$): $49.63$ fb $\times 1.41 = 69.98$ fb each
     - Different-flavor (e$\mu$, e$\tau$, $\mu\tau$): $2 \times 49.63$ fb $\times 1.41 = 139.96$ fb each (factor 2 from combining ordering samples)
     - Total gg$\to$WW$\to 2\ell 2\nu$ = $629.8$ fb

3. **WZ Decay-Mode Cross Sections (`processes/ewk.py`)**:
   - All WZ decay-mode processes now have explicit 13.6 TeV cross sections using XSDB NLO values $\times k=1.08$ (NLO POWHEG $\to$ NNLO QCD $\times$ NLO EW from [MATRIX](https://arxiv.org/abs/1912.00068)):
     - `wz_wlnu_zll` (WZto3LNu): $4.924 \times 1.08 = 5.318$ pb ([WZ Run3 paper](https://arxiv.org/pdf/2412.02477))
     - `wz_wqq_zll` (WZto2L2Q): $7.568 \times 1.08 = 8.173$ pb (verified from CMS AN-2023/179)
     - `wz_wlnu_zqq` (WZtoLNu2Q): $15.87 \times 1.08 = 17.14$ pb (GenXSecAnalyzer verified)
     - `wz_wqq_zqq` (WZto4Q): $24.97 \times 1.08 = 26.97$ pb (GenXSecAnalyzer verified; XSDB mislabels this as "LO" but `amcatnloFXFX` is NLO — confirmed by 21% negative weight fraction)
   - 13 TeV `wz_wlnu_zll`: $4.430 \times 1.19 = 5.271$ pb ([WZ Run2 paper](https://arxiv.org/pdf/2110.11231))
   - 13 TeV values for other WZ decay modes still derived from inclusive via branching ratios
   - $k$-factor is between NNLO QCD $\times$ NLO EW (MATRIX) and NLO POWHEG (not NLO MATRIX) — both papers must be cited

4. **New Process Definitions (`processes/ewk.py`)**:
   - `wg_lnug`: $W\gamma \to \ell\nu\gamma$ ($671.5 \pm 0.75$ pb at NLO from XSDB)
   - `wpwp_jj`: $W^\pm W^\pm jj$ same-sign WW ($0.0587 \pm 1.5\times 10^{-5}$ pb at LO from XSDB)

5. **New Dataset Entries (Run 3 2024 Summer24 NanoAOD v15)**:
   - `top.py`: `tttt_amcatnlo`, `ttg_amcatnlo`, `ttg_pt100to200_amcatnlo`, `ttg_pt200toinf_amcatnlo`
   - `higgs.py`: `thq_ctcvcp_madgraph`, `thw_ctcvcp_madgraph`
   - `ewk.py`: `wpwp_jj_ewkqcd_madgraph`, `wg_lnug_amcatnlo`

### Cross-Section References

| Reference | Used for |
|-----------|----------|
| [PhysRevD 10.1103/2rr7-5xv3](https://journals.aps.org/prd/abstract/10.1103/2rr7-5xv3) | ZZ inclusive NNLO+NNLL |
| [MATRIX (arXiv:1912.00068)](https://arxiv.org/abs/1912.00068) | WZ NNLO QCD $\times$ NLO EW |
| [WZ Run3 (arXiv:2412.02477)](https://arxiv.org/pdf/2412.02477) | WZ $k=1.08$ (13.6 TeV) |
| [WZ Run2 (arXiv:2110.11231)](https://arxiv.org/pdf/2110.11231) | WZ $k=1.19$ (13 TeV) |
| [Torben's slides](https://indico.cern.ch/event/1677270/contributions/7200886/attachments/3317393/5938464/ZZXS.pdf) | ggZZ values |
| [arXiv:1511.08617](https://arxiv.org/abs/1511.08617) (Caola et al.) | ggWW $k=1.41$ (LO$\to$NLO) |
| [arXiv:1605.02716](https://arxiv.org/abs/1605.02716) (Grazzini et al., JHEP08(2016)140) | qqWW $k=1.14$ (NLO$\to$NNLO), WW Pythia $k\approx 1.75$ (LO$\to$NNLO) |
| [CMS AN-2023/179](https://cms-alcm.web.cern.ch/notes/CMS-AN-2023-179/AN2023_179_v6.pdf) | gg$\to$WW MCFM values, WZto2L2Q verification |
